### PR TITLE
feat(sehave-cli): add truman setup command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +430,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
 
 [[package]]
 name = "memchr"
@@ -461,6 +476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +514,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pin-project-lite"
@@ -550,8 +581,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -562,8 +602,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -606,7 +652,14 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 name = "seahaven-cli"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
+ "indoc",
+ "seahaven-file",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -734,6 +787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +809,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "strsim"
@@ -804,6 +872,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -865,6 +943,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1020,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
@@ -957,6 +1102,28 @@ dependencies = [
  "rustix",
  "winsafe",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -8,5 +8,16 @@ repository.workspace = true
 edition.workspace = true
 rust-version = "1.85.0"
 
+[[bin]]
+name = "truman"
+path = "src/main.rs"
+
 [dependencies]
-clap = "4.5"
+anyhow = "1.0.97"
+clap = { version = "4.5", features = ["cargo"] }
+indoc = "2.0.6"
+seahaven-file = { version = "0.1.0", path = "../seahaven-file" }
+thiserror = "2.0.12"
+tokio = { version = "1.44", features = ["rt", "macros"] }
+tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -1,0 +1,18 @@
+mod result;
+mod setup;
+
+use self::result::Result;
+
+/// Create and execute the DIPs CLI command line interface
+pub async fn run() -> Result<()> {
+    let matches = clap::command!()
+        .subcommands([setup::cmd()])
+        .infer_long_args(true)
+        .infer_subcommands(true)
+        .get_matches();
+
+    match matches.subcommand() {
+        Some((setup::CMD, matches)) => setup::run(matches).await,
+        _ => Err(anyhow::anyhow!("No command specified").into()),
+    }
+}

--- a/seahaven-cli/src/cmd/result.rs
+++ b/seahaven-cli/src/cmd/result.rs
@@ -1,0 +1,61 @@
+/// The result type for CLI commands
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// The default error code for CLI commands
+const DEFAULT_ERROR_CODE: i32 = 1;
+
+/// The error type for CLI commands
+#[derive(Debug, thiserror::Error)]
+#[error("{source}")]
+pub struct Error {
+    /// The error code
+    code: i32,
+    /// The error message
+    #[source]
+    source: anyhow::Error,
+}
+
+impl Error {
+    /// Create a new [`Error`] instance
+    ///
+    /// The default error code is 1.
+    pub fn new(err: impl Into<anyhow::Error> + Send + Sync + 'static) -> Self {
+        Self {
+            code: DEFAULT_ERROR_CODE,
+            source: err.into(),
+        }
+    }
+
+    /// Set the error code
+    ///
+    /// # Panic
+    ///
+    /// Panics if the error code is zero, as zero is reserved for success.
+    pub fn with_code(mut self, code: i32) -> Self {
+        if code == 0 {
+            panic!("Error code must be non-zero");
+        }
+
+        self.code = code;
+        self
+    }
+
+    /// Get the error code
+    pub fn code(&self) -> i32 {
+        self.code
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    #[inline]
+    fn from(value: anyhow::Error) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<(i32, anyhow::Error)> for Error {
+    #[inline]
+    fn from((code, err): (i32, anyhow::Error)) -> Self {
+        Self::new(err).with_code(code)
+    }
+}

--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -1,0 +1,236 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use clap::{ArgMatches, Command, arg, command, value_parser};
+use seahaven_file::compose::ComposeFile;
+
+use super::result::Result;
+
+/// The `setup` command name
+pub(super) const CMD: &str = "setup";
+
+/// Create the `setup` command
+pub(super) fn cmd() -> Command {
+    command!(CMD)
+        .about("Manage local development environment setup")
+        .subcommands([
+            command!("env").about("Print the .env file contents").args([
+                arg!(-f --file <FILE> "The setup file")
+                    .default_value("setup.yaml")
+                    .value_parser(value_parser!(PathBuf)),
+                arg!(--"no-interpolation" "Do not interpolate the environment values"),
+            ]),
+            command!("compose")
+                .about("Print the docker-compose.yaml file contents")
+                .args([
+                    arg!(-f --file <FILE> "The setup file")
+                        .default_value("setup.yaml")
+                        .value_parser(value_parser!(PathBuf)),
+                    arg!(--"no-interpolation" "Do not interpolate the environment values"),
+                ]),
+            command!("eject")
+                .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
+                .args([
+                    arg!(-f --file <FILE> "The setup file" )
+                        .default_value("setup.yaml")
+                        .value_parser(value_parser!(PathBuf)),
+                    arg!(-o --"output-dir" <DIR> "The output directory")
+                        .default_value(".")
+                        .value_parser(value_parser!(PathBuf)),
+                    arg!(--"no-interpolation" "Do not interpolate the environment values"),
+                ]),
+        ])
+}
+
+/// The `setup` command implementation
+pub(super) async fn run(matches: &ArgMatches) -> Result<()> {
+    match matches.subcommand() {
+        Some(("env", matches)) => env(matches).await,
+        Some(("compose", matches)) => compose(matches).await,
+        Some(("eject", matches)) => eject(matches).await,
+        _ => Err(anyhow::anyhow!("No setup command specified").into()),
+    }
+}
+
+/// The `setup env` command
+///
+/// This function prints the .env file contents to the console with all the interpolated values.
+pub async fn env(matches: &ArgMatches) -> Result<()> {
+    // Get the setup file path from the command line (required)
+    let setup_file_path = matches
+        .get_one::<PathBuf>("file")
+        .expect("Failed to get setup file path");
+    if !setup_file_path.is_file() {
+        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
+    }
+
+    // Read and parse the setup file
+    let file = File::open(setup_file_path)
+        .map(BufReader::new)
+        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+    let (env_file, _) = seahaven_file::from_reader(file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+
+    // If no environment is present, print a warning and return
+    let env_file = match env_file {
+        Some(env) => env,
+        None => {
+            eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: No env found in the setup file");
+            return Ok(());
+        }
+    };
+
+    // Check if we need to interpolate the environment variables
+    if !matches.get_flag("no-interpolation") {
+        // TODO: Implement interpolation (shellexpand crate?)
+        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation not implemented");
+    }
+
+    // Serialize the environment variables to a string
+    let env_content = seahaven_file::env::ser::to_string(&env_file)
+        .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
+
+    println!("{}", env_content);
+
+    Ok(())
+}
+
+/// The `setup compose` command
+///
+/// This function prints the docker-compose.yaml file contents to the console with all the interpolated values.
+pub async fn compose(matches: &ArgMatches) -> Result<()> {
+    // Get the setup file path from the command line (required)
+    let setup_file_path = matches
+        .get_one::<PathBuf>("file")
+        .expect("Failed to get setup file path");
+    if !setup_file_path.is_file() {
+        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
+    }
+
+    // Read and parse the setup file
+    let file = File::open(setup_file_path)
+        .map(BufReader::new)
+        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+    let (_env_file, content) = seahaven_file::from_reader(file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+
+    // Transform the content into a compose file
+    // TODO: Move the transformation into the `seahaven_file` crate
+    let compose_file = ComposeFile {
+        name: content.name,
+        services: content.services,
+        networks: content.networks,
+        volumes: content.volumes,
+        configs: content.configs,
+        secrets: content.secrets,
+    };
+
+    // Serialize the compose file to a string
+    let compose_content = seahaven_file::compose::ser::to_string(&compose_file)
+        .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
+
+    // Interpolate the compose file (env_file -> compose_file)
+    if !matches.get_flag("no-interpolation") {
+        // TODO: Implement interpolation (shellexpand crate?) for the compose file
+        // let mut env = EnvFile::from_iter(std::env::vars());
+        // if let Some(env_file) = env_file {
+        //     env.extend(env_file.into_iter());
+        // }
+        // <Shell expand the compose file>
+        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation not implemented");
+    }
+
+    println!("{}", compose_content);
+
+    Ok(())
+}
+
+/// The `setup eject` command
+///
+/// This function ejects the setup.yaml file to get the docker-compose.yaml and .env files.
+/// This is a one-way operation. Once ejected, you will need to manage the configuration manually.
+pub async fn eject(matches: &ArgMatches) -> Result<()> {
+    // Display warning message about the one-way nature of the operation
+    indoc::eprintdoc! {r#"
+        \x1b[33m\x1b[1mWARNING\x1b[0m: This is a one-way operation. Once ejected, you will need to manage the configuration manually.
+        \x1b[33m\x1b[1mWARNING\x1b[0m: The ejected files will be created in the specified output directory.
+        \x1b[33m\x1b[1mWARNING\x1b[0m: You can always regenerate the setup.yaml file from the ejected files if needed.
+        \x1b[33m\x1b[1mWARNING\x1b[0m: Are you sure you want to continue? [y/N] "#
+    }
+
+    // Get user confirmation
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .map_err(|err| anyhow::anyhow!("Failed to read user input: {err}"))?;
+    if !input.trim().to_lowercase().starts_with('y') {
+        eprintln!("Operation cancelled.");
+        return Ok(());
+    }
+
+    // Get the setup file path from the command line (required)
+    let setup_file_path = matches
+        .get_one::<PathBuf>("file")
+        .expect("Failed to get setup file path");
+    if !setup_file_path.is_file() {
+        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
+    }
+
+    // Get the output directory from the command line (required)
+    let output_dir = matches
+        .get_one::<PathBuf>("output-dir")
+        .expect("Failed to get output directory");
+    if !output_dir.is_dir() {
+        return Err(anyhow::anyhow!("Invalid output directory: {}", output_dir.display()).into());
+    }
+
+    // Read and parse the setup file
+    let file = File::open(setup_file_path)
+        .map(BufReader::new)
+        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+    let (env_file, content) = seahaven_file::from_reader(file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+
+    // Transform the content into a compose file
+    // TODO: Move the transformation into the `seahaven_file` crate
+    let compose_file = ComposeFile {
+        name: content.name,
+        services: content.services,
+        networks: content.networks,
+        volumes: content.volumes,
+        configs: content.configs,
+        secrets: content.secrets,
+    };
+
+    // Serialize the compose file to a string
+    let compose_content = seahaven_file::compose::ser::to_string(&compose_file)
+        .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
+
+    // Write the docker-compose.yaml file
+    let output_compose_file_path = output_dir.join("docker-compose.yaml");
+    std::fs::write(&output_compose_file_path, compose_content)
+        .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml: {}", err))?;
+    println!(
+        "Created docker-compose.yaml file at {}",
+        output_compose_file_path.display()
+    );
+
+    // If environment section is present, write the .env file
+    if let Some(env_file) = env_file {
+        // Serialize the environment variables to a string
+        let env_content = seahaven_file::env::ser::to_string(&env_file)
+            .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
+
+        // Write the .env file
+        let output_env_file_path = output_dir.join(".env");
+        std::fs::write(&output_env_file_path, env_content)
+            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {}", err))?;
+        println!("Created .env file at {}", output_env_file_path.display());
+    } else {
+        println!("No environment variables found in the setup file, skipping .env file creation");
+    }
+
+    println!("Ejection completed successfully!");
+    println!("You can now manage your configuration manually.");
+
+    Ok(())
+}

--- a/seahaven-cli/src/main.rs
+++ b/seahaven-cli/src/main.rs
@@ -1,3 +1,14 @@
-fn main() {
-    println!("Hello, world!");
+mod cmd;
+
+#[tokio::main(flavor = "current_thread")]
+pub async fn main() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+
+    // Parse and run
+    if let Err(err) = cmd::run().await {
+        eprintln!("{err}");
+        std::process::exit(err.code());
+    }
 }


### PR DESCRIPTION
- Introduced a new binary target "truman" in Cargo.toml.
- Refactored main function in src/main.rs to utilize async/await with tracing for better error reporting and structured logging.
- Added a new command "setup" to the CLI, for managing the local development environment setup.