### PR TITLE
feat(seahaven-file): add envfile_from_reader function

### DIFF
--- a/seahaven-file/src/env.rs
+++ b/seahaven-file/src/env.rs
@@ -9,7 +9,7 @@
 /// This struct provides a convenient way to work with environment variables
 /// stored in a file format. It wraps a `serde_envfile::Value` and provides
 /// methods to create, manipulate, and access environment variables.
-#[derive(Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
 pub struct EnvFile(serde_envfile::Value);
 

--- a/seahaven-file/src/lib.rs
+++ b/seahaven-file/src/lib.rs
@@ -85,10 +85,27 @@ where
 {
     let (front_matter, content) = matter::extract_front_matter(reader)?;
 
-    let env_file = front_matter.map(serde_envfile::from_reader).transpose()?;
+    let envfile = front_matter.map(serde_envfile::from_reader).transpose()?;
     let file_content = content::de::from_reader(content)?;
 
-    Ok((env_file, file_content))
+    Ok((envfile, file_content))
+}
+
+/// Parses a Seahaven setup description file from a IO stream and returns the envfile.
+///
+/// This function extracts and parses the front-matter section (if present) and returns
+/// the environment variables as an [`EnvFile`].
+///
+/// See [`Error`] for the errors that can occur when parsing a setup description file
+pub fn envfile_from_reader<R>(reader: R) -> Result<Option<EnvFile>, ParsingError>
+where
+    R: BufRead + Seek,
+{
+    let (front_matter, _) = matter::extract_front_matter(reader)?;
+
+    let env_file = front_matter.map(serde_envfile::from_reader).transpose()?;
+
+    Ok(env_file)
 }
 
 /// Errors that can occur when parsing a setup description file

--- a/seahaven-file/src/tests/parsing.rs
+++ b/seahaven-file/src/tests/parsing.rs
@@ -4,7 +4,7 @@ use testlib_file_testdata::setup_yaml::{
     EMPTY_ENV, KITCHEN_SINK, NO_SERVICES, SINGLE_SERVICE, SINGLE_SERVICE_BASIC,
 };
 
-use crate::{ParsingError, from_reader};
+use crate::{ParsingError, envfile_from_reader, from_reader};
 
 #[test]
 fn single_service() {
@@ -103,4 +103,24 @@ fn kitchen_sink() {
     assert!(content.volumes.is_some());
     assert!(content.configs.is_some());
     assert!(content.secrets.is_some());
+}
+
+#[test]
+fn kitchen_sink_env_file() {
+    // * Given
+    let input = Cursor::new(KITCHEN_SINK);
+
+    // * When
+    let env_file = envfile_from_reader(input).expect("Failed to parse KITCHEN_SINK");
+
+    // * Then
+    let env_file = env_file.expect("Env file should be present");
+    assert_eq!(env_file.get("chain_id").unwrap(), "1337");
+    assert_eq!(env_file.get("chain_name").unwrap(), "hardhat");
+    assert_eq!(env_file.get("app_port").unwrap(), "8080");
+    assert_eq!(env_file.get("chain_rpc").unwrap(), "8545");
+    assert_eq!(env_file.get("db_password").unwrap(), "secret");
+    assert_eq!(env_file.get("app_server_admin").unwrap(), "7600");
+    assert_eq!(env_file.get("app_server_rpc").unwrap(), "7601");
+    assert_eq!(env_file.get("app_server_metrics").unwrap(), "7602");
 }


### PR DESCRIPTION
- Updated the EnvFile struct to derive Clone for improved usability.
- Introduced a new function, `envfile_from_reader`, to parse environment variables from a setup description file's front-matter.
- Added a test case for validating the parsing of environment variables from the kitchen sink example.