### PR TITLE
feat(seahaven-docker): enhance Docker command builder with new options

### DIFF
--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -1,13 +1,68 @@
-//! Docker command builder
+//! # Command builder
 //!
-//! Supported commands:
+//! This module provides a type-safe abstraction for constructing and executing Docker commands.
+//! It allows for programmatic interaction with Docker's CLI without directly relying on string
+//! manipulation or process spawning, making Docker operations more maintainable and less error-prone.
+//!
+//! ## Architecture
+//!
+//! The module is structured around command builders that implement the `IntoCommand` trait,
+//! enabling consistent conversion of builder structs into executable command representations.
+//! Each Docker command family is organized into its own submodule.
+//!
+//! ## Supported Commands
+//!
+//! The following Docker commands are currently supported:
+//!
 //! - `docker version`
-//! - `docker system info`
-//! - `docker system prune`
-//! - `docker compose pull`
-//! - `docker compose build`
-//! - `docker compose up`
-//! - `docker compose down`
+//! - `docker system (info | prune)`
+//! - `docker compose (pull | build | up | down)`
+//!
+//! ## Examples
+//!
+//! ### Basic Docker Command
+//!
+//! ```rust
+//! use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+//!
+//! // Get Docker version information
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let version_cmd = DockerCmd::new().version();
+//! let mut command = version_cmd.into_command();
+//!
+//! // Execute the command
+//! let output = command.output().await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Docker Compose Command with Options
+//!
+//! ```rust
+//! use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+//!
+//! // Configure and start services with Docker Compose
+//! let mut compose_cmd = DockerCmd::new()
+//!     .compose()
+//!     .up()
+//!     .with_detached()
+//!     .with_service("my-service");
+//!
+//! let command = compose_cmd.into_command();
+//! ```
+//! Note the precedence of the `with_detached` method over the `with_service` method. The
+//! opposite order would not compile:
+//!
+//! ```compilation_error
+//! use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+//!
+//! let mut compose_cmd = DockerCmd::new()
+//!     .compose()
+//!     .up()
+//!     .with_service("my-service") // ❌ Error!
+//!     .with_detached();
+//! ```
+
 mod common;
 pub mod compose;
 mod root;

--- a/seahaven-docker/src/cmd/compose.rs
+++ b/seahaven-docker/src/cmd/compose.rs
@@ -1,15 +1,25 @@
-pub use build::DockerComposeBuildCmd;
-pub use down::DockerComposeDownCmd;
-pub use pull::DockerComposePullCmd;
-pub use up::DockerComposeUpCmd;
+use std::marker::PhantomData;
 
+pub use self::{
+    build::DockerComposeBuildCmd,
+    down::DockerComposeDownCmd,
+    opts::{
+        AnsiAlways, AnsiAuto, AnsiNever, NoProjectName, ProgressAuto, ProgressJson, ProgressPlain,
+        ProgressQuiet, ProgressTty, WithProjectName,
+    },
+    pull::DockerComposePullCmd,
+    up::DockerComposeUpCmd,
+};
 use super::common::IntoCommand;
 
-pub struct DockerComposeCmd(tokio::process::Command);
+pub struct DockerComposeCmd<N = NoProjectName, P = ProgressAuto, A = AnsiAuto>(
+    tokio::process::Command,
+    PhantomData<(N, P, A)>,
+);
 
-impl DockerComposeCmd {
+impl<N, P, A> DockerComposeCmd<N, P, A> {
     pub(crate) fn new(cmd: tokio::process::Command) -> Self {
-        Self(cmd)
+        Self(cmd, PhantomData)
     }
 
     /// Pull the images for the services defined in the `docker-compose.yml` file.
@@ -43,11 +53,186 @@ impl DockerComposeCmd {
     pub fn down(self) -> DockerComposeDownCmd {
         DockerComposeDownCmd::new(self.0)
     }
+
+    /// Specify an alternate compose file.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
+    /// for more information about the `--file` option.
+    pub fn with_file<S>(mut self, file: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        self.0.arg("--file").arg(file.as_ref());
+        self
+    }
+
+    /// Specify multiple compose files.
+    ///
+    /// Files will be applied in the order they're specified, with later files overriding
+    /// and adding to their predecessors.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
+    /// for more information about the `--file` option.
+    pub fn with_files<I, S>(mut self, files: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        for file in files {
+            self.0.arg("--file").arg(file.as_ref());
+        }
+        self
+    }
+
+    /// Specify an alternate environment file.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
+    /// for more information about the `--env-file` option.
+    pub fn with_env_file<S>(mut self, env_file: S) -> Self
+    where
+        S: AsRef<str>,
+    {
+        self.0.arg("--env-file").arg(env_file.as_ref());
+        self
+    }
 }
 
-impl IntoCommand for DockerComposeCmd {
+impl<N, P> DockerComposeCmd<N, P, AnsiAuto> {
+    /// Always print ANSI control characters.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
+    /// for more information about the `--ansi` option.
+    pub fn with_ansi_always(mut self) -> DockerComposeCmd<N, P, AnsiAlways> {
+        self.0.arg("--ansi").arg("always");
+        DockerComposeCmd(self.0, PhantomData)
+    }
+
+    /// Never print ANSI control characters.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
+    /// for more information about the `--ansi` option.
+    pub fn with_ansi_never(mut self) -> DockerComposeCmd<N, P, AnsiNever> {
+        self.0.arg("--ansi").arg("never");
+        DockerComposeCmd(self.0, PhantomData)
+    }
+}
+
+impl<P, A> DockerComposeCmd<NoProjectName, P, A> {
+    /// Specify a project name for the Docker Compose deployment.
+    ///
+    /// The project name is used as a prefix for container names and creates an isolated
+    /// environment for the services. By default, Docker Compose uses the directory name
+    /// of the compose file.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/#use--p-to-specify-a-project-name)
+    /// for more information about the `--project-name` option.
+    pub fn with_project_name<S>(mut self, name: S) -> DockerComposeCmd<WithProjectName, P, A>
+    where
+        S: AsRef<str>,
+    {
+        self.0.arg("--project-name").arg(name.as_ref());
+        DockerComposeCmd(self.0, PhantomData)
+    }
+}
+
+impl<N, A> DockerComposeCmd<N, ProgressAuto, A> {
+    /// Set the type of progress output to TTY
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
+    /// for more information.
+    pub fn with_tty_progress(mut self) -> DockerComposeCmd<N, ProgressTty, A> {
+        self.0.arg("--progress").arg("tty");
+        DockerComposeCmd(self.0, PhantomData)
+    }
+
+    /// Set the type of progress output to plain text
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
+    /// for more information.
+    pub fn with_plain_progress(mut self) -> DockerComposeCmd<N, ProgressPlain, A> {
+        self.0.arg("--progress").arg("plain");
+        DockerComposeCmd(self.0, PhantomData)
+    }
+
+    /// Set the type of progress output to JSON
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
+    /// for more information.
+    pub fn with_json_progress(mut self) -> DockerComposeCmd<N, ProgressJson, A> {
+        self.0.arg("--progress").arg("json");
+        DockerComposeCmd(self.0, PhantomData)
+    }
+
+    /// Set the type of progress output to quiet (no output)
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
+    /// for more information.
+    pub fn with_quiet_progress(mut self) -> DockerComposeCmd<N, ProgressQuiet, A> {
+        self.0.arg("--progress").arg("quiet");
+        DockerComposeCmd(self.0, PhantomData)
+    }
+}
+
+impl<N, P, A> IntoCommand for DockerComposeCmd<N, P, A> {
     fn into_command(self) -> tokio::process::Command {
         self.0
+    }
+}
+
+pub mod opts {
+    // Progress markers
+    pub trait ProgressOpt: _priv::Sealed {}
+
+    pub struct ProgressAuto;
+    impl ProgressOpt for ProgressAuto {}
+    impl _priv::Sealed for ProgressAuto {}
+
+    pub struct ProgressTty;
+    impl ProgressOpt for ProgressTty {}
+    impl _priv::Sealed for ProgressTty {}
+
+    pub struct ProgressPlain;
+    impl ProgressOpt for ProgressPlain {}
+    impl _priv::Sealed for ProgressPlain {}
+
+    pub struct ProgressJson;
+    impl ProgressOpt for ProgressJson {}
+    impl _priv::Sealed for ProgressJson {}
+
+    pub struct ProgressQuiet;
+    impl ProgressOpt for ProgressQuiet {}
+    impl _priv::Sealed for ProgressQuiet {}
+
+    // Project name markers
+    pub trait ProjectNameOpt: _priv::Sealed {}
+
+    pub struct NoProjectName;
+    impl ProjectNameOpt for NoProjectName {}
+    impl _priv::Sealed for NoProjectName {}
+
+    pub struct WithProjectName;
+    impl ProjectNameOpt for WithProjectName {}
+    impl _priv::Sealed for WithProjectName {}
+
+    // ANSI control characters markers
+    pub trait AnsiOpt: _priv::Sealed {}
+
+    pub struct AnsiAuto;
+    impl AnsiOpt for AnsiAuto {}
+    impl _priv::Sealed for AnsiAuto {}
+
+    pub struct AnsiAlways;
+    impl AnsiOpt for AnsiAlways {}
+    impl _priv::Sealed for AnsiAlways {}
+
+    pub struct AnsiNever;
+    impl AnsiOpt for AnsiNever {}
+    impl _priv::Sealed for AnsiNever {}
+
+    // Private module for sealing traits
+    #[allow(dead_code)]
+    mod _priv {
+        pub trait Sealed {}
     }
 }
 

--- a/seahaven-docker/src/cmd/root.rs
+++ b/seahaven-docker/src/cmd/root.rs
@@ -21,9 +21,9 @@ impl Default for DockerCmd {
 }
 
 impl DockerCmd {
-    /// Create a new docker command
+    /// Create a new `docker` command
     ///
-    /// This is equivalent to calling [`DockerCommand::default()`].
+    /// This is equivalent to calling [`DockerCmd::default()`].
     ///
     /// # Panics
     ///
@@ -32,7 +32,7 @@ impl DockerCmd {
         Self::default()
     }
 
-    /// Create a new docker command with a custom executable
+    /// Create a new `docker` command with a custom executable
     pub fn with_executable<B>(bin: B) -> Self
     where
         B: Borrow<Executable>,
@@ -40,7 +40,7 @@ impl DockerCmd {
         Self(tokio::process::Command::new(bin.borrow()))
     }
 
-    /// Create a new docker command with a custom executable
+    /// Create a new `docker` command with a custom executable
     #[cfg(test)]
     pub fn with_test_executable<E>(exe: E) -> Self
     where

--- a/seahaven-docker/src/cmd/system.rs
+++ b/seahaven-docker/src/cmd/system.rs
@@ -1,9 +1,10 @@
-pub use info::{DefaultFormat, DockerSystemInfoCmd, FormatOpt, WithCustomFormat, WithJsonFormat};
-pub use prune::{
-    All, AllOpt, DockerSystemPruneCmd, Force, ForceOpt, NoForce, NoVolumes, NotAll, Volumes,
-    VolumesOpt,
+pub use self::{
+    info::{DefaultFormat, DockerSystemInfoCmd, FormatOpt, WithCustomFormat, WithJsonFormat},
+    prune::{
+        All, AllOpt, DockerSystemPruneCmd, Force, ForceOpt, NoForce, NoVolumes, NotAll, Volumes,
+        VolumesOpt,
+    },
 };
-
 use super::common::IntoCommand;
 
 pub struct DockerSystemCmd(tokio::process::Command);

--- a/seahaven-docker/src/cmd/tests/it_compose.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose.rs
@@ -72,3 +72,421 @@ async fn run_docker_compose_pull() {
 
     assert_eq!(args, ["compose", "pull"]);
 }
+
+#[tokio::test]
+async fn run_docker_compose_with_plain_progress() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_plain_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with plain progress");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--progress", "plain", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_quiet_progress() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_quiet_progress()
+        .pull()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with quiet progress");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--progress", "quiet", "pull"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_project_name() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_project_name("test-project")
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with project name");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--project-name", "test-project", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_project_name_and_progress() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_project_name("test-project")
+        .with_json_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with project name and progress");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--project-name",
+            "test-project",
+            "--progress",
+            "json",
+            "up"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_progress_and_project_name() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_plain_progress()
+        .with_project_name("test-project")
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with progress and project name");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--progress",
+            "plain",
+            "--project-name",
+            "test-project",
+            "up"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_file() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_file("docker-compose.prod.yml")
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with file option");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--file", "docker-compose.prod.yml", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_multiple_files() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_files(["docker-compose.yml", "docker-compose.override.yml"])
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with multiple files");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--file",
+            "docker-compose.yml",
+            "--file",
+            "docker-compose.override.yml",
+            "up"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_env_file() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_env_file(".env.prod")
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with env file");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--env-file", ".env.prod", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_tty_progress() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_tty_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with tty progress");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--progress", "tty", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_json_progress() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_json_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with json progress");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--progress", "json", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_all_options() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_file("docker-compose.prod.yml")
+        .with_env_file(".env.prod")
+        .with_project_name("test-project")
+        .with_quiet_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with all options");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--file",
+            "docker-compose.prod.yml",
+            "--env-file",
+            ".env.prod",
+            "--project-name",
+            "test-project",
+            "--progress",
+            "quiet",
+            "up"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_file_and_env_file() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_file("docker-compose.dev.yml")
+        .with_env_file(".env.dev")
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with file and env file");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--file",
+            "docker-compose.dev.yml",
+            "--env-file",
+            ".env.dev",
+            "up"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_ansi_always() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_ansi_always()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with ansi always");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--ansi", "always", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_ansi_never() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_ansi_never()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with ansi never");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(args, ["compose", "--ansi", "never", "up"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_ansi_and_progress() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_ansi_always()
+        .with_plain_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with ansi and progress");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        ["compose", "--ansi", "always", "--progress", "plain", "up"]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_ansi_and_project_name() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_ansi_never()
+        .with_project_name("test-project")
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with ansi and project name");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--ansi",
+            "never",
+            "--project-name",
+            "test-project",
+            "up"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_with_all_options_including_ansi() {
+    //* Given
+    let mut cmd = DockerCmd::with_test_executable(MOCKER_SH_PATH)
+        .compose()
+        .with_file("docker-compose.prod.yml")
+        .with_env_file(".env.prod")
+        .with_ansi_always()
+        .with_project_name("test-project")
+        .with_quiet_progress()
+        .up()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose with all options including ansi");
+    let args = parse_fixture_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "--file",
+            "docker-compose.prod.yml",
+            "--env-file",
+            ".env.prod",
+            "--ansi",
+            "always",
+            "--project-name",
+            "test-project",
+            "--progress",
+            "quiet",
+            "up"
+        ]
+    );
+}


### PR DESCRIPTION
- Expanded the `DockerComposeCmd` struct to support additional command options, including specifying alternate compose files, multiple files, environment files, and project names.
- Introduced methods for controlling progress output formats (TTY, plain, JSON, quiet) and ANSI control character handling.
- Added comprehensive integration tests for the new command options to ensure correct functionality and output.