### PR TITLE
feat(testlib): add testlib/conf-testdata crate for test vector codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,16 +86,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "minijinja"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e36f1329330bb1614c94b78632b9ce45dd7d761f3304a1bed07b2990a7c5097"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "seahaven-cli"
@@ -109,10 +142,55 @@ name = "seahaven-conf"
 version = "0.1.0"
 
 [[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "syn"
+version = "2.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "testlib-conf-testdata"
+version = "0.0.0"
+dependencies = [
+ "indoc",
+ "minijinja",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "seahaven-cli",
     "seahaven-conf",
+    "testlib/conf-testdata",
 ]
 
 [workspace.package]

--- a/testlib/README.md
+++ b/testlib/README.md
@@ -1,0 +1,4 @@
+testlib
+-------
+
+This folder contains a test libraries for the Seahaven project.

--- a/testlib/conf-testdata/Cargo.toml
+++ b/testlib/conf-testdata/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "testlib-conf-testdata"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[features]
+codegen = []
+
+[dependencies]
+indoc = "2"
+
+[build-dependencies]
+minijinja = { version = "2", features = ["builtins"] }

--- a/testlib/conf-testdata/README.md
+++ b/testlib/conf-testdata/README.md
@@ -1,0 +1,19 @@
+testlib-conf-testdata
+---------------------
+
+This crate contains test vectors for the Seahaven configuration files.
+
+The test vectors are stored in the `data` directory. 
+The templates for the test vectors are stored in the `templates` directory.
+
+## Code generation
+
+The `build.rs` file contains the code that generates the test vectors from the templates and the data files.
+
+To re-generate the test vectors, run the following command:
+
+```sh
+cargo build -p testlib-conf-testdata --features=codegen
+```
+
+This will generate the test vector files in the `src/gen` directory.

--- a/testlib/conf-testdata/build.rs
+++ b/testlib/conf-testdata/build.rs
@@ -1,0 +1,232 @@
+use std::{
+    ffi::OsStr,
+    io,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+/// The test sets to generate test vectors for
+///
+/// This list of the directories under the `data` directory that contain the test vectors
+const TEST_SETS: &[&str] = &["setup-yaml"];
+
+/// Print a message to the console (green)
+macro_rules! echo {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning=\r\x1b[32;1m   {}", format!($($tokens)*))
+    }
+}
+
+/// Print a warning message to the console (yellow)
+macro_rules! warning {
+    ($($tokens: tt)*) => {
+        println!("cargo:warning=\r\x1b[33;1m   {}", format!($($tokens)*))
+    }
+}
+
+/// Return the path to root of the crate being built
+///
+/// The `CARGO_MANIFEST_DIR` env variable contains the path to the  directory containing the
+/// manifest for the package being built (the package containing the build script). Also note that
+/// this is the value of the current working directory of the build script when it starts.
+///
+/// https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-build-scripts
+fn crate_root_dir() -> Box<Path> {
+    PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"))
+        .into_boxed_path()
+}
+
+/// Code generation
+mod codegen {
+    use std::path::Path;
+
+    /// Test vector file Jinja template
+    const TEST_VECTOR_RS_TEMPLATE: &str = include_str!("templates/vector.rs.jinja");
+
+    /// Test vector mod.rs Jinja template
+    const TEST_VECTOR_MOD_RS_TEMPLATE: &str = include_str!("templates/mod.rs.jinja");
+
+    /// Initialize the Jinja template engine with the templates
+    pub fn engine() -> &'static Codegen {
+        // Init the template engine with the templates
+        static CODEGEN: std::sync::OnceLock<Codegen> = std::sync::OnceLock::new();
+        CODEGEN.get_or_init(|| {
+            let mut jinja = minijinja::Environment::new();
+            jinja.set_keep_trailing_newline(true);
+            jinja
+                .add_template("test_vector", TEST_VECTOR_RS_TEMPLATE)
+                .expect("failed test_vector template initialization");
+            jinja
+                .add_template("test_vector_mod_rs", TEST_VECTOR_MOD_RS_TEMPLATE)
+                .expect("failed test_vector_mod_rs template initialization");
+            Codegen { jinja }
+        })
+    }
+
+    /// Wrapper around the Jinja template engine
+    pub struct Codegen {
+        jinja: minijinja::Environment<'static>,
+    }
+
+    impl Codegen {
+        /// Render a test vector using the codegen template engine
+        pub fn render_test_vector(
+            &self,
+            name: &str,
+            data_set: &str,
+            content: Vec<String>,
+        ) -> String {
+            self.jinja
+                .get_template("test_vector")
+                .expect("template not found")
+                .render(minijinja::context! {
+                    data_set => data_set,
+                    name => name,
+                    content => content,
+                })
+                .expect("render failed")
+        }
+
+        /// Render a test vector mod.rs using the codegen template engine
+        pub fn render_test_vector_mod_rs_include(&self, path: impl AsRef<Path>) -> String {
+            self.jinja
+                .get_template("test_vector_mod_rs")
+                .expect("template not found")
+                .render(minijinja::context! {
+                    path => path.as_ref(),
+                })
+                .expect("render failed")
+        }
+    }
+}
+
+/// Take a relative path and turn it into a sanitized string
+///
+/// - Remove the file extension.
+/// - Replace `/` with `_`.
+/// - Replace `-` with `_`.
+/// - Replace `.` with `_`.
+///
+/// For example, `exec/query_named.graphql` becomes `exec_query_named`
+fn sanitize_filename(name: impl AsRef<Path>) -> String {
+    let base_dir = name.as_ref().parent().expect("file has no parent");
+    let file_stem = name.as_ref().file_stem().expect("file has no stem");
+    let mut name = PathBuf::new()
+        .join(base_dir)
+        .join(file_stem)
+        .to_string_lossy()
+        .to_string();
+    name = name.replace('/', "_");
+    name = name.replace('-', "_");
+    name = name.replace('.', "_");
+    name
+}
+
+/// Take a file name stem and turn it into a valid rust filename
+///
+/// - Append `.rs` to the end
+///
+/// For example, `query_named` becomes `exec_query_named.rs`
+fn as_rust_filename(stem: impl AsRef<OsStr>) -> std::ffi::OsString {
+    let mut name = stem.as_ref().to_owned();
+    name.push(".rs");
+    name
+}
+
+/// Load the content of a file as a vector of strings, where each string is a line in the file
+fn load_file_and_read_lines(path: impl AsRef<Path>) -> io::Result<Vec<String>> {
+    let lines = std::fs::read_to_string(path)?
+        .lines()
+        .map(|s| s.to_string())
+        .collect();
+    Ok(lines)
+}
+
+/// Given a `Path`, get a directory's file names iterator
+///
+/// The iterator will return the file names in the directory in alphabetical order
+fn walk_dir_files(dir: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
+    let mut paths: Vec<_> = std::fs::read_dir(dir)
+        .expect("failed to read directory")
+        .filter_map(|dir| dir.ok())
+        .filter(|dir| dir.file_type().expect("failed to get file type").is_file())
+        .collect();
+    paths.sort_by_key(|dir| dir.path());
+    paths.into_iter().map(|dir| dir.path())
+}
+
+/// Determine if code generation feature is enabled
+fn is_codegen_feature_enabled() -> bool {
+    std::env::var("CARGO_FEATURE_CODEGEN").is_ok()
+}
+
+fn main() {
+    // Run code generation only if `codegen` feature is enabled
+    if !is_codegen_feature_enabled() {
+        echo!(
+            "Skipping code generation. Enable the `codegen` feature to regenerate the test vectors"
+        );
+        return;
+    }
+
+    let data_root_dir = crate_root_dir().join("data");
+    let src_gen_dir = crate_root_dir().join("src").join("gen");
+
+    for test_set_name in TEST_SETS {
+        let src_dir = data_root_dir.join(test_set_name);
+        if !src_dir.exists() {
+            warning!("Test vectors set `{test_set_name}` does not exist");
+            continue;
+        }
+
+        // Create the destination directory
+        let dest_dir = src_gen_dir.join(test_set_name);
+        std::fs::create_dir_all(&dest_dir).expect("failed to create gen directory");
+
+        // Open (and overwrite) the test vectors set mod.rs file
+        let mut mod_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(dest_dir.join("mod.rs"))
+            .unwrap_or_else(|err| panic!("failed to open gen/{test_set_name}/mod.rs: {}", err));
+
+        // Generate the test vector files
+        for test_vector_file in walk_dir_files(&src_dir) {
+            let test_vector_file_name = test_vector_file.file_name().expect("file has no name");
+            let test_vector_name = &sanitize_filename(test_vector_file_name);
+
+            // Load the content of the test vector file
+            let content = match load_file_and_read_lines(test_vector_file) {
+                Ok(content) => content,
+                Err(err) => {
+                    warning!(
+                        "failed to read test vector `{test_set_name}/{test_vector_name}` source file: {err}"
+                    );
+                    continue;
+                }
+            };
+
+            let gen_file_name = as_rust_filename(test_vector_name);
+
+            // Render the content and write to the generated file
+            let rendered_content =
+                codegen::engine().render_test_vector(test_vector_name, test_set_name, content);
+            let gen_file = dest_dir.join(&gen_file_name);
+            std::fs::write(&gen_file, rendered_content).unwrap_or_else(|err| {
+                panic!("failed to write test vector `{test_vector_name}` source file: {err}")
+            });
+
+            // Append the new line to the `mod.rs` file
+            let rendered_include =
+                codegen::engine().render_test_vector_mod_rs_include(&gen_file_name);
+            writeln!(mod_file, "{}", rendered_include).unwrap_or_else(|err| {
+                panic!("failed to include generated file into gen/{test_set_name}/mod.rs: {err}")
+            });
+        }
+    }
+
+    // Re-run this build script if any of the files under the templates or data directories have changed
+    println!("cargo:rerun-if-changed=data/templates/**");
+    println!("cargo:rerun-if-changed=data/**");
+}

--- a/testlib/conf-testdata/data/setup-yaml/gettingstarted.yaml
+++ b/testlib/conf-testdata/data/setup-yaml/gettingstarted.yaml
@@ -1,0 +1,7 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8000:5000"
+  redis:
+    image: "redis:alpine"

--- a/testlib/conf-testdata/src/gen/setup-yaml/gettingstarted.rs
+++ b/testlib/conf-testdata/src/gen/setup-yaml/gettingstarted.rs
@@ -1,0 +1,21 @@
+/// Test vector: `setup-yaml/gettingstarted`
+///
+/// ```yaml
+/// services:
+///   web:
+///     build: .
+///     ports:
+///       - "8000:5000"
+///   redis:
+///     image: "redis:alpine"
+/// ```
+///
+/// See file: `setup-yaml/gettingstarted.yaml`
+pub const GETTINGSTARTED: &str = indoc::indoc! { r###"
+  services:
+    web:
+      build: .
+      ports:
+        - "8000:5000"
+    redis:
+      image: "redis:alpine""### };

--- a/testlib/conf-testdata/src/gen/setup-yaml/mod.rs
+++ b/testlib/conf-testdata/src/gen/setup-yaml/mod.rs
@@ -1,0 +1,1 @@
+include!("gettingstarted.rs");

--- a/testlib/conf-testdata/src/lib.rs
+++ b/testlib/conf-testdata/src/lib.rs
@@ -1,0 +1,6 @@
+//! Test vectors for Seahaven configuration files.
+
+/// Test vector for the `setup-yaml` test set
+pub mod setup_yaml {
+    include!("gen/setup-yaml/mod.rs");
+}

--- a/testlib/conf-testdata/templates/mod.rs.jinja
+++ b/testlib/conf-testdata/templates/mod.rs.jinja
@@ -1,0 +1,1 @@
+include!("{{ path }}");

--- a/testlib/conf-testdata/templates/vector.rs.jinja
+++ b/testlib/conf-testdata/templates/vector.rs.jinja
@@ -1,0 +1,13 @@
+/// Test vector: `{{ data_set }}/{{ name }}`
+///
+/// ```yaml
+{% for line in content -%}
+///{{ line | indent(1, true) }}
+{% endfor -%}
+/// ```
+///
+/// See file: `{{ data_set }}/{{ name }}.yaml`
+pub const {{ name | upper | replace("/","_") }}: &str = indoc::indoc! { r###"
+{% for line in content -%}
+{{ line |  indent(2, true) }} {%- if loop.last %}"### };{% endif %}
+{% endfor -%}


### PR DESCRIPTION
This pull request introduces a new test library for the Seahaven project, `testlib-conf-testdata`, which includes test vectors for configuration files. The changes involve adding the new library to the workspace, creating the necessary files and directories, and implementing code generation for test vectors.