### PR TITLE
feat(seahaven-compose-file): introduce seahaven-compose-file crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,7 +121,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -204,6 +210,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +271,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,6 +292,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "env_home"
@@ -298,16 +334,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "h2"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.9.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "hashbrown"
@@ -326,6 +484,119 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -352,10 +623,149 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -384,6 +794,12 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -421,9 +837,15 @@ checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "log"
@@ -447,6 +869,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minijinja"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -471,8 +899,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -516,16 +961,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "openssl"
+version = "0.10.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "powerfmt"
@@ -574,6 +1081,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +1131,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "reqwest"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -625,15 +1197,54 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -649,6 +1260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "seahaven-cli"
 version = "0.1.0"
 dependencies = [
@@ -660,6 +1280,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "seahaven-compose-file"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_yaml",
+ "testlib-file-testdata",
+ "thiserror",
 ]
 
 [[package]]
@@ -683,11 +1314,35 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "indoc",
+ "seahaven-compose-file",
  "serde",
  "serde-envfile",
  "serde_yaml",
  "testlib-file-testdata",
  "thiserror",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -739,6 +1394,18 @@ checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -811,16 +1478,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "socket2"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -831,6 +1529,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -916,6 +1668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tokio"
 version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -927,6 +1689,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -941,6 +1704,66 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1004,6 +1827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,6 +1843,35 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -1028,10 +1886,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1057,6 +1939,19 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1092,10 +1987,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "7.0.2"
