### PR TITLE
 feat(seahaven-file): add iterator implementation to env module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,7 +711,7 @@ dependencies = [
 [[package]]
 name = "serde-envfile"
 version = "0.2.0"
-source = "git+https://github.com/LNSD/serde-envfile.git?rev=006e135#006e1353ca6115402d7e232a26f8d25b913a744a"
+source = "git+https://github.com/LNSD/serde-envfile.git?rev=ad00e40#ad00e4029930d238cb1b1465b46e5647a87ded6e"
 dependencies = [
  "cfg-if",
  "dotenvy",
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "test-with"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ed0eeaca420c94c7fbcfd53f425b6ea2ce25e23111523b76bde45ec1c4e2ca"
+checksum = "5b81f4413c3bd5ce29fcc54572bc44122364be6f68f047844e034acdea8e7e47"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",

--- a/seahaven-file/Cargo.toml
+++ b/seahaven-file/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 [dependencies]
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "006e135" }
+serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "ad00e40" }
 serde_yaml = "0.9"
 thiserror = "2.0"
 

--- a/seahaven-file/src/env.rs
+++ b/seahaven-file/src/env.rs
@@ -20,6 +20,84 @@ impl EnvFile {
     pub fn new() -> Self {
         Self(serde_envfile::Value::new())
     }
+
+    /// Returns an iterator over references to key-value pairs in this environment file.
+    pub fn iter(&self) -> Iter<'_> {
+        self.into_iter()
+    }
+
+    /// Returns an iterator over mutable references to key-value pairs in this environment file.
+    pub fn iter_mut(&mut self) -> IterMut<'_> {
+        self.into_iter()
+    }
+
+    /// Inserts a key-value pair into the environment file.
+    ///
+    /// If the key already exists, the value is replaced and the old value is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seahaven_file::env::EnvFile;
+    ///
+    /// let mut env_file = EnvFile::new();
+    /// assert_eq!(env_file.insert("KEY1", "VALUE1"), None);
+    /// assert_eq!(
+    ///     env_file.insert("KEY1", "NEW_VALUE"),
+    ///     Some("VALUE1".to_string())
+    /// );
+    /// ```
+    pub fn insert<K, V>(&mut self, key: K, value: V) -> Option<String>
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        self.0.insert(key.into(), value.into())
+    }
+
+    /// Removes a key-value pair from the environment file.
+    ///
+    /// Returns the value if the key was present, or `None` if it was not.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seahaven_file::env::EnvFile;
+    ///
+    /// let mut env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// assert_eq!(env_file.remove("KEY1"), Some("VALUE1".to_string()));
+    /// assert_eq!(env_file.remove("KEY3"), None);
+    /// ```
+    pub fn remove<K>(&mut self, key: K) -> Option<String>
+    where
+        K: Into<String>,
+    {
+        self.0.remove(key.into())
+    }
+
+    /// Removes a key-value pair from the environment file and returns it as a tuple.
+    ///
+    /// Returns the key-value pair if the key was present, or `None` if it was not.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seahaven_file::env::EnvFile;
+    ///
+    /// let mut env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// assert_eq!(
+    ///     env_file.remove_entry("KEY1"),
+    ///     Some(("KEY1".to_string(), "VALUE1".to_string()))
+    /// );
+    /// assert_eq!(env_file.remove_entry("KEY3"), None);
+    /// ```
+    pub fn remove_entry<K>(&mut self, key: K) -> Option<(String, String)>
+    where
+        K: Into<String>,
+    {
+        let key = key.into();
+        self.0.remove(&key).map(|value| (key, value))
+    }
 }
 
 impl Default for EnvFile {
@@ -66,7 +144,142 @@ where
     /// # assert_eq!(env_file.get("KEY2").unwrap(), "VALUE2");
     /// ```
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
-        Self(serde_envfile::Value::from_iter(iter))
+        Self(FromIterator::from_iter(iter))
+    }
+}
+
+impl<K, V> Extend<(K, V)> for EnvFile
+where
+    K: Into<String>,
+    V: Into<String>,
+{
+    /// Extends an `EnvFile` with key-value pairs from an iterator.
+    ///
+    /// This allows adding multiple key-value pairs to an existing environment file.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use seahaven_file::env::EnvFile;
+    ///
+    /// let mut env_file = EnvFile::new();
+    /// env_file.extend([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// # assert_eq!(env_file.get("KEY1").unwrap(), "VALUE1");
+    /// # assert_eq!(env_file.get("KEY2").unwrap(), "VALUE2");
+    /// ```
+    fn extend<T: IntoIterator<Item = (K, V)>>(&mut self, iter: T) {
+        self.0.extend(iter)
+    }
+}
+
+/// Enables iteration over references to key-value pairs in an `EnvFile`.
+///
+/// # Examples
+///
+/// ```rust
+/// use seahaven_file::env::EnvFile;
+///
+/// let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+/// for (key, value) in &env_file {
+///     println!("{} = {}", key, value);
+/// }
+/// ```
+impl<'a> IntoIterator for &'a EnvFile {
+    type Item = (&'a String, &'a String);
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Iter(self.0.iter())
+    }
+}
+
+/// Enables iteration over mutable references to key-value pairs in an `EnvFile`.
+///
+/// # Examples
+///
+/// ```rust
+/// use seahaven_file::env::EnvFile;
+///
+/// let mut env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+/// for (key, value) in &mut env_file {
+///     *value = format!("{}_UPDATED", value);
+/// }
+/// ```
+impl<'a> IntoIterator for &'a mut EnvFile {
+    type Item = (&'a String, &'a mut String);
+    type IntoIter = IterMut<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IterMut(self.0.iter_mut())
+    }
+}
+
+/// Enables iteration over owned key-value pairs from an `EnvFile`.
+///
+/// # Examples
+///
+/// ```rust
+/// use seahaven_file::env::EnvFile;
+///
+/// let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+/// for (key, value) in env_file {
+///     println!("{} = {}", key, value);
+/// }
+/// ```
+impl IntoIterator for EnvFile {
+    type Item = (String, String);
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        IntoIter(self.0.into_iter())
+    }
+}
+
+/// Iterator over references to key-value pairs in an [`EnvFile`]
+#[derive(Debug)]
+pub struct Iter<'a>(serde_envfile::value::Iter<'a>);
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (&'a String, &'a String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+/// Iterator over mutable references to key-value pairs in an [`EnvFile`]
+#[derive(Debug)]
+pub struct IterMut<'a>(serde_envfile::value::IterMut<'a>);
+
+impl<'a> Iterator for IterMut<'a> {
+    type Item = (&'a String, &'a mut String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+/// Iterator over owned key-value pairs from an [`EnvFile`]
+#[derive(Debug)]
+pub struct IntoIter(serde_envfile::value::IntoIter);
+
+impl Iterator for IntoIter {
+    type Item = (String, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 


### PR DESCRIPTION
- Updated the `serde-envfile` dependency to a new commit reference for improved functionality.
- Enhanced the `EnvFile` struct with new methods for key-value pair manipulation, including `insert`, `remove`, and iterator implementations.