### PR TITLE
refactor(seahaven-file): update setup file parsing and structure

### DIFF
--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -67,11 +67,11 @@ pub async fn env(matches: &ArgMatches) -> Result<()> {
     let file = File::open(setup_file_path)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let env_file = seahaven_file::envfile_from_reader(file)
+    let env = seahaven_file::fileenv_from_reader(file)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     // If no environment is present, print a warning and return
-    let env_file = match env_file {
+    let env = match env {
         Some(env) => env,
         None => {
             eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: No env found in the setup file");
@@ -82,11 +82,11 @@ pub async fn env(matches: &ArgMatches) -> Result<()> {
     // Check if we need to interpolate the environment variables
     if !matches.get_flag("no-interpolation") {
         // TODO: Implement interpolation (shellexpand crate?)
-        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation not implemented");
+        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation unavailable");
     }
 
     // Serialize the environment variables to a string
-    let env_content = seahaven_file::env::ser::to_string(&env_file)
+    let env_content = seahaven_file::serde_envfile::to_string(&env)
         .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
 
     println!("{}", env_content);
@@ -110,8 +110,9 @@ pub async fn compose(matches: &ArgMatches) -> Result<()> {
     let file = File::open(setup_file_path)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let (_env_file, content) = seahaven_file::from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+    let (_env, content) = seahaven_file::from_reader(file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
+        .unpack();
 
     // Transform the content into a compose file
     // TODO: Move the transformation into the `seahaven_file` crate
@@ -131,12 +132,7 @@ pub async fn compose(matches: &ArgMatches) -> Result<()> {
     // Interpolate the compose file (env_file -> compose_file)
     if !matches.get_flag("no-interpolation") {
         // TODO: Implement interpolation (shellexpand crate?) for the compose file
-        // let mut env = EnvFile::from_iter(std::env::vars());
-        // if let Some(env_file) = env_file {
-        //     env.extend(env_file.into_iter());
-        // }
-        // <Shell expand the compose file>
-        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation not implemented");
+        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation unavailable");
     }
 
     println!("{}", compose_content);
@@ -187,8 +183,9 @@ pub async fn eject(matches: &ArgMatches) -> Result<()> {
     let file = File::open(setup_file_path)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let (env_file, content) = seahaven_file::from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+    let (env, content) = seahaven_file::from_reader(file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
+        .unpack();
 
     // Transform the content into a compose file
     // TODO: Move the transformation into the `seahaven_file` crate
@@ -215,9 +212,9 @@ pub async fn eject(matches: &ArgMatches) -> Result<()> {
     );
 
     // If environment section is present, write the .env file
-    if let Some(env_file) = env_file {
+    if let Some(env) = env {
         // Serialize the environment variables to a string
-        let env_content = seahaven_file::env::ser::to_string(&env_file)
+        let env_content = seahaven_file::serde_envfile::to_string(&env)
             .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
 
         // Write the .env file

--- a/seahaven-file/src/lib.rs
+++ b/seahaven-file/src/lib.rs
@@ -63,69 +63,18 @@
 //!
 //! [compose-spec]: https://github.com/compose-spec/compose-spec/blob/main/spec.md
 
-pub mod compose;
-pub mod content;
-pub mod env;
+// Re-export serde_envfile
+pub use serde_envfile;
+
+pub mod compose; // TODO: Move to seahaven-docker or seahaven-compose-spec
 mod matter;
+pub mod model;
+mod parsing;
 
-use std::io::{BufRead, Seek};
-
-use self::{content::FileContent, env::EnvFile};
-
-/// Parses a Seahaven setup description YAML file from a IO stream
-///
-/// This function extracts and parses both the front-matter section (if present) and the main YAML content.
-/// The front-matter is parsed into an optional [`EnvFile`] containing environment variables,
-/// while the remaining content is parsed into a [`FileContent`].
-///
-/// See [`Error`] for the errors that can occur when parsing a setup description file
-pub fn from_reader<R>(reader: R) -> Result<(Option<EnvFile>, FileContent), ParsingError>
-where
-    R: BufRead + Seek,
-{
-    let (front_matter, content) = matter::extract_front_matter(reader)?;
-
-    let envfile = front_matter.map(serde_envfile::from_reader).transpose()?;
-    let file_content = content::de::from_reader(content)?;
-
-    Ok((envfile, file_content))
-}
-
-/// Parses a Seahaven setup description file from a IO stream and returns the envfile.
-///
-/// This function extracts and parses the front-matter section (if present) and returns
-/// the environment variables as an [`EnvFile`].
-///
-/// See [`Error`] for the errors that can occur when parsing a setup description file
-pub fn envfile_from_reader<R>(reader: R) -> Result<Option<EnvFile>, ParsingError>
-where
-    R: BufRead + Seek,
-{
-    let (front_matter, _) = matter::extract_front_matter(reader)?;
-
-    let env_file = front_matter.map(serde_envfile::from_reader).transpose()?;
-
-    Ok(env_file)
-}
-
-/// Errors that can occur when parsing a setup description file
-#[derive(Debug, thiserror::Error)]
-#[non_exhaustive]
-pub enum ParsingError {
-    /// The front matter section of a file has an invalid format
-    #[error("invalid front-matter format: {0}")]
-    InvalidFrontMatterFormat(#[from] matter::Error),
-
-    /// The environment variables in the front-matter section cannot be parsed
-    #[error("environment variables parsing failed: {0}")]
-    EnvParsingFailed(#[from] serde_envfile::Error),
-
-    /// The main content of the setup description file cannot be parsed
-    #[error("content deserialization failed: {0}")]
-    ContentDeserializationFailed(#[from] content::de::DeserializationError),
-}
+pub use model::{SetupFile, content::Content, env::Env};
+pub use parsing::{ParsingError, fileenv_from_reader, from_reader};
 
 #[cfg(test)]
 mod tests {
-    mod parsing;
+    mod it_parsing;
 }

--- a/seahaven-file/src/model.rs
+++ b/seahaven-file/src/model.rs
@@ -1,0 +1,9 @@
+//! # Seahaven setup description file model
+//!
+//! This module provides the core types and functions for working with Seahaven setup description files.
+
+pub mod content;
+pub mod env;
+mod file;
+
+pub use file::SetupFile;

--- a/seahaven-file/src/model/content.rs
+++ b/seahaven-file/src/model/content.rs
@@ -1,7 +1,7 @@
-//! # Seahaven setup description file contenta
+//! # Seahaven setup description file contents
 //!
 //! This module provides types and functions for working with Seahaven setup description files.
-//! It includes the `FileContent` struct that represents the content of a setup file,
+//! It includes the [`Content`] struct that represents the content of a setup file,
 //! along with serialization and deserialization utilities.
 
 /// Represents the content of a Seahaven setup description file.
@@ -9,8 +9,8 @@
 /// This struct follows the compose file format with top-level elements
 /// for services, networks, volumes, configs, and secrets. The `services`
 /// field is required while other elements are optional.
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-pub struct FileContent {
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Content {
     /// Name top-level element
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18,6 +18,11 @@ pub struct FileContent {
 
     /// Services top-level element
     pub services: serde_yaml::Mapping,
+
+    /// Init containers top-level element
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub init: Option<serde_yaml::Mapping>,
 
     /// Networks top-level element
     #[serde(default)]
@@ -42,7 +47,7 @@ pub struct FileContent {
 
 /// Module containing serialization functionality
 pub mod ser {
-    use super::FileContent;
+    use super::Content;
 
     /// An error that happened when serializing the setup description file content
     #[derive(Debug, thiserror::Error)]
@@ -50,12 +55,12 @@ pub mod ser {
     pub struct SerializationError(#[from] serde_yaml::Error);
 
     /// Serialize a setup description file content to a string
-    pub fn to_string(file: &FileContent) -> Result<String, SerializationError> {
+    pub fn to_string(file: &Content) -> Result<String, SerializationError> {
         serde_yaml::to_string(file).map_err(SerializationError)
     }
 
     /// Serialize a setup description file content to a writer
-    pub fn to_writer<W>(writer: W, file: &FileContent) -> Result<(), SerializationError>
+    pub fn to_writer<W>(writer: W, file: &Content) -> Result<(), SerializationError>
     where
         W: std::io::Write,
     {
@@ -65,7 +70,7 @@ pub mod ser {
 
 /// Module containing deserialization functionality
 pub mod de {
-    use super::FileContent;
+    use super::Content;
 
     /// An error that happened when deserializing the setup description file content
     #[derive(Debug, thiserror::Error)]
@@ -73,12 +78,12 @@ pub mod de {
     pub struct DeserializationError(#[from] serde_yaml::Error);
 
     /// Deserialize a setup description file content from a string
-    pub fn from_str(s: &str) -> Result<FileContent, DeserializationError> {
+    pub fn from_str(s: &str) -> Result<Content, DeserializationError> {
         serde_yaml::from_str(s).map_err(DeserializationError)
     }
 
     /// Deserialize a setup description file content from a reader
-    pub fn from_reader<R>(reader: R) -> Result<FileContent, DeserializationError>
+    pub fn from_reader<R>(reader: R) -> Result<Content, DeserializationError>
     where
         R: std::io::Read,
     {

--- a/seahaven-file/src/model/env.rs
+++ b/seahaven-file/src/model/env.rs
@@ -1,24 +1,122 @@
 //! Environment file handling
 //!
-//! This module provides functionality for working with environment files,
-//! including parsing, creating, and manipulating environment variables
-//! stored in an envfile format.
+//! This module provides a robust interface for working with environment files in the
+//! standard `.env` format. It offers functionality for:
+//!
+//! - Parsing environment files from strings or readers
+//! - Creating and manipulating environment variables
+//! - Serializing environment variables to strings or writers
+//! - Iterating over environment variables
+//!
+//! The module is built on top of the `serde_envfile` crate and provides a more
+//! ergonomic API for working with environment files in Rust applications.
 
-/// Represents an environment file containing key-value pairs
+/// Represents environment variables
 ///
 /// This struct provides a convenient way to work with environment variables
 /// stored in a file format. It wraps a `serde_envfile::Value` and provides
 /// methods to create, manipulate, and access environment variables.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(transparent)]
-pub struct EnvFile(serde_envfile::Value);
+pub struct Env(serde_envfile::Value);
 
-impl EnvFile {
+impl Env {
     /// Creates a new empty environment file.
     ///
-    /// Returns an `EnvFile` instance with no key-value pairs.
+    /// Returns an `Env` instance with no key-value pairs.
     pub fn new() -> Self {
         Self(serde_envfile::Value::new())
+    }
+
+    /// Returns the number of key-value pairs in the environment file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seahaven_file::model::env::Env;
+    ///
+    /// let mut env = Env::new();
+    /// assert_eq!(env.len(), 0);
+    ///
+    /// env.insert("KEY1", "VALUE1");
+    /// assert_eq!(env.len(), 1);
+    ///
+    /// env.insert("KEY2", "VALUE2");
+    /// assert_eq!(env.len(), 2);
+    ///
+    /// env.remove("KEY1");
+    /// assert_eq!(env.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns true if the environment file contains no key-value pairs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seahaven_file::model::env::Env;
+    ///
+    /// let mut env = Env::new();
+    /// assert!(env.is_empty());
+    ///
+    /// env.insert("KEY", "VALUE");
+    /// assert!(!env.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns a reference to the value associated with the key.
+    ///
+    /// Returns `None` if the key is not present in the environment file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seahaven_file::model::env::Env;
+    ///
+    /// let mut env = Env::new();
+    /// env.insert("DATABASE_URL", "postgres://localhost:5432/mydb");
+    ///
+    /// let value = env.get("DATABASE_URL");
+    /// assert!(value.is_some());
+    /// assert_eq!(value.unwrap(), "postgres://localhost:5432/mydb");
+    /// assert!(env.get("NONEXISTENT_KEY").is_none());
+    /// ```
+    pub fn get<K>(&self, key: K) -> Option<&String>
+    where
+        K: Into<String>,
+    {
+        self.0.get(&key.into())
+    }
+
+    /// Returns a mutable reference to the value associated with the key.
+    ///
+    /// Returns `None` if the key is not present in the environment file.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use seahaven_file::model::env::Env;
+    ///
+    /// let mut env = Env::new();
+    /// env.insert("DATABASE_URL", "postgres://localhost:5432/mydb");
+    ///
+    /// if let Some(value) = env.get_mut("DATABASE_URL") {
+    ///     *value = "postgres://localhost:5432/newdb".to_string();
+    /// }
+    ///
+    /// let value = env.get("DATABASE_URL");
+    /// assert!(value.is_some());
+    /// assert_eq!(value.unwrap(), "postgres://localhost:5432/newdb");
+    /// ```
+    pub fn get_mut<K>(&mut self, key: K) -> Option<&mut String>
+    where
+        K: Into<String>,
+    {
+        self.0.get_mut(&key.into())
     }
 
     /// Returns an iterator over references to key-value pairs in this environment file.
@@ -38,9 +136,9 @@ impl EnvFile {
     /// # Examples
     ///
     /// ```rust
-    /// use seahaven_file::env::EnvFile;
+    /// use seahaven_file::model::env::Env;
     ///
-    /// let mut env_file = EnvFile::new();
+    /// let mut env_file = Env::new();
     /// assert_eq!(env_file.insert("KEY1", "VALUE1"), None);
     /// assert_eq!(
     ///     env_file.insert("KEY1", "NEW_VALUE"),
@@ -62,9 +160,9 @@ impl EnvFile {
     /// # Examples
     ///
     /// ```rust
-    /// use seahaven_file::env::EnvFile;
+    /// use seahaven_file::model::env::Env;
     ///
-    /// let mut env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// let mut env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
     /// assert_eq!(env_file.remove("KEY1"), Some("VALUE1".to_string()));
     /// assert_eq!(env_file.remove("KEY3"), None);
     /// ```
@@ -82,9 +180,9 @@ impl EnvFile {
     /// # Examples
     ///
     /// ```rust
-    /// use seahaven_file::env::EnvFile;
+    /// use seahaven_file::model::env::Env;
     ///
-    /// let mut env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// let mut env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
     /// assert_eq!(
     ///     env_file.remove_entry("KEY1"),
     ///     Some(("KEY1".to_string(), "VALUE1".to_string()))
@@ -100,46 +198,30 @@ impl EnvFile {
     }
 }
 
-impl Default for EnvFile {
-    /// Creates a default `EnvFile` instance.
+impl Default for Env {
+    /// Creates a default `Env` instance.
     ///
-    /// This is equivalent to calling `EnvFile::new()`.
+    /// This is equivalent to calling `Env::new()`.
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::ops::Deref for EnvFile {
-    type Target = serde_envfile::Value;
-
-    /// Provides immutable access to the underlying map
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for EnvFile {
-    /// Provides mutable access to the underlying map
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-impl<K, V> FromIterator<(K, V)> for EnvFile
+impl<K, V> FromIterator<(K, V)> for Env
 where
     K: Into<String>,
     V: Into<String>,
 {
-    /// Creates an `EnvFile` from an iterator of key-value pairs.
+    /// Creates an `Env` from an iterator of key-value pairs.
     ///
     /// This allows constructing an environment file from any collection of string-like key-value pairs.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use seahaven_file::env::EnvFile;
+    /// use seahaven_file::model::env::Env;
     ///
-    /// let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+    /// let env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
     /// # assert_eq!(env_file.get("KEY1").unwrap(), "VALUE1");
     /// # assert_eq!(env_file.get("KEY2").unwrap(), "VALUE2");
     /// ```
@@ -148,21 +230,21 @@ where
     }
 }
 
-impl<K, V> Extend<(K, V)> for EnvFile
+impl<K, V> Extend<(K, V)> for Env
 where
     K: Into<String>,
     V: Into<String>,
 {
-    /// Extends an `EnvFile` with key-value pairs from an iterator.
+    /// Extends an `Env` with key-value pairs from an iterator.
     ///
     /// This allows adding multiple key-value pairs to an existing environment file.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use seahaven_file::env::EnvFile;
+    /// use seahaven_file::model::env::Env;
     ///
-    /// let mut env_file = EnvFile::new();
+    /// let mut env_file = Env::new();
     /// env_file.extend([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
     /// # assert_eq!(env_file.get("KEY1").unwrap(), "VALUE1");
     /// # assert_eq!(env_file.get("KEY2").unwrap(), "VALUE2");
@@ -172,19 +254,19 @@ where
     }
 }
 
-/// Enables iteration over references to key-value pairs in an `EnvFile`.
+/// Enables iteration over references to key-value pairs in an `Env`.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use seahaven_file::env::EnvFile;
+/// use seahaven_file::model::env::Env;
 ///
-/// let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+/// let env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
 /// for (key, value) in &env_file {
 ///     println!("{} = {}", key, value);
 /// }
 /// ```
-impl<'a> IntoIterator for &'a EnvFile {
+impl<'a> IntoIterator for &'a Env {
     type Item = (&'a String, &'a String);
     type IntoIter = Iter<'a>;
 
@@ -193,19 +275,19 @@ impl<'a> IntoIterator for &'a EnvFile {
     }
 }
 
-/// Enables iteration over mutable references to key-value pairs in an `EnvFile`.
+/// Enables iteration over mutable references to key-value pairs in an `Env`.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use seahaven_file::env::EnvFile;
+/// use seahaven_file::model::env::Env;
 ///
-/// let mut env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+/// let mut env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
 /// for (key, value) in &mut env_file {
 ///     *value = format!("{}_UPDATED", value);
 /// }
 /// ```
-impl<'a> IntoIterator for &'a mut EnvFile {
+impl<'a> IntoIterator for &'a mut Env {
     type Item = (&'a String, &'a mut String);
     type IntoIter = IterMut<'a>;
 
@@ -214,19 +296,19 @@ impl<'a> IntoIterator for &'a mut EnvFile {
     }
 }
 
-/// Enables iteration over owned key-value pairs from an `EnvFile`.
+/// Enables iteration over owned key-value pairs from an `Env`.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use seahaven_file::env::EnvFile;
+/// use seahaven_file::model::env::Env;
 ///
-/// let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+/// let env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
 /// for (key, value) in env_file {
 ///     println!("{} = {}", key, value);
 /// }
 /// ```
-impl IntoIterator for EnvFile {
+impl IntoIterator for Env {
     type Item = (String, String);
     type IntoIter = IntoIter;
 
@@ -235,7 +317,7 @@ impl IntoIterator for EnvFile {
     }
 }
 
-/// Iterator over references to key-value pairs in an [`EnvFile`]
+/// Iterator over references to key-value pairs in an [`Env`]
 #[derive(Debug)]
 pub struct Iter<'a>(serde_envfile::value::Iter<'a>);
 
@@ -251,7 +333,7 @@ impl<'a> Iterator for Iter<'a> {
     }
 }
 
-/// Iterator over mutable references to key-value pairs in an [`EnvFile`]
+/// Iterator over mutable references to key-value pairs in an [`Env`]
 #[derive(Debug)]
 pub struct IterMut<'a>(serde_envfile::value::IterMut<'a>);
 
@@ -267,7 +349,7 @@ impl<'a> Iterator for IterMut<'a> {
     }
 }
 
-/// Iterator over owned key-value pairs from an [`EnvFile`]
+/// Iterator over owned key-value pairs from an [`Env`]
 #[derive(Debug)]
 pub struct IntoIter(serde_envfile::value::IntoIter);
 
@@ -285,24 +367,24 @@ impl Iterator for IntoIter {
 
 /// Module containing serialization functionality
 pub mod ser {
-    use super::EnvFile;
+    use super::Env;
 
     /// An error that occurs when serializing an env file
     #[derive(Debug, thiserror::Error)]
     #[error(transparent)]
     pub struct SerializationError(#[from] serde_envfile::Error);
 
-    /// Converts an [`EnvFile`] to a string representation.
+    /// Converts an [`Env`] to a string representation.
     ///
     /// Returns a [`SerializationError`] if the serialization fails.
-    pub fn to_string(file: &EnvFile) -> Result<String, SerializationError> {
+    pub fn to_string(file: &Env) -> Result<String, SerializationError> {
         serde_envfile::to_string(file).map_err(SerializationError)
     }
 
-    /// Writes an [`EnvFile`] to the provided writer.
+    /// Writes an [`Env`] to the provided writer.
     ///
     /// Returns a [`SerializationError`] if the write operation fails.
-    pub fn to_writer<W>(writer: W, file: &EnvFile) -> Result<(), SerializationError>
+    pub fn to_writer<W>(writer: W, file: &Env) -> Result<(), SerializationError>
     where
         W: std::io::Write,
     {
@@ -312,24 +394,24 @@ pub mod ser {
 
 /// Module containing deserialization functionality
 pub mod de {
-    use super::EnvFile;
+    use super::Env;
 
     /// An error that occurs when deserializing an env file
     #[derive(Debug, thiserror::Error)]
     #[error(transparent)]
     pub struct DeserializationError(#[from] serde_envfile::Error);
 
-    /// Parses a string into an [`EnvFile`]
+    /// Parses a string into an [`Env`]
     ///
     /// Returns a [`DeserializationError`] if the parsing fails.
-    pub fn from_string(string: &str) -> Result<EnvFile, DeserializationError> {
+    pub fn from_string(string: &str) -> Result<Env, DeserializationError> {
         serde_envfile::from_str(string).map_err(DeserializationError)
     }
 
-    /// Reads an [`EnvFile`] from the provided reader
+    /// Reads an [`Env`] from the provided reader
     ///
     /// Returns a [`DeserializationError`] if the reading operation fails.
-    pub fn from_reader<R>(reader: R) -> Result<EnvFile, DeserializationError>
+    pub fn from_reader<R>(reader: R) -> Result<Env, DeserializationError>
     where
         R: std::io::Read,
     {
@@ -342,7 +424,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::{
-        EnvFile,
+        Env,
         de::{from_reader, from_string},
         ser::{to_string, to_writer},
     };
@@ -350,7 +432,7 @@ mod tests {
     #[test]
     fn serialize_env_file_to_string() {
         //* Given
-        let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+        let env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
 
         //* When
         let serialized = to_string(&env_file).expect("failed to serialize env file");
@@ -363,7 +445,7 @@ mod tests {
     #[test]
     fn serialize_env_file_to_writer() {
         //* Given
-        let env_file = EnvFile::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
+        let env_file = Env::from_iter([("KEY1", "VALUE1"), ("KEY2", "VALUE2")]);
 
         let mut buffer = Vec::new();
 
@@ -386,7 +468,7 @@ mod tests {
 
         //* Then
         // There is a bug in serde_envfile that causes the keys to be converted to lowercase
-        let expected_env_file = EnvFile::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
+        let expected_env_file = Env::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
         assert_eq!(env_file, expected_env_file);
     }
 
@@ -401,7 +483,7 @@ mod tests {
 
         //* Then
         // There is a bug in serde_envfile that causes the keys to be converted to lowercase
-        let expected_env_file = EnvFile::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
+        let expected_env_file = Env::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
         assert_eq!(env_file, expected_env_file);
     }
 
@@ -421,7 +503,7 @@ mod tests {
     fn roundtrip_serialization_deserialization() {
         //* Given
         // There is a bug in serde_envfile that causes the keys to be converted to lowercase
-        let original_env_file = EnvFile::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
+        let original_env_file = Env::from_iter([("key1", "VALUE1"), ("key2", "VALUE2")]);
 
         //* When
         let serialized = to_string(&original_env_file).expect("Failed to serialize env file");

--- a/seahaven-file/src/model/file.rs
+++ b/seahaven-file/src/model/file.rs
@@ -1,0 +1,71 @@
+use super::{content::Content, env::Env};
+
+/// A setup file containing an optional environment configuration and content.
+///
+/// The `SetupFile` struct represents a configuration file that can optionally include
+/// environment-specific settings along with its main content. This allows for flexible
+/// configuration management across different environments.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupFile(Option<Env>, Content);
+
+impl SetupFile {
+    /// Returns a reference to the environment configuration if present.
+    ///
+    /// The environment configuration contains variables and settings defined in the front matter
+    /// section of the setup file. Returns `None` if no environment configuration exists.
+    pub fn env(&self) -> Option<&Env> {
+        self.0.as_ref()
+    }
+
+    /// Returns a reference to the main configuration content.
+    ///
+    /// The content contains the core setup configuration including Docker Compose elements
+    /// like services, networks, volumes, configs, and secrets.
+    pub fn content(&self) -> &Content {
+        &self.1
+    }
+
+    /// Returns a mutable reference to the environment configuration if present.
+    ///
+    /// Allows modifying the environment variables and settings in the front matter.
+    /// Returns `None` if no environment configuration exists.
+    pub fn env_mut(&mut self) -> Option<&mut Env> {
+        self.0.as_mut()
+    }
+
+    /// Returns a mutable reference to the main configuration content.
+    ///
+    /// Allows modifying the core setup configuration including Docker Compose elements
+    /// like services, networks, volumes, configs, and secrets.
+    pub fn content_mut(&mut self) -> &mut Content {
+        &mut self.1
+    }
+
+    /// Consumes the `SetupFile` and returns its components as a tuple.
+    ///
+    /// Returns a tuple containing:
+    /// - An optional environment configuration (`Option<Env>`)
+    /// - The main configuration content (`Content`)
+    pub fn unpack(self) -> (Option<Env>, Content) {
+        (self.0, self.1)
+    }
+}
+
+impl From<(Option<Env>, Content)> for SetupFile {
+    /// Creates a new setup file from an environment and content tuple.
+    ///
+    /// Returns a new [`SetupFile`] instance containing the provided environment and content.
+    fn from((env, content): (Option<Env>, Content)) -> Self {
+        Self(env, content)
+    }
+}
+
+impl From<Content> for SetupFile {
+    /// Creates a new setup file from content only, with no environment configuration.
+    ///
+    /// Returns a new [`SetupFile`] instance containing only the provided content, with no environment
+    /// configuration (None).
+    fn from(content: Content) -> Self {
+        Self(None, content)
+    }
+}

--- a/seahaven-file/src/parsing.rs
+++ b/seahaven-file/src/parsing.rs
@@ -1,0 +1,62 @@
+use std::io::{BufRead, Seek};
+
+use crate::{
+    matter,
+    model::{
+        SetupFile, content,
+        env::{self, Env},
+    },
+};
+
+/// Parses a Seahaven setup description YAML file from a IO stream
+///
+/// This function extracts and parses both the front-matter section (if present) and the main YAML content.
+/// The front-matter is parsed into an optional [`Env`] containing environment variables,
+/// while the remaining content is parsed into a [`Content`](content::Content).
+///
+/// See [`ParsingError`] for the errors that can occur when parsing a setup description file
+pub fn from_reader<R>(reader: R) -> Result<SetupFile, ParsingError>
+where
+    R: BufRead + Seek,
+{
+    let (front_matter, content) = matter::extract_front_matter(reader)?;
+
+    let envfile = front_matter.map(env::de::from_reader).transpose()?;
+    let file_content = content::de::from_reader(content)?;
+
+    Ok(SetupFile::from((envfile, file_content)))
+}
+
+/// Parses a Seahaven setup description file from a IO stream and returns the envfile.
+///
+/// This function extracts and parses the front-matter section (if present) and returns
+/// the environment variables as an [`Env`].
+///
+/// See [`ParsingError`] for the errors that can occur when parsing a setup description file
+pub fn fileenv_from_reader<R>(reader: R) -> Result<Option<Env>, ParsingError>
+where
+    R: BufRead + Seek,
+{
+    let (front_matter, _) = matter::extract_front_matter(reader)?;
+
+    let env_file = front_matter.map(env::de::from_reader).transpose()?;
+
+    Ok(env_file)
+}
+
+/// Errors that can occur when parsing a setup description file
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ParsingError {
+    /// The front matter section of a file has an invalid format
+    #[error("invalid front-matter format: {0}")]
+    InvalidFrontMatterFormat(#[from] matter::Error),
+
+    /// The environment variables in the front-matter section cannot be parsed
+    #[error("environment variables parsing failed: {0}")]
+    EnvParsingFailed(#[from] env::de::DeserializationError),
+
+    /// The main content of the setup description file cannot be parsed
+    #[error("content deserialization failed: {0}")]
+    ContentDeserializationFailed(#[from] content::de::DeserializationError),
+}

--- a/seahaven-file/src/tests/it_parsing.rs
+++ b/seahaven-file/src/tests/it_parsing.rs
@@ -4,7 +4,7 @@ use testlib_file_testdata::setup_yaml::{
     EMPTY_ENV, KITCHEN_SINK, NO_SERVICES, SINGLE_SERVICE, SINGLE_SERVICE_BASIC,
 };
 
-use crate::{ParsingError, envfile_from_reader, from_reader};
+use crate::parsing::{ParsingError, fileenv_from_reader, from_reader};
 
 #[test]
 fn single_service() {
@@ -12,13 +12,15 @@ fn single_service() {
     let input = Cursor::new(SINGLE_SERVICE);
 
     // * When
-    let (env_file, content) = from_reader(input).expect("Failed to parse content");
+    let setup_file = from_reader(input).expect("Failed to parse content");
 
     // * Then
     // Verify envfile is not present
-    assert!(env_file.is_none());
+    let env = setup_file.env();
+    assert!(env.is_none());
 
     // Verify service content at top level only
+    let content = setup_file.content();
     assert!(!content.services.is_empty());
     assert!(content.services.contains_key("app"));
 }
@@ -29,13 +31,15 @@ fn single_service_basic() {
     let input = Cursor::new(SINGLE_SERVICE_BASIC);
 
     // * When
-    let (env_file, content) = from_reader(input).expect("Failed to parse content");
+    let setup_file = from_reader(input).expect("Failed to parse content");
 
     // * Then
     // Verify envfile is not present
-    assert!(env_file.is_none());
+    let env = setup_file.env();
+    assert!(env.is_none());
 
     // Verify service content at top level only
+    let content = setup_file.content();
     assert!(!content.services.is_empty());
     assert!(content.services.contains_key("app"));
 }
@@ -62,16 +66,17 @@ fn empty_env() {
     let input = Cursor::new(EMPTY_ENV);
 
     // * When
-    let (env_file, content) = from_reader(input).expect("Failed to parse EMPTY_ENV");
+    let setup_file = from_reader(input).expect("Failed to parse EMPTY_ENV");
 
     // * Then
     // Verify env file is present but empty
     assert!(
-        matches!(env_file, Some(env_file) if env_file.is_empty()),
+        matches!(setup_file.env(), Some(env_file) if env_file.is_empty()),
         "Expected env file to be present but empty"
     );
 
     // Verify the top-level content
+    let content = setup_file.content();
     assert!(!content.services.is_empty());
     assert!(content.volumes.is_some());
 }
@@ -82,21 +87,22 @@ fn kitchen_sink() {
     let input = Cursor::new(KITCHEN_SINK);
 
     // * When
-    let (env_file, content) = from_reader(input).expect("Failed to parse KITCHEN_SINK");
+    let setup_file = from_reader(input).expect("Failed to parse KITCHEN_SINK");
 
     // * Then
     // Assert that the env file is present and has the correct values
-    let env_file = env_file.expect("Front matter should be present");
-    assert_eq!(env_file.get("chain_id").unwrap(), "1337");
-    assert_eq!(env_file.get("chain_name").unwrap(), "hardhat");
-    assert_eq!(env_file.get("app_port").unwrap(), "8080");
-    assert_eq!(env_file.get("chain_rpc").unwrap(), "8545");
-    assert_eq!(env_file.get("db_password").unwrap(), "secret");
-    assert_eq!(env_file.get("app_server_admin").unwrap(), "7600");
-    assert_eq!(env_file.get("app_server_rpc").unwrap(), "7601");
-    assert_eq!(env_file.get("app_server_metrics").unwrap(), "7602");
+    let env = setup_file.env().expect("Front matter should be present");
+    assert_eq!(env.get("chain_id").unwrap(), "1337");
+    assert_eq!(env.get("chain_name").unwrap(), "hardhat");
+    assert_eq!(env.get("app_port").unwrap(), "8080");
+    assert_eq!(env.get("chain_rpc").unwrap(), "8545");
+    assert_eq!(env.get("db_password").unwrap(), "secret");
+    assert_eq!(env.get("app_server_admin").unwrap(), "7600");
+    assert_eq!(env.get("app_server_rpc").unwrap(), "7601");
+    assert_eq!(env.get("app_server_metrics").unwrap(), "7602");
 
     // Assert that the content structure is correct
+    let content = setup_file.content();
     assert!(content.name.is_some());
     assert_eq!(content.services.len(), 3);
     assert!(content.networks.is_some());
@@ -111,16 +117,16 @@ fn kitchen_sink_env_file() {
     let input = Cursor::new(KITCHEN_SINK);
 
     // * When
-    let env_file = envfile_from_reader(input).expect("Failed to parse KITCHEN_SINK");
+    let env = fileenv_from_reader(input).expect("Failed to parse KITCHEN_SINK");
 
     // * Then
-    let env_file = env_file.expect("Env file should be present");
-    assert_eq!(env_file.get("chain_id").unwrap(), "1337");
-    assert_eq!(env_file.get("chain_name").unwrap(), "hardhat");
-    assert_eq!(env_file.get("app_port").unwrap(), "8080");
-    assert_eq!(env_file.get("chain_rpc").unwrap(), "8545");
-    assert_eq!(env_file.get("db_password").unwrap(), "secret");
-    assert_eq!(env_file.get("app_server_admin").unwrap(), "7600");
-    assert_eq!(env_file.get("app_server_rpc").unwrap(), "7601");
-    assert_eq!(env_file.get("app_server_metrics").unwrap(), "7602");
+    let env = env.expect("Env file should be present");
+    assert_eq!(env.get("chain_id").unwrap(), "1337");
+    assert_eq!(env.get("chain_name").unwrap(), "hardhat");
+    assert_eq!(env.get("app_port").unwrap(), "8080");
+    assert_eq!(env.get("chain_rpc").unwrap(), "8545");
+    assert_eq!(env.get("db_password").unwrap(), "secret");
+    assert_eq!(env.get("app_server_admin").unwrap(), "7600");
+    assert_eq!(env.get("app_server_rpc").unwrap(), "7601");
+    assert_eq!(env.get("app_server_metrics").unwrap(), "7602");
 }


### PR DESCRIPTION
- Replaced `envfile_from_reader` with `fileenv_from_reader` for improved environment variable parsing.
- Refactored the `from_reader` function to return a `SetupFile` struct containing both environment and content.
- Introduced a new `SetupFile` struct to encapsulate environment configurations and main content.
- Enhanced error handling and updated related tests to ensure proper functionality.