### PR TITLE
feat(seahaven-file): add file convert module

### DIFF
--- a/seahaven-cli/src/cmd/result.rs
+++ b/seahaven-cli/src/cmd/result.rs
@@ -12,14 +12,16 @@ pub struct Error {
     code: i32,
     /// The error message
     #[source]
-    source: anyhow::Error,
+    source: Box<dyn std::error::Error + Send + Sync + 'static>,
 }
 
 impl Error {
     /// Create a new [`Error`] instance
     ///
     /// The default error code is 1.
-    pub fn new(err: impl Into<anyhow::Error> + Send + Sync + 'static) -> Self {
+    pub fn new(
+        err: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>> + Send + Sync + 'static,
+    ) -> Self {
         Self {
             code: DEFAULT_ERROR_CODE,
             source: err.into(),

--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -81,7 +81,7 @@ pub async fn env(matches: &ArgMatches) -> Result<()> {
 
     // Check if we need to interpolate the environment variables
     if !matches.get_flag("no-interpolation") {
-        // TODO: Implement interpolation (shellexpand crate?)
+        // TODO: Implement interpolation
         eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation unavailable");
     }
 
@@ -115,15 +115,8 @@ pub async fn compose(matches: &ArgMatches) -> Result<()> {
         .unpack();
 
     // Transform the content into a compose file
-    // TODO: Move the transformation into the `seahaven_file` crate
-    let compose_file = ComposeFile {
-        name: content.name,
-        services: content.services,
-        networks: content.networks,
-        volumes: content.volumes,
-        configs: content.configs,
-        secrets: content.secrets,
-    };
+    let compose_file = seahaven_file::try_into_compose_file(content)
+        .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
 
     // Serialize the compose file to a string
     let compose_content = seahaven_file::compose::ser::to_string(&compose_file)
@@ -131,7 +124,7 @@ pub async fn compose(matches: &ArgMatches) -> Result<()> {
 
     // Interpolate the compose file (env_file -> compose_file)
     if !matches.get_flag("no-interpolation") {
-        // TODO: Implement interpolation (shellexpand crate?) for the compose file
+        // TODO: Implement interpolation for the compose file
         eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation unavailable");
     }
 

--- a/seahaven-file/src/convert.rs
+++ b/seahaven-file/src/convert.rs
@@ -1,0 +1,182 @@
+//! # Seahaven setup description file transformations
+//!
+//! This module provides functions for converting Seahaven setup description files
+//! into [Compose] and [.env] files.
+//!
+//! [Compose]: https://github.com/compose-spec/compose-spec/blob/main/spec.md
+//! [.env]: https://dotenvx.com/docs/env-file
+
+use crate::{compose::ComposeFile, model::content::Content};
+
+/// Try to convert a [`Content`] into a [`ComposeFile`].
+pub fn try_into_compose_file(file: Content) -> Result<ComposeFile, Error> {
+    let mut compose_file = ComposeFile {
+        name: file.name,
+        services: file.services,
+        networks: file.networks,
+        volumes: file.volumes,
+        configs: file.configs,
+        secrets: file.secrets,
+    };
+
+    // Merge the init-containers into the services
+    if let Some(init) = file.init {
+        // Check name overlap between init-containers, `init`, and `services`
+        let bad_keys = init
+            .keys()
+            .filter_map(|key| key.as_str())
+            .filter(|key| compose_file.services.contains_key(key))
+            .collect::<Vec<_>>();
+        if !bad_keys.is_empty() {
+            return Err(anyhow::anyhow!("The following names overlap: {:?}", bad_keys).into());
+        }
+
+        compose_file.services.extend(init);
+    }
+
+    Ok(compose_file)
+}
+
+/// Error type for conversion operations in the Seahaven file module.
+///
+/// It's designed to be used as a return type for functions that may fail during
+/// the conversion of Seahaven setup description files.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct Error(Box<dyn std::error::Error + Send + Sync>);
+
+impl From<anyhow::Error> for Error {
+    fn from(err: anyhow::Error) -> Self {
+        Self(err.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_yaml::Mapping;
+
+    use super::*;
+
+    const PROJECT_NAME: &str = "test-project";
+    const CHAIN_SERVICE_NAME: &str = "chain";
+    const DEPLOY_SMART_CONTRACTS_INIT_CONTAINER_NAME: &str = "deploy-smart-contracts";
+
+    fn chain_service() -> (serde_yaml::Value, serde_yaml::Value) {
+        let name = CHAIN_SERVICE_NAME.to_string();
+        let map = Mapping::from_iter([(
+            serde_yaml::Value::String("image".to_string()),
+            serde_yaml::Value::String("ghcr.io/foundry-rs/foundry:latest".to_string()),
+        )]);
+        (
+            serde_yaml::Value::String(name),
+            serde_yaml::Value::Mapping(map),
+        )
+    }
+
+    fn deploy_smart_contracts_init_container() -> (serde_yaml::Value, serde_yaml::Value) {
+        let name = DEPLOY_SMART_CONTRACTS_INIT_CONTAINER_NAME.to_string();
+        let map = Mapping::from_iter([(
+            serde_yaml::Value::String("build".to_string()),
+            serde_yaml::Value::Mapping(Mapping::from_iter([
+                (
+                    serde_yaml::Value::String("context".to_string()),
+                    serde_yaml::Value::String("contracts".to_string()),
+                ),
+                (
+                    serde_yaml::Value::String("dockerfile".to_string()),
+                    serde_yaml::Value::String("Dockerfile.deploy".to_string()),
+                ),
+            ])),
+        )]);
+        (
+            serde_yaml::Value::String(name),
+            serde_yaml::Value::Mapping(map),
+        )
+    }
+
+    #[test]
+    fn init_containers_are_merged_into_services() {
+        //* Given
+        let services = Mapping::from_iter([chain_service()]);
+        let init = Mapping::from_iter([deploy_smart_contracts_init_container()]);
+
+        let content = Content {
+            name: Some(PROJECT_NAME.to_string()),
+            services,
+            init: Some(init),
+            networks: None,
+            volumes: None,
+            configs: None,
+            secrets: None,
+        };
+
+        //* When
+        let result = try_into_compose_file(content);
+
+        //* Then
+        assert!(result.is_ok());
+
+        let compose_file = result.expect("Failed to convert content to compose file");
+
+        // Verify the name is preserved
+        assert_eq!(compose_file.name, Some(PROJECT_NAME.to_string()));
+
+        // Verify services contains both the chain service and the init container
+        assert_eq!(compose_file.services.len(), 2);
+        assert!(compose_file.services.contains_key(CHAIN_SERVICE_NAME));
+        assert!(
+            compose_file
+                .services
+                .contains_key(DEPLOY_SMART_CONTRACTS_INIT_CONTAINER_NAME)
+        );
+
+        // Verify other fields are None
+        assert!(compose_file.networks.is_none());
+        assert!(compose_file.volumes.is_none());
+        assert!(compose_file.configs.is_none());
+        assert!(compose_file.secrets.is_none());
+    }
+
+    #[test]
+    fn overlapping_container_names_error() {
+        //* Given
+        const OVERLAPPING_NAME: &str = "overlap";
+
+        let services = {
+            let (_, service) = chain_service();
+            Mapping::from_iter([(
+                serde_yaml::Value::String(OVERLAPPING_NAME.to_string()),
+                service,
+            )])
+        };
+        let init = {
+            let (_, init_container) = deploy_smart_contracts_init_container();
+            Mapping::from_iter([(
+                serde_yaml::Value::String(OVERLAPPING_NAME.to_string()),
+                init_container,
+            )])
+        };
+
+        let content = Content {
+            name: Some(PROJECT_NAME.to_string()),
+            services,
+            init: Some(init),
+            networks: None,
+            volumes: None,
+            configs: None,
+            secrets: None,
+        };
+
+        //* When
+        let result = try_into_compose_file(content);
+
+        //* Then
+        assert!(result.is_err());
+
+        // Verify the error message contains the overlapping name
+        let err = result.expect_err("Expected an error");
+
+        let err_msg = err.to_string();
+        assert!(err_msg.contains(OVERLAPPING_NAME));
+    }
+}

--- a/seahaven-file/src/lib.rs
+++ b/seahaven-file/src/lib.rs
@@ -67,10 +67,12 @@
 pub use serde_envfile;
 
 pub mod compose; // TODO: Move to seahaven-docker or seahaven-compose-spec
+mod convert;
 mod matter;
 pub mod model;
 mod parsing;
 
+pub use convert::{Error as ConvertError, try_into_compose_file};
 pub use model::{SetupFile, content::Content, env::Env};
 pub use parsing::{ParsingError, fileenv_from_reader, from_reader};
 


### PR DESCRIPTION
- Updated the `Error` struct to use a boxed trait object for better flexibility in error types.
- Refactored the `compose` function to utilize a new `try_into_compose_file` function for converting setup files to compose files, improving code organization.
- Added a new `convert` module to encapsulate conversion logic for Seahaven setup description files.