+name = "web-sys"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
@@ -1135,7 +2040,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]
@@ -1167,10 +2072,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
+dependencies = [
+ "windows-result",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -1190,7 +2115,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1199,7 +2124,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1208,14 +2133,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -1225,10 +2166,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1237,10 +2190,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1249,10 +2214,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1261,13 +2238,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "3"
 members = [
     "seahaven-cli",
+    "seahaven-compose-file",
     "seahaven-docker",
     "seahaven-file",
     "testlib/file-testdata",

--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -1,7 +1,6 @@
 use std::{fs::File, io::BufReader, path::PathBuf};
 
 use clap::{ArgMatches, Command, arg, command, value_parser};
-use seahaven_file::compose::ComposeFile;
 
 use super::result::Result;
 
@@ -119,7 +118,7 @@ pub async fn compose(matches: &ArgMatches) -> Result<()> {
         .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
 
     // Serialize the compose file to a string
-    let compose_content = seahaven_file::compose::ser::to_string(&compose_file)
+    let compose_content = seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
         .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
 
     // Interpolate the compose file (env_file -> compose_file)
@@ -181,18 +180,11 @@ pub async fn eject(matches: &ArgMatches) -> Result<()> {
         .unpack();
 
     // Transform the content into a compose file
-    // TODO: Move the transformation into the `seahaven_file` crate
-    let compose_file = ComposeFile {
-        name: content.name,
-        services: content.services,
-        networks: content.networks,
-        volumes: content.volumes,
-        configs: content.configs,
-        secrets: content.secrets,
-    };
+    let compose_file = seahaven_file::try_into_compose_file(content)
+        .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
 
     // Serialize the compose file to a string
-    let compose_content = seahaven_file::compose::ser::to_string(&compose_file)
+    let compose_content = seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
         .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
 
     // Write the docker-compose.yaml file

--- a/seahaven-compose-file/Cargo.toml
+++ b/seahaven-compose-file/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "seahaven-compose-file"
+version = "0.1.0"
+description = "A library for working with Compose files"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[features]
+# Enables serialization and deserialization support via serde
+# When enabled, types can be converted to/from various formats (JSON, YAML, etc.)
+serde = ["dep:serde"]
+
+# Enables automatic schema updates from the official Compose specification
+# When enabled, the build script will:
+# 1. Download the latest Compose specification from GitHub
+# 2. Update the local schema files in the schemas directory
+# 3. Ensure the library stays in sync with the latest Compose format
+update-spec-file = []
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_yaml = "0.9"
+thiserror = "2.0"
+
+[dev-dependencies]
+testlib-file-testdata = { path = "../testlib/file-testdata" }
+
+[build-dependencies]
+reqwest = { version = "0.12", features = ["blocking"] }

--- a/seahaven-compose-file/README.md
+++ b/seahaven-compose-file/README.md
@@ -1,0 +1,27 @@
+seahaven-compose-file
+=====================
+
+A Rust library for working with Docker Compose files,
+providing functionality for parsing, validating, and manipulating Compose files
+according to the [Compose specification](https://github.com/compose-spec/compose-spec/blob/main/spec.md).
+
+## Update the Compose specification schema file
+
+The library includes a build feature `update-spec-file` that allows you to update the [Compose specification schema file](https://github.com/compose-spec/compose-spec/blob/main/schema/compose-spec.json).
+When enabled, the build script will download the latest version of the schema
+from the official Compose specification repository.
+
+To update the schema file, run:
+
+```bash
+cargo build -p seahaven-compose-file --features=update-spec-file
+```
+
+This will download the latest Compose specification schema
+and save it to `schemas/compose-spec.json`.
+
+## References
+
+- [Compose Specification](https://github.com/compose-spec/compose-spec/blob/main/spec.md)
+- [Compose Specification JSON Schema](https://github.com/compose-spec/compose-spec/blob/main/schema/compose-spec.json)
+- [Docker Compose File Reference](https://docs.docker.com/reference/compose-file/)

--- a/seahaven-compose-file/build.rs
+++ b/seahaven-compose-file/build.rs
@@ -1,0 +1,47 @@
+use std::{env, fs, path::PathBuf};
+
+/// The URL to the compose spec file (main branch)
+const COMPOSE_SPEC_FILE_URL: &str =
+    "https://github.com/compose-spec/compose-spec/raw/refs/heads/main/schema/compose-spec.json";
+
+/// The path to the compose spec file
+const COMPOSE_SPEC_FILE_PATH: &str = "schemas/compose-spec.json";
+
+fn main() {
+    // Check if update-spec-file feature is enabled
+    if cfg!(feature = "update-spec-file") {
+        let spec_path = {
+            let manifest_dir = env::var("CARGO_MANIFEST_DIR")
+                .map(PathBuf::from)
+                .expect("Failed to get CARGO_MANIFEST_DIR");
+            manifest_dir.join(COMPOSE_SPEC_FILE_PATH)
+        };
+
+        // Create schemas directory if it doesn't exist
+        if let Some(parent) = spec_path.parent() {
+            fs::create_dir_all(parent).expect("Failed to create schemas directory");
+        }
+
+        // Download the spec using reqwest
+        let client = reqwest::blocking::Client::new();
+        let response = client
+            .get(COMPOSE_SPEC_FILE_URL)
+            .send()
+            .expect("Failed to download compose spec");
+
+        if !response.status().is_success() {
+            panic!(
+                "Failed to download compose spec: HTTP request failed with status {}",
+                response.status()
+            );
+        }
+
+        let content = response
+            .text()
+            .expect("Failed to read compose spec response body");
+
+        fs::write(spec_path, content).expect("Failed to write compose-spec.json to file");
+
+        println!("cargo:warning=Downloaded latest version of compose-spec.json from GitHub");
+    }
+}

--- a/seahaven-compose-file/schemas/compose-spec.json
+++ b/seahaven-compose-file/schemas/compose-spec.json
@@ -259,6 +259,20 @@
             }
           ]
         },
+        "provider": {
+          "type": "object",
+          "properties": {
+            "type": {"type": "string"},
+            "options": {
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {"type": ["string", "number", "null"]}
+              }
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
         "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "extra_hosts": {"$ref": "#/definitions/extra_hosts"},
         "gpus": {"$ref": "#/definitions/gpus"},
@@ -279,7 +293,6 @@
         "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
         "logging": {
           "type": "object",
-
           "properties": {
             "driver": {"type": "string"},
             "options": {
@@ -405,7 +418,9 @@
                 "type": "object",
                 "required": ["type"],
                 "properties": {
-                  "type": {"type": "string"},
+                  "type": {"type": "string",
+                    "enum": ["bind", "volume", "tmpfs", "cluster", "image"]
+                  },
                   "source": {"type": "string"},
                   "target": {"type": "string"},
                   "read_only": {"type": ["boolean", "string"]},
@@ -424,6 +439,7 @@
                   "volume": {
                     "type": "object",
                     "properties": {
+                      "labels": {"$ref": "#/definitions/list_or_dict"},
                       "nocopy": {"type": ["boolean", "string"]},
                       "subpath": {"type": "string"}
                     },
@@ -440,6 +456,14 @@
                         ]
                       },
                       "mode": {"type": ["number", "string"]}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "subpath": {"type": "string"}
                     },
                     "additionalProperties": false,
                     "patternProperties": {"^x-": {}}

--- a/seahaven-compose-file/src/lib.rs
+++ b/seahaven-compose-file/src/lib.rs
@@ -1,0 +1,301 @@
+//! # Compose file
+//!
+//! A Rust library for working with Docker Compose files.
+//! This crate provides functionality for parsing, validating, and manipulating
+//! Compose files according to the [Compose specification](https://github.com/compose-spec/compose-spec/blob/main/spec.md).
+//!
+//! The [`ComposeFile`] struct represents a Compose file that follows
+//! the [Compose specification](https://github.com/compose-spec/compose-spec/blob/main/spec.md),
+//! allowing for specification of multi-container applications.
+//!
+//! ## References
+//!
+//! - [Compose Spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md)
+//! - [Docker Compose File Reference](https://docs.docker.com/reference/compose-file/)
+
+/// A compose file
+///
+/// This struct represents a Compose file that follows the [Compose specification]
+/// format, allowing for configuration and operation of multi-container applications.
+///
+/// [Compose specification]: https://github.com/compose-spec/compose-spec/blob/main/spec.md
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ComposeFile {
+    /// Name top-level element
+    ///
+    /// Ref: [Name top-level element](https://github.com/compose-spec/compose-spec/blob/main/spec.md#name-top-level-element)
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub name: Option<String>,
+
+    /// Services top-level element
+    ///
+    /// Ref: [Services top-level element](https://github.com/compose-spec/compose-spec/blob/main/spec.md#services-top-level-element)
+    pub services: serde_yaml::Mapping,
+
+    /// Networks top-level element
+    ///
+    /// Ref: [Networks top-level element](https://github.com/compose-spec/compose-spec/blob/main/spec.md#networks-top-level-element)
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub networks: Option<serde_yaml::Mapping>,
+
+    /// Volumes top-level element
+    ///
+    /// Ref: [Volumes top-level element](https://github.com/compose-spec/compose-spec/blob/main/spec.md#volumes-top-level-element)
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub volumes: Option<serde_yaml::Mapping>,
+
+    /// Configs top-level element
+    ///
+    /// Ref: [Configs top-level element](https://github.com/compose-spec/compose-spec/blob/main/spec.md#configs-top-level-element)
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub configs: Option<serde_yaml::Mapping>,
+
+    /// Secrets top-level element
+    ///
+    /// Ref: [Secrets top-level element](https://github.com/compose-spec/compose-spec/blob/main/spec.md#secrets-top-level-element)
+    #[cfg_attr(
+        feature = "serde",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
+    pub secrets: Option<serde_yaml::Mapping>,
+}
+
+/// Module containing serialization functionality
+#[cfg(feature = "serde")]
+pub mod ser {
+    use super::ComposeFile;
+
+    /// An error that occurs when serializing a compose file
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct SerializationError(#[from] pub(crate) serde_yaml::Error);
+
+    /// Converts a [`ComposeFile`] to a string representation.
+    ///
+    /// Returns a [`SerializationError`] if the serialization fails.
+    pub fn to_string(file: &ComposeFile) -> Result<String, SerializationError> {
+        serde_yaml::to_string(file).map_err(SerializationError)
+    }
+
+    /// Writes a [`ComposeFile`] to the provided writer.
+    ///
+    /// Returns a [`SerializationError`] if the write operation fails.
+    pub fn to_writer<W>(writer: W, file: &ComposeFile) -> Result<(), SerializationError>
+    where
+        W: std::io::Write,
+    {
+        serde_yaml::to_writer(writer, file).map_err(SerializationError)
+    }
+}
+
+/// Module containing deserialization functionality
+#[cfg(feature = "serde")]
+pub mod de {
+    use super::ComposeFile;
+
+    /// An error that occurs when deserializing a compose file
+    #[derive(Debug, thiserror::Error)]
+    #[error(transparent)]
+    pub struct DeserializationError(#[from] pub(crate) serde_yaml::Error);
+
+    /// Parses a string into a [`ComposeFile`]
+    ///
+    /// Returns a [`DeserializationError`] if the parsing fails.
+    pub fn from_str(s: &str) -> Result<ComposeFile, DeserializationError> {
+        serde_yaml::from_str(s).map_err(DeserializationError)
+    }
+
+    /// Reads a [`ComposeFile`] from the provided reader
+    ///
+    /// Returns a [`DeserializationError`] if the reading operation fails.
+    pub fn from_reader<R>(reader: R) -> Result<ComposeFile, DeserializationError>
+    where
+        R: std::io::Read,
+    {
+        serde_yaml::from_reader(reader).map_err(DeserializationError)
+    }
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use std::io::{Cursor, ErrorKind, Write};
+
+    use testlib_file_testdata::setup_yaml::SINGLE_SERVICE;
+
+    use super::{
+        de::{DeserializationError, from_reader, from_str},
+        ser::{SerializationError, to_string, to_writer},
+    };
+
+    #[test]
+    fn serialize_compose_file_to_string() {
+        //* Given
+        let compose_file =
+            serde_yaml::from_str(SINGLE_SERVICE).expect("failed to deserialize compose file");
+
+        //* When
+        let serialized = to_string(&compose_file).expect("failed to serialize compose file");
+
+        //* Then
+        // The last character of the serialized string is a newline, so we need to remove it
+        assert_eq!(&serialized[..serialized.len() - 1], SINGLE_SERVICE);
+    }
+
+    #[test]
+    fn serialize_compose_file_to_writer() {
+        //* Given
+        let compose_file =
+            serde_yaml::from_str(SINGLE_SERVICE).expect("failed to deserialize compose file");
+
+        let mut writer = Vec::new();
+
+        //* When
+        to_writer(&mut writer, &compose_file).expect("failed to serialize compose file");
+
+        //* Then
+        let serialized =
+            String::from_utf8(writer).expect("failed to convert serialized bytes to string");
+
+        // The last character of the serialized string is a newline, so we need to remove it
+        assert_eq!(&serialized[..serialized.len() - 1], SINGLE_SERVICE);
+    }
+
+    #[test]
+    fn serialize_compose_file_to_writer_fails_on_write_error() {
+        //* Given
+        let compose_file =
+            serde_yaml::from_str(SINGLE_SERVICE).expect("failed to deserialize compose file");
+
+        // Create a writer that will fail on write
+        struct FailingWriter;
+        impl Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    ErrorKind::Other,
+                    "simulated write failure",
+                ))
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let writer = FailingWriter;
+
+        //* When
+        let result = to_writer(writer, &compose_file);
+
+        //* Then
+        assert!(result.is_err(), "Expected the serialization to fail");
+        assert!(
+            matches!(result, Err(SerializationError(_))),
+            "Expected SerializationError"
+        );
+    }
+
+    #[test]
+    fn deserialize_compose_file_from_str() {
+        //* Given
+        let compose_yaml = SINGLE_SERVICE;
+
+        //* When
+        let compose_file = from_str(compose_yaml).expect("Failed to deserialize compose file");
+
+        //* Then
+        assert!(compose_file.name.is_none());
+        assert_eq!(compose_file.services.len(), 1);
+        assert!(compose_file.networks.is_none());
+        assert!(compose_file.volumes.is_none());
+        assert!(compose_file.configs.is_none());
+        assert!(compose_file.secrets.is_none());
+    }
+
+    #[test]
+    fn deserialize_compose_file_from_reader() {
+        //* Given
+        let reader = Cursor::new(SINGLE_SERVICE);
+
+        //* When
+        let compose_file = from_reader(reader).expect("Failed to deserialize compose file");
+
+        //* Then
+        assert!(compose_file.name.is_none());
+        assert_eq!(compose_file.services.len(), 1);
+        assert!(compose_file.networks.is_none());
+        assert!(compose_file.volumes.is_none());
+        assert!(compose_file.configs.is_none());
+        assert!(compose_file.secrets.is_none());
+    }
+
+    #[test]
+    fn deserialize_invalid_compose_file_returns_error() {
+        //* Given
+        let invalid_yaml = "services: - invalid yaml format";
+
+        //* When
+        let result = from_str(invalid_yaml);
+
+        //* Then
+        assert!(result.is_err(), "Expected the deserialization to fail");
+        assert!(
+            matches!(result, Err(DeserializationError(_))),
+            "Expected DeserializationError"
+        );
+    }
+
+    #[test]
+    fn deserialize_compose_file_from_reader_fails_on_read_error() {
+        //* Given
+        // Create a reader that will fail on read
+        struct FailingReader;
+        impl std::io::Read for FailingReader {
+            fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+                Err(std::io::Error::new(
+                    ErrorKind::Other,
+                    "simulated read failure",
+                ))
+            }
+        }
+
+        let reader = FailingReader;
+
+        //* When
+        let result = from_reader(reader);
+
+        //* Then
+        assert!(result.is_err(), "Expected the deserialization to fail");
+        assert!(
+            matches!(result, Err(DeserializationError(_))),
+            "Expected DeserializationError"
+        );
+    }
+
+    #[test]
+    fn roundtrip_serialization_deserialization() {
+        //* Given
+        let original_compose_file =
+            from_str(SINGLE_SERVICE).expect("Failed to deserialize compose file");
+
+        //* When
+        let serialized =
+            to_string(&original_compose_file).expect("Failed to serialize compose file");
+        let deserialized_compose_file =
+            from_str(&serialized).expect("Failed to deserialize compose file");
+
+        //* Then
+        assert_eq!(original_compose_file, deserialized_compose_file);
+    }
+}

--- a/seahaven-file/Cargo.toml
+++ b/seahaven-file/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1.0"
+seahaven-compose-file = { version = "0.1.0", path = "../seahaven-compose-file", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "ad00e40" }
 serde_yaml = "0.9"

--- a/seahaven-file/src/convert.rs
+++ b/seahaven-file/src/convert.rs
@@ -6,7 +6,9 @@
 //! [Compose]: https://github.com/compose-spec/compose-spec/blob/main/spec.md
 //! [.env]: https://dotenvx.com/docs/env-file
 
-use crate::{compose::ComposeFile, model::content::Content};
+use seahaven_compose_file::ComposeFile;
+
+use crate::model::content::Content;
 
 /// Try to convert a [`Content`] into a [`ComposeFile`].
 pub fn try_into_compose_file(file: Content) -> Result<ComposeFile, Error> {

--- a/seahaven-file/src/lib.rs
+++ b/seahaven-file/src/lib.rs
@@ -63,10 +63,9 @@
 //!
 //! [compose-spec]: https://github.com/compose-spec/compose-spec/blob/main/spec.md
 
-// Re-export serde_envfile
+pub use seahaven_compose_file;
 pub use serde_envfile;
 
-pub mod compose; // TODO: Move to seahaven-docker or seahaven-compose-spec
 mod convert;
 mod matter;
 pub mod model;

--- a/testlib/file-testdata/build.rs
+++ b/testlib/file-testdata/build.rs
@@ -10,13 +10,6 @@ use std::{
 /// This list of the directories under the `data` directory that contain the test vectors
 const TEST_SETS: &[&str] = &["setup-yaml"];
 
-/// Print a message to the console (green)
-macro_rules! echo {
-    ($($tokens: tt)*) => {
-        println!("cargo:warning=\r\x1b[32;1m   {}", format!($($tokens)*))
-    }
-}
-
 /// Print a warning message to the console (yellow)
 macro_rules! warning {
     ($($tokens: tt)*) => {
@@ -155,78 +148,72 @@ fn walk_dir_files(dir: impl AsRef<Path>) -> impl Iterator<Item = PathBuf> {
     paths.into_iter().map(|dir| dir.path())
 }
 
-/// Determine if code generation feature is enabled
-fn is_codegen_feature_enabled() -> bool {
-    std::env::var("CARGO_FEATURE_CODEGEN").is_ok()
-}
-
 fn main() {
     // Run code generation only if `codegen` feature is enabled
-    if !is_codegen_feature_enabled() {
-        echo!(
-            "Skipping code generation. Enable the `codegen` feature to regenerate the test vectors"
-        );
-        return;
-    }
+    if cfg!(feature = "codegen") {
+        let data_root_dir = crate_root_dir().join("data");
+        let src_gen_dir = crate_root_dir().join("src").join("gen");
 
-    let data_root_dir = crate_root_dir().join("data");
-    let src_gen_dir = crate_root_dir().join("src").join("gen");
+        for test_set_name in TEST_SETS {
+            let src_dir = data_root_dir.join(test_set_name);
+            if !src_dir.exists() {
+                warning!("Test vectors set `{test_set_name}` does not exist");
+                continue;
+            }
 
-    for test_set_name in TEST_SETS {
-        let src_dir = data_root_dir.join(test_set_name);
-        if !src_dir.exists() {
-            warning!("Test vectors set `{test_set_name}` does not exist");
-            continue;
+            // Create the destination directory
+            let dest_dir = src_gen_dir.join(test_set_name);
+            std::fs::create_dir_all(&dest_dir).expect("failed to create gen directory");
+
+            // Open (and overwrite) the test vectors set mod.rs file
+            let mut mod_file = std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(dest_dir.join("mod.rs"))
+                .unwrap_or_else(|err| panic!("failed to open gen/{test_set_name}/mod.rs: {}", err));
+
+            // Generate the test vector files
+            for test_vector_file in walk_dir_files(&src_dir) {
+                let test_vector_file_name = test_vector_file.file_name().expect("file has no name");
+                let test_vector_name = &sanitize_filename(test_vector_file_name);
+
+                // Load the content of the test vector file
+                let content = match load_file_and_read_lines(test_vector_file) {
+                    Ok(content) => content,
+                    Err(err) => {
+                        warning!(
+                            "failed to read test vector `{test_set_name}/{test_vector_name}` source file: {err}"
+                        );
+                        continue;
+                    }
+                };
+
+                let gen_file_name = as_rust_filename(test_vector_name);
+
+                // Render the content and write to the generated file
+                let rendered_content =
+                    codegen::engine().render_test_vector(test_vector_name, test_set_name, content);
+                let gen_file = dest_dir.join(&gen_file_name);
+                std::fs::write(&gen_file, rendered_content).unwrap_or_else(|err| {
+                    panic!("failed to write test vector `{test_vector_name}` source file: {err}")
+                });
+
+                // Append the new line to the `mod.rs` file
+                let rendered_include =
+                    codegen::engine().render_test_vector_mod_rs_include(&gen_file_name);
+                writeln!(mod_file, "{}", rendered_include).unwrap_or_else(|err| {
+                    panic!(
+                        "failed to include generated file into gen/{test_set_name}/mod.rs: {err}"
+                    )
+                });
+            }
         }
 
-        // Create the destination directory
-        let dest_dir = src_gen_dir.join(test_set_name);
-        std::fs::create_dir_all(&dest_dir).expect("failed to create gen directory");
+        // Re-run this build script if any of the files under the templates or data directories have changed
+        println!("cargo:rerun-if-changed=data/templates/**");
+        println!("cargo:rerun-if-changed=data/**");
 
-        // Open (and overwrite) the test vectors set mod.rs file
-        let mut mod_file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(dest_dir.join("mod.rs"))
-            .unwrap_or_else(|err| panic!("failed to open gen/{test_set_name}/mod.rs: {}", err));
-
-        // Generate the test vector files
-        for test_vector_file in walk_dir_files(&src_dir) {
-            let test_vector_file_name = test_vector_file.file_name().expect("file has no name");
-            let test_vector_name = &sanitize_filename(test_vector_file_name);
-
-            // Load the content of the test vector file
-            let content = match load_file_and_read_lines(test_vector_file) {
-                Ok(content) => content,
-                Err(err) => {
-                    warning!(
-                        "failed to read test vector `{test_set_name}/{test_vector_name}` source file: {err}"
-                    );
-                    continue;
-                }
-            };
-
-            let gen_file_name = as_rust_filename(test_vector_name);
-
-            // Render the content and write to the generated file
-            let rendered_content =
-                codegen::engine().render_test_vector(test_vector_name, test_set_name, content);
-            let gen_file = dest_dir.join(&gen_file_name);
-            std::fs::write(&gen_file, rendered_content).unwrap_or_else(|err| {
-                panic!("failed to write test vector `{test_vector_name}` source file: {err}")
-            });
-
-            // Append the new line to the `mod.rs` file
-            let rendered_include =
-                codegen::engine().render_test_vector_mod_rs_include(&gen_file_name);
-            writeln!(mod_file, "{}", rendered_include).unwrap_or_else(|err| {
-                panic!("failed to include generated file into gen/{test_set_name}/mod.rs: {err}")
-            });
-        }
+        println!("cargo:warning=Test vectors code generation completed");
     }
-
-    // Re-run this build script if any of the files under the templates or data directories have changed
-    println!("cargo:rerun-if-changed=data/templates/**");
-    println!("cargo:rerun-if-changed=data/**");
 }


### PR DESCRIPTION
- Added a new crate `seahaven-compose-file` to provide functionality for parsing, validating, and manipulating Docker Compose files.
- Implemented serialization and deserialization capabilities for Compose files using `serde_yaml`.
- Included a build script to download the latest Compose specification schema from GitHub.
- Updated the `seahaven-file` crate to utilize the new `ComposeFile` struct for improved file conversion processes.