### PR TITLE
feat(seahaven-docker): add support for docker compose commands

### DIFF
--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -4,10 +4,10 @@
 //! - `docker version`
 //! - `docker system info`
 //! - `docker system prune`
+//! - `docker compose pull`
 //! - `docker compose build`
 //! - `docker compose up`
 //! - `docker compose down`
-
 mod common;
 pub mod compose;
 mod root;
@@ -20,6 +20,9 @@ pub use root::DockerCmd;
 #[cfg(test)]
 mod tests {
     mod common;
+    mod it_compose;
+    mod it_compose_build;
+    mod it_compose_up;
     mod it_root;
     mod it_system;
     mod it_version;

--- a/seahaven-docker/src/cmd/compose.rs
+++ b/seahaven-docker/src/cmd/compose.rs
@@ -1,3 +1,8 @@
+pub use build::DockerComposeBuildCmd;
+pub use down::DockerComposeDownCmd;
+pub use pull::DockerComposePullCmd;
+pub use up::DockerComposeUpCmd;
+
 use super::common::IntoCommand;
 
 pub struct DockerComposeCmd(tokio::process::Command);
@@ -7,22 +12,36 @@ impl DockerComposeCmd {
         Self(cmd)
     }
 
+    /// Pull the images for the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`docker compose pull`](https://docs.docker.com/compose/reference/pull/)
+    /// for more information.
+    pub fn pull(self) -> DockerComposePullCmd {
+        DockerComposePullCmd::new(self.0)
+    }
+
+    /// Build the images for the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`Docker Compose Build`](https://docs.docker.com/compose/reference/build/)
+    /// for more information.
     pub fn build(self) -> DockerComposeBuildCmd {
-        let mut cmd = self.0;
-        cmd.arg("build");
-        DockerComposeBuildCmd(cmd)
+        DockerComposeBuildCmd::new(self.0)
     }
 
+    /// Start the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`docker compose up`](https://docs.docker.com/compose/reference/up/)
+    /// for more information.
     pub fn up(self) -> DockerComposeUpCmd {
-        let mut cmd = self.0;
-        cmd.arg("up");
-        DockerComposeUpCmd(cmd)
+        DockerComposeUpCmd::new(self.0)
     }
 
+    /// Stop the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`docker compose down`](https://docs.docker.com/compose/reference/down/)
+    /// for more information.
     pub fn down(self) -> DockerComposeDownCmd {
-        let mut cmd = self.0;
-        cmd.arg("down");
-        DockerComposeDownCmd(cmd)
+        DockerComposeDownCmd::new(self.0)
     }
 }
 
@@ -32,34 +51,358 @@ impl IntoCommand for DockerComposeCmd {
     }
 }
 
-pub struct DockerComposeBuildCmd(tokio::process::Command);
+pub mod build {
+    use std::marker::PhantomData;
 
-impl IntoCommand for DockerComposeBuildCmd {
-    fn into_command(self) -> tokio::process::Command {
-        self.0
+    use super::IntoCommand;
+
+    pub struct DockerComposeBuildCmd<S = NoServices> {
+        cmd: tokio::process::Command,
+        _args: PhantomData<S>,
+    }
+
+    impl<S> DockerComposeBuildCmd<S>
+    where
+        S: ServicesOpt,
+    {
+        pub(crate) fn new(cmd: tokio::process::Command) -> Self {
+            let mut cmd = cmd;
+            cmd.arg("build");
+            Self {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    impl<S> IntoCommand for DockerComposeBuildCmd<S>
+    where
+        S: ServicesOpt,
+    {
+        fn into_command(self) -> tokio::process::Command {
+            self.cmd
+        }
+    }
+
+    impl DockerComposeBuildCmd<NoServices> {
+        /// Specify which services to build.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+        /// for more information.
+        pub fn with_services<I, S>(self, services: I) -> DockerComposeBuildCmd<WithServices>
+        where
+            I: IntoIterator<Item = S>,
+            S: AsRef<str>,
+        {
+            let mut cmd = self.cmd;
+            for service in services {
+                cmd.arg(service.as_ref());
+            }
+            DockerComposeBuildCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+
+        /// Specify a single service to build.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+        /// for more information.
+        pub fn with_service<S>(self, service: S) -> DockerComposeBuildCmd<WithServices>
+        where
+            S: AsRef<str>,
+        {
+            self.with_services([service])
+        }
+
+        /// Add a build argument in the form of `<key>=<value>`.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+        /// for more information.
+        pub fn with_build_arg<S>(self, arg: S) -> Self
+        where
+            S: AsRef<str>,
+        {
+            let mut cmd = self.cmd;
+            cmd.arg("--build-arg").arg(arg.as_ref());
+            DockerComposeBuildCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+
+        /// Add multiple build arguments.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+        /// for more information.
+        pub fn with_build_args<I, S>(self, args: I) -> Self
+        where
+            I: IntoIterator<Item = S>,
+            S: AsRef<str>,
+        {
+            let mut cmd = self.cmd;
+            for arg in args {
+                cmd.arg("--build-arg").arg(arg.as_ref());
+            }
+            DockerComposeBuildCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    /// Marker trait for services options.
+    pub trait ServicesOpt {}
+
+    /// Marker type for no services specified.
+    pub struct NoServices;
+    impl ServicesOpt for NoServices {}
+
+    /// Marker type for services specified.
+    pub struct WithServices;
+    impl ServicesOpt for WithServices {}
+}
+
+pub mod up {
+    use std::marker::PhantomData;
+
+    use super::IntoCommand;
+
+    pub struct DockerComposeUpCmd<D = NotDetached, B = NoBuild, S = NoServices> {
+        cmd: tokio::process::Command,
+        _args: PhantomData<(D, B, S)>,
+    }
+
+    impl<D, B, S> DockerComposeUpCmd<D, B, S>
+    where
+        D: DetachedOpt,
+        B: BuildOpt,
+        S: ServicesOpt,
+    {
+        pub(crate) fn new(cmd: tokio::process::Command) -> Self {
+            let mut cmd = cmd;
+            cmd.arg("up");
+            Self {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    impl<D, B, S> IntoCommand for DockerComposeUpCmd<D, B, S>
+    where
+        D: DetachedOpt,
+        B: BuildOpt,
+        S: ServicesOpt,
+    {
+        fn into_command(self) -> tokio::process::Command {
+            self.cmd
+        }
+    }
+
+    impl<B> DockerComposeUpCmd<NotDetached, B, NoServices>
+    where
+        B: BuildOpt,
+    {
+        /// Run containers in the background with the `--detached` flag.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+        /// for more information.
+        pub fn with_detached(self) -> DockerComposeUpCmd<Detached, B, NoServices> {
+            let mut cmd = self.cmd;
+            cmd.arg("--detached");
+            DockerComposeUpCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    impl<D> DockerComposeUpCmd<D, NoBuild, NoServices>
+    where
+        D: DetachedOpt,
+    {
+        /// Build images before starting containers with the `--build` flag.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+        /// for more information.
+        pub fn with_build(self) -> DockerComposeUpCmd<D, WithBuild, NoServices> {
+            let mut cmd = self.cmd;
+            cmd.arg("--build");
+            DockerComposeUpCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    impl<D, B> DockerComposeUpCmd<D, B, NoServices>
+    where
+        D: DetachedOpt,
+        B: BuildOpt,
+    {
+        /// Specify one or more services to start.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+        /// for more information.
+        pub fn with_services<I, S>(self, services: I) -> DockerComposeUpCmd<D, B, WithServices>
+        where
+            I: IntoIterator<Item = S>,
+            S: AsRef<str>,
+        {
+            let mut cmd = self.cmd;
+            for service in services {
+                cmd.arg(service.as_ref());
+            }
+            DockerComposeUpCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+
+        /// Specify a single service to include.
+        ///
+        /// This is a convenience method for `with_services([service])`.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+        /// for more information.
+        pub fn with_service<S>(self, service: S) -> DockerComposeUpCmd<D, B, WithServices>
+        where
+            S: AsRef<str>,
+        {
+            self.with_services([service])
+        }
+    }
+
+    /// A trait that represents the detached option for the `docker compose up` command.
+    pub trait DetachedOpt: _priv::Sealed {}
+
+    pub struct NotDetached;
+
+    impl DetachedOpt for NotDetached {}
+    impl _priv::Sealed for NotDetached {}
+
+    pub struct Detached;
+
+    impl DetachedOpt for Detached {}
+    impl _priv::Sealed for Detached {}
+
+    /// A trait that represents the build option for the `docker compose up` command.
+    pub trait BuildOpt: _priv::Sealed {}
+
+    pub struct NoBuild;
+
+    impl BuildOpt for NoBuild {}
+    impl _priv::Sealed for NoBuild {}
+
+    pub struct WithBuild;
+
+    impl BuildOpt for WithBuild {}
+    impl _priv::Sealed for WithBuild {}
+
+    /// A trait that represents whether services have been specified for the `docker compose up` command.
+    pub trait ServicesOpt: _priv::Sealed {}
+
+    pub struct NoServices;
+
+    impl ServicesOpt for NoServices {}
+    impl _priv::Sealed for NoServices {}
+
+    pub struct WithServices;
+
+    impl ServicesOpt for WithServices {}
+    impl _priv::Sealed for WithServices {}
+
+    #[allow(dead_code)]
+    mod _priv {
+        pub trait Sealed {}
     }
 }
 
-pub struct DockerComposeUpCmd(tokio::process::Command);
+pub mod down {
+    use std::marker::PhantomData;
 
-impl IntoCommand for DockerComposeUpCmd {
-    fn into_command(self) -> tokio::process::Command {
-        self.0
+    use super::IntoCommand;
+
+    pub struct DockerComposeDownCmd<V = NoVolumes> {
+        cmd: tokio::process::Command,
+        _args: PhantomData<V>,
+    }
+
+    impl<V> DockerComposeDownCmd<V>
+    where
+        V: VolumesOpt,
+    {
+        pub(crate) fn new(cmd: tokio::process::Command) -> Self {
+            let mut cmd = cmd;
+            cmd.arg("down");
+            Self {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    impl<V> IntoCommand for DockerComposeDownCmd<V>
+    where
+        V: VolumesOpt,
+    {
+        fn into_command(self) -> tokio::process::Command {
+            self.cmd
+        }
+    }
+
+    impl DockerComposeDownCmd<NoVolumes> {
+        /// Remove named volumes declared in the `volumes` section of the Compose file
+        /// and anonymous volumes attached to containers.
+        ///
+        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/down/)
+        /// for more information.
+        pub fn with_volumes(self) -> DockerComposeDownCmd<WithVolumes> {
+            let mut cmd = self.cmd;
+            cmd.arg("--volumes");
+            DockerComposeDownCmd {
+                cmd,
+                _args: PhantomData,
+            }
+        }
+    }
+
+    /// A trait that represents the volumes option for the `docker compose down` command.
+    pub trait VolumesOpt: _priv::Sealed {}
+
+    /// Marker type for no volumes option specified.
+    pub struct NoVolumes;
+    impl VolumesOpt for NoVolumes {}
+    impl _priv::Sealed for NoVolumes {}
+
+    /// Marker type for volumes option specified.
+    pub struct WithVolumes;
+    impl VolumesOpt for WithVolumes {}
+    impl _priv::Sealed for WithVolumes {}
+
+    #[allow(dead_code)]
+    mod _priv {
+        pub trait Sealed {}
     }
 }
 
-pub struct DockerComposeDownCmd(tokio::process::Command);
+pub mod pull {
+    use super::IntoCommand;
 
-impl IntoCommand for DockerComposeDownCmd {
-    fn into_command(self) -> tokio::process::Command {
-        self.0
+    pub struct DockerComposePullCmd(tokio::process::Command);
+
+    impl DockerComposePullCmd {
+        pub(crate) fn new(cmd: tokio::process::Command) -> Self {
+            let mut cmd = cmd;
+            cmd.arg("pull");
+            Self(cmd)
+        }
     }
-}
 
-pub struct DockerComposePullCmd(tokio::process::Command);
-
-impl IntoCommand for DockerComposePullCmd {
-    fn into_command(self) -> tokio::process::Command {
-        self.0
+    impl IntoCommand for DockerComposePullCmd {
+        fn into_command(self) -> tokio::process::Command {
+            self.0
+        }
     }
 }

--- a/seahaven-docker/src/cmd/tests/common.rs
+++ b/seahaven-docker/src/cmd/tests/common.rs
@@ -10,8 +10,7 @@ pub const MOCKER_SH_PATH: &str = {
 
 /// Parses the output of the `mocker.sh` fixture file into a Vec of string slices
 ///
-/// The `mocker.sh` script sorts all arguments alphabetically, so we need to do the same here
-/// to make the tests deterministic.
+/// The `mocker.sh` script outputs each argument on a new line in the order they were received.
 pub fn parse_fixture_output(output: &std::process::Output) -> Vec<&str> {
     let stdout =
         std::str::from_utf8(&output.stdout).expect("Failed to parse command output as UTF-8");

--- a/seahaven-docker/src/cmd/tests/fixtures/mocker.sh
+++ b/seahaven-docker/src/cmd/tests/fixtures/mocker.sh
@@ -1,6 +1,6 @@
 #!/bin/env bash
-# This script sorts all arguments alphabetically and prints each on a new line.
-# This way, the output of the CLI is deterministic and can be tested against.
+# This script prints each argument on a new line.
+# The output of the CLI can be tested against.
 
 # If no arguments were passed, just print an special string, and exit
 if [ $# -eq 0 ]; then
@@ -8,5 +8,5 @@ if [ $# -eq 0 ]; then
     exit 0
 fi
 
-# Using `LC_ALL=C` enforces traditional ASCII sorting order where hyphens come before letters
-printf "%s\n" "$@" | LC_ALL=C sort
+# Print each argument on a new line in the order they were received
+printf "%s\n" "$@"

--- a/seahaven-docker/src/cmd/tests/it_compose.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose.rs
@@ -1,0 +1,74 @@
+use super::common::{MOCKER_SH_PATH, parse_fixture_output};
+use crate::cmd::{DockerCmd, IntoCommand};
+
+#[tokio::test]
+async fn run_docker_compose() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_down() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .down()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "down"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_down_with_volumes() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .down()
+        .with_volumes()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with volumes");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "down", "--volumes"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_pull() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .pull()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose pull");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "pull"]);
+}

--- a/seahaven-docker/src/cmd/tests/it_compose_build.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_build.rs
@@ -1,0 +1,161 @@
+use super::common::{MOCKER_SH_PATH, parse_fixture_output};
+use crate::cmd::{DockerCmd, IntoCommand};
+
+#[tokio::test]
+async fn run_docker_compose_build() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .build()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose build");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "build"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_build_with_services() {
+    //* Given
+    let services = ["service1", "service2"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .build()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose build with services");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "build", "service1", "service2"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_build_with_build_arg() {
+    //* Given
+    let arg = "FOO=bar";
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .build()
+        .with_build_arg(arg)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose build with build arg");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "build", "--build-arg", "FOO=bar"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_build_with_multiple_build_args() {
+    //* Given
+    let build_args = ["FOO=bar", "BAZ=qux"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .build()
+        .with_build_args(build_args)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose build with multiple build args");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "build",
+            "--build-arg",
+            "FOO=bar",
+            "--build-arg",
+            "BAZ=qux"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_build_with_single_service_and_build_arg() {
+    //* Given
+    let service = "api-service";
+    let arg = "NODE_ENV=production";
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .build()
+        .with_build_arg(arg)
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose build with service and build arg");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "build",
+            "--build-arg",
+            "NODE_ENV=production",
+            "api-service"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_build_with_multiple_services_and_build_args() {
+    //* Given
+    let services = ["api-service", "web-service"];
+    let build_args = ["NODE_ENV=production", "DEBUG=false"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .build()
+        .with_build_args(build_args)
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output =
+        res.expect("Failed to run docker compose build with multiple services and build args");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "build",
+            "--build-arg",
+            "NODE_ENV=production",
+            "--build-arg",
+            "DEBUG=false",
+            "api-service",
+            "web-service"
+        ]
+    );
+}

--- a/seahaven-docker/src/cmd/tests/it_compose_up.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_up.rs
@@ -1,0 +1,275 @@
+use super::common::{MOCKER_SH_PATH, parse_fixture_output};
+use crate::cmd::{DockerCmd, IntoCommand};
+
+#[tokio::test]
+async fn run_docker_compose_up() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_detached() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_detached()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with detached flag");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "--detached"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_build() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_build()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with build flag");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "--build"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_services() {
+    //* Given
+    let services = ["service1", "service2"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with services");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "service1", "service2"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_single_service() {
+    //* Given
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with a single service");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_detached_with_build() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_build()
+        .with_detached()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with build and detached flags");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "--build", "--detached"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_detached_with_services() {
+    //* Given
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_detached()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with detached flag and services");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        ["compose", "up", "--detached", "api-service", "web-service"]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_build_and_services() {
+    //* Given
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_build()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with build flag and services");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        ["compose", "up", "--build", "api-service", "web-service"]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_all_options() {
+    //* Given
+    let services = ["api-service", "web-service", "db-service"];
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_build()
+        .with_detached()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with all options");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "up",
+            "--build",
+            "--detached",
+            "api-service",
+            "web-service",
+            "db-service"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_build_and_single_service() {
+    //* Given
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_build()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with build flag and single service");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "--build", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_detached_with_single_service() {
+    //* Given
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_detached()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output =
+        res.expect("Failed to run docker compose up with detached flag and single service");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "up", "--detached", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_up_with_detached_build_and_single_service() {
+    //* Given
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .up()
+        .with_build()
+        .with_detached()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose up with all options and single service");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        ["compose", "up", "--build", "--detached", "api-service"]
+    );
+}

--- a/seahaven-docker/src/cmd/tests/it_system.rs
+++ b/seahaven-docker/src/cmd/tests/it_system.rs
@@ -33,7 +33,7 @@ async fn run_docker_system_info() {
     let output = res.expect("Failed to run docker system info");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["info", "system"]);
+    assert_eq!(args, ["system", "info"]);
 }
 
 #[tokio::test]
@@ -52,7 +52,7 @@ async fn run_docker_system_info_with_json_format() {
     let output = res.expect("Failed to run docker system info with json format");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--format", "info", "json", "system"]);
+    assert_eq!(args, ["system", "info", "--format", "json"]);
 }
 
 #[tokio::test]
@@ -73,7 +73,7 @@ async fn run_docker_system_info_with_custom_format() {
     let output = res.expect("Failed to run docker system info with custom format");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--format", "info", "system", fmt_str]);
+    assert_eq!(args, ["system", "info", "--format", fmt_str]);
 }
 
 #[tokio::test]
@@ -91,7 +91,7 @@ async fn run_docker_system_prune() {
     let output = res.expect("Failed to run docker system prune");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["prune", "system"]);
+    assert_eq!(args, ["system", "prune"]);
 }
 
 #[tokio::test]
@@ -110,7 +110,7 @@ async fn run_docker_system_prune_with_volumes() {
     let output = res.expect("Failed to run docker system prune with volumes");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--volumes", "prune", "system"]);
+    assert_eq!(args, ["system", "prune", "--volumes"]);
 }
 
 #[tokio::test]
@@ -129,7 +129,7 @@ async fn run_docker_system_prune_with_all() {
     let output = res.expect("Failed to run docker system prune with all");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--all", "prune", "system"]);
+    assert_eq!(args, ["system", "prune", "--all"]);
 }
 
 #[tokio::test]
@@ -148,7 +148,7 @@ async fn run_docker_system_prune_with_force() {
     let output = res.expect("Failed to run docker system prune with force");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--force", "prune", "system"]);
+    assert_eq!(args, ["system", "prune", "--force"]);
 }
 
 #[tokio::test]
@@ -169,6 +169,6 @@ async fn run_docker_system_prune_with_all_options() {
     let output = res.expect("Failed to run docker system prune with all options");
     let args = parse_fixture_output(&output);
 
-    // The mocker.sh script sorts all arguments alphabetically
-    assert_eq!(args, ["--all", "--force", "--volumes", "prune", "system"]);
+    // The arguments will appear in the order they were added
+    assert_eq!(args, ["system", "prune", "--volumes", "--all", "--force"]);
 }

--- a/seahaven-docker/src/cmd/tests/it_version.rs
+++ b/seahaven-docker/src/cmd/tests/it_version.rs
@@ -34,7 +34,7 @@ async fn run_docker_version_with_json_format() {
     let output = res.expect("Failed to run docker version");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--format", "json", "version"]);
+    assert_eq!(args, ["version", "--format", "json"]);
 }
 
 #[tokio::test]
@@ -54,5 +54,5 @@ async fn run_docker_version_with_custom_format() {
     let output = res.expect("Failed to run docker version");
     let args = parse_fixture_output(&output);
 
-    assert_eq!(args, ["--format", "version", fmt_str]);
+    assert_eq!(args, ["version", "--format", fmt_str]);
 }


### PR DESCRIPTION
- Added support for `docker compose pull`, `docker compose build`, `docker compose up`, and `docker compose down` commands in the `DockerComposeCmd` struct.
- Introduced new command structures for handling build arguments and service specifications.
- Implemented integration tests for `docker compose` commands, including various scenarios for building and running services.
- Updated the mock script to reflect changes in argument handling for deterministic test outputs.