### PR TITLE
fix(seahaven-file): skip YAML comments in front matter extraction

### DIFF
--- a/seahaven-file/src/matter.rs
+++ b/seahaven-file/src/matter.rs
@@ -68,6 +68,9 @@ where
         if trimmed.is_empty() {
             // Skip empty lines
             continue;
+        } else if trimmed.starts_with('#') {
+            // Skip YAML comments
+            continue;
         } else if trimmed == DELIMITER {
             // Found opening delimiter
             break;
@@ -317,6 +320,38 @@ mod tests {
             r#"
 
 
+            ---
+            ENV_KEY1: "ENV_VALUE1"
+            ---
+            name: "solo-app"
+            "#
+        };
+
+        let mut reader = Cursor::new(raw_file);
+
+        //* When
+        let (front_matter_content, remaining_content) =
+            extract_front_matter(&mut reader).expect("Failed to extract front matter");
+
+        //* Then
+        let front_matter_reader = front_matter_content.expect("Failed to get front matter reader");
+        let front_matter_value: YamlValue =
+            serde_yaml::from_reader(front_matter_reader).expect("Failed to parse front matter");
+        assert_eq!(front_matter_value["ENV_KEY1"], "ENV_VALUE1");
+
+        let remaining_content_value: YamlValue =
+            serde_yaml::from_reader(remaining_content).expect("Failed to parse remaining content");
+        assert_eq!(remaining_content_value["name"], "solo-app");
+    }
+
+    #[test]
+    fn omments_before_delimiter() {
+        //* Given
+        let raw_file = indoc::indoc! {
+            r#"
+            # This is a YAML comment
+              # An indented comment line that should be ignored
+            # --- This looks like a delimiter but it's a comment
             ---
             ENV_KEY1: "ENV_VALUE1"
             ---

--- a/testlib/file-testdata/data/setup-yaml/kitchen-sink.yaml
+++ b/testlib/file-testdata/data/setup-yaml/kitchen-sink.yaml
@@ -1,3 +1,10 @@
+# The following YAML file is a "kitchen sink" of sorts, containing a
+# variety of features and edge cases that are commonly encountered in
+# the Seahaven setup description file.
+#
+# What is exact meaning of "kitchen sink" in programming?
+# https://stackoverflow.com/q/33779296/1099999
+
 ---
 # Chain config
 CHAIN_RPC: 8545
@@ -9,8 +16,6 @@ APP_SERVER_ADMIN: 7600
 APP_SERVER_RPC: 7601
 APP_SERVER_METRICS: 7602
 ---
-# What is exact meaning of "kitchen sink" in programming?
-# https://stackoverflow.com/q/33779296/1099999
 
 services:
   chain:

--- a/testlib/file-testdata/src/gen/setup-yaml/kitchen_sink.rs
+++ b/testlib/file-testdata/src/gen/setup-yaml/kitchen_sink.rs
@@ -1,6 +1,13 @@
 /// Test vector: `setup-yaml/kitchen_sink`
 ///
 /// ```yaml
+/// # The following YAML file is a "kitchen sink" of sorts, containing a
+/// # variety of features and edge cases that are commonly encountered in
+/// # the Seahaven setup description file.
+/// #
+/// # What is exact meaning of "kitchen sink" in programming?
+/// # https://stackoverflow.com/q/33779296/1099999
+///
 /// ---
 /// # Chain config
 /// CHAIN_RPC: 8545
@@ -12,8 +19,6 @@
 /// APP_SERVER_RPC: 7601
 /// APP_SERVER_METRICS: 7602
 /// ---
-/// # What is exact meaning of "kitchen sink" in programming?
-/// # https://stackoverflow.com/q/33779296/1099999
 ///
 /// services:
 ///   chain:
@@ -47,6 +52,13 @@
 ///
 /// See file: `setup-yaml/kitchen_sink.yaml`
 pub const KITCHEN_SINK: &str = indoc::indoc! { r###"
+  # The following YAML file is a "kitchen sink" of sorts, containing a
+  # variety of features and edge cases that are commonly encountered in
+  # the Seahaven setup description file.
+  #
+  # What is exact meaning of "kitchen sink" in programming?
+  # https://stackoverflow.com/q/33779296/1099999
+
   ---
   # Chain config
   CHAIN_RPC: 8545
@@ -58,8 +70,6 @@ pub const KITCHEN_SINK: &str = indoc::indoc! { r###"
   APP_SERVER_RPC: 7601
   APP_SERVER_METRICS: 7602
   ---
-  # What is exact meaning of "kitchen sink" in programming?
-  # https://stackoverflow.com/q/33779296/1099999
 
   services:
     chain:


### PR DESCRIPTION
- Updated the front matter extraction logic to ignore lines starting with '#' to properly handle YAML comments.
- Added a new test case to verify that comments before the delimiter are correctly skipped, ensuring accurate extraction of front matter.