### PR TITLE
refactor(seahaven-docker): restructure docker compose cmd typestate

### DIFF
--- a/seahaven-cli/src/cmd/up.rs
+++ b/seahaven-cli/src/cmd/up.rs
@@ -74,41 +74,16 @@ pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
 
-    let compose_up_cmd = DockerCmd::new()
+    let mut command = DockerCmd::new()
         .compose()
         .with_file(content_file_path)
         .with_env_file(env_file_path)
         .with_plain_progress()
-        .up();
-
-    // TODO: Change the command to support conditional flags
-    let mut command = match (
-        matches.get_flag("detach"),
-        matches.get_flag("build"),
-        matches.get_many::<String>("SERVICE"),
-    ) {
-        // Detached mode combinations
-        (true, true, Some(services)) => compose_up_cmd
-            .with_detached()
-            .with_build()
-            .with_services(services)
-            .into_command(),
-        (true, true, None) => compose_up_cmd.with_detached().with_build().into_command(),
-        (true, false, Some(services)) => compose_up_cmd
-            .with_detached()
-            .with_services(services)
-            .into_command(),
-        (true, false, None) => compose_up_cmd.with_detached().into_command(),
-
-        // Non-detached mode combinations
-        (false, true, Some(services)) => compose_up_cmd
-            .with_build()
-            .with_services(services)
-            .into_command(),
-        (false, true, None) => compose_up_cmd.with_build().into_command(),
-        (false, false, Some(services)) => compose_up_cmd.with_services(services).into_command(),
-        (false, false, None) => compose_up_cmd.into_command(),
-    };
+        .up()
+        .with_build(matches.get_flag("build"))
+        .with_detached(matches.get_flag("detach"))
+        .with_services(matches.get_many::<String>("SERVICE").unwrap_or_default())
+        .into_command();
 
     tracing::debug!("Running command: {:?}", command.as_std());
 

--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -45,13 +45,13 @@
 //! let mut compose_cmd = DockerCmd::new()
 //!     .compose()
 //!     .up()
-//!     .with_detached()
+//!     .with_detached(true)
 //!     .with_service("my-service");
 //!
 //! let command = compose_cmd.into_command();
 //! ```
-//! Note the precedence of the `with_detached` method over the `with_service` method. The
-//! opposite order would not compile:
+//! Note that the order of method calls matters - `with_progress_json` must be called before `up`.
+//! The reverse order would not compile:
 //!
 //! ```compilation_error
 //! use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -59,7 +59,7 @@
 //! let mut compose_cmd = DockerCmd::new()
 //!     .compose()
 //!     .up()
-//!     .with_service("my-service") // ❌ Error!
+//!     .with_progress_json() // ❌ Error!
 //!     .with_detached();
 //! ```
 

--- a/seahaven-docker/src/cmd/common.rs
+++ b/seahaven-docker/src/cmd/common.rs
@@ -5,3 +5,21 @@ pub trait IntoCommand {
     /// Convert the command into a [`tokio::process::Command`].
     fn into_command(self) -> tokio::process::Command;
 }
+
+impl IntoCommand for tokio::process::Command {
+    fn into_command(self) -> tokio::process::Command {
+        self
+    }
+}
+
+/// A trait that converts a command option struct into an optional value.
+///
+/// This trait is used internally to convert command option structs (like `DetachedSet` or `BuildSet`)
+/// into their corresponding values. It allows for a type-safe way to handle optional command line
+/// arguments where the presence or absence of a value is encoded in the type system.
+pub(super) trait IntoCmdOptValue<T> {
+    /// Convert the command option struct into a [`Option<T>`].
+    ///
+    /// Returns `Some(value)` if the option is set, or `None` if the option is not set.
+    fn into_value(self) -> Option<T>;
+}

--- a/seahaven-docker/src/cmd/compose.rs
+++ b/seahaven-docker/src/cmd/compose.rs
@@ -1,34 +1,61 @@
-use std::{ffi::OsStr, marker::PhantomData};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+pub mod build;
+pub mod down;
+pub mod pull;
+pub mod up;
 
 use self::{
-    build::DockerComposeBuildCmd,
-    down::DockerComposeDownCmd,
-    opts::{
-        AnsiAlways, AnsiAuto, AnsiNever, NoProjectName, ProgressAuto, ProgressJson, ProgressPlain,
-        ProgressQuiet, ProgressTty, WithProjectName,
-    },
-    pull::DockerComposePullCmd,
+    build::DockerComposeBuildCmd, down::DockerComposeDownCmd, pull::DockerComposePullCmd,
     up::DockerComposeUpCmd,
 };
-use super::common::IntoCommand;
+use super::common::{IntoCmdOptValue, IntoCommand};
 
-pub struct DockerComposeCmd<N = NoProjectName, P = ProgressAuto, A = AnsiAuto>(
-    tokio::process::Command,
-    PhantomData<(N, P, A)>,
-);
+pub struct DockerComposeCmd<
+    N = NameNotSet,
+    F = ProjectFileNotSet,
+    E = EnvFileNotSet,
+    P = ProgressNotSet,
+    A = AnsiNotSet,
+> {
+    cmd: tokio::process::Command,
+    name_opt: N,
+    project_file_opt: F,
+    env_file_opt: E,
+    progress_opt: P,
+    ansi_opt: A,
+}
 
-impl<N, P, A> DockerComposeCmd<N, P, A> {
-    pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
-        cmd.arg("compose");
-        Self(cmd, PhantomData)
+impl DockerComposeCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self {
+            cmd: cmd.into_command(),
+            name_opt: NameNotSet,
+            project_file_opt: ProjectFileNotSet,
+            env_file_opt: EnvFileNotSet,
+            progress_opt: ProgressNotSet,
+            ansi_opt: AnsiNotSet,
+        }
     }
+}
 
+impl<N, F, E, P, A> DockerComposeCmd<N, F, E, P, A>
+where
+    N: NameOpt,
+    F: ProjectFileOpt,
+    E: EnvFileOpt,
+    P: ProgressOpt,
+    A: AnsiOpt,
+{
     /// Pull the images for the services defined in the `docker-compose.yml` file.
     ///
     /// See [`docker compose pull`](https://docs.docker.com/compose/reference/pull/)
     /// for more information.
     pub fn pull(self) -> DockerComposePullCmd {
-        DockerComposePullCmd::new(self.0)
+        DockerComposePullCmd::new(self)
     }
 
     /// Build the images for the services defined in the `docker-compose.yml` file.
@@ -36,7 +63,7 @@ impl<N, P, A> DockerComposeCmd<N, P, A> {
     /// See [`Docker Compose Build`](https://docs.docker.com/compose/reference/build/)
     /// for more information.
     pub fn build(self) -> DockerComposeBuildCmd {
-        DockerComposeBuildCmd::new(self.0)
+        DockerComposeBuildCmd::new(self)
     }
 
     /// Start the services defined in the `docker-compose.yml` file.
@@ -44,7 +71,7 @@ impl<N, P, A> DockerComposeCmd<N, P, A> {
     /// See [`docker compose up`](https://docs.docker.com/compose/reference/up/)
     /// for more information.
     pub fn up(self) -> DockerComposeUpCmd {
-        DockerComposeUpCmd::new(self.0)
+        DockerComposeUpCmd::new(self)
     }
 
     /// Stop the services defined in the `docker-compose.yml` file.
@@ -52,73 +79,54 @@ impl<N, P, A> DockerComposeCmd<N, P, A> {
     /// See [`docker compose down`](https://docs.docker.com/compose/reference/down/)
     /// for more information.
     pub fn down(self) -> DockerComposeDownCmd {
-        DockerComposeDownCmd::new(self.0)
+        DockerComposeDownCmd::new(self)
     }
+}
 
-    /// Specify an alternate compose file.
-    ///
-    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
-    /// for more information about the `--file` option.
-    pub fn with_file<S>(mut self, file: S) -> Self
-    where
-        S: AsRef<OsStr>,
-    {
-        self.0.arg("--file").arg(file.as_ref());
-        self
-    }
+impl<N, F, E, P, A> IntoCommand for DockerComposeCmd<N, F, E, P, A>
+where
+    N: NameOpt,
+    F: ProjectFileOpt,
+    E: EnvFileOpt,
+    P: ProgressOpt,
+    A: AnsiOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
 
-    /// Specify multiple compose files.
-    ///
-    /// Files will be applied in the order they're specified, with later files overriding
-    /// and adding to their predecessors.
-    ///
-    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
-    /// for more information about the `--file` option.
-    pub fn with_files<I, S>(mut self, files: I) -> Self
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
-    {
-        for file in files {
-            self.0.arg("--file").arg(file.as_ref());
+        // Add the `compose` subcommand
+        cmd.arg("compose");
+
+        // --project-name <name>
+        if let Some(name) = self.name_opt.into_value() {
+            cmd.arg("--project-name").arg(name);
         }
-        self
-    }
 
-    /// Specify an alternate environment file.
-    ///
-    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
-    /// for more information about the `--env-file` option.
-    pub fn with_env_file<S>(mut self, env_file: S) -> Self
-    where
-        S: AsRef<OsStr>,
-    {
-        self.0.arg("--env-file").arg(env_file.as_ref());
-        self
-    }
-}
+        // --file <path>
+        if let Some(file) = self.project_file_opt.into_value() {
+            cmd.arg("--file").arg(file.as_os_str());
+        }
 
-impl<N, P> DockerComposeCmd<N, P, AnsiAuto> {
-    /// Always print ANSI control characters.
-    ///
-    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
-    /// for more information about the `--ansi` option.
-    pub fn with_ansi_always(mut self) -> DockerComposeCmd<N, P, AnsiAlways> {
-        self.0.arg("--ansi").arg("always");
-        DockerComposeCmd(self.0, PhantomData)
-    }
+        // --env-file <path>
+        if let Some(env_file) = self.env_file_opt.into_value() {
+            cmd.arg("--env-file").arg(env_file.as_os_str());
+        }
 
-    /// Never print ANSI control characters.
-    ///
-    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
-    /// for more information about the `--ansi` option.
-    pub fn with_ansi_never(mut self) -> DockerComposeCmd<N, P, AnsiNever> {
-        self.0.arg("--ansi").arg("never");
-        DockerComposeCmd(self.0, PhantomData)
+        // --progress <type>
+        if let Some(progress) = self.progress_opt.into_value() {
+            cmd.arg("--progress").arg(progress.to_string());
+        }
+
+        // --ansi <type>
+        if let Some(ansi) = self.ansi_opt.into_value() {
+            cmd.arg("--ansi").arg(ansi.to_string());
+        }
+
+        cmd
     }
 }
 
-impl<P, A> DockerComposeCmd<NoProjectName, P, A> {
+impl<F, E, P, A> DockerComposeCmd<NameNotSet, F, E, P, A> {
     /// Specify a project name for the Docker Compose deployment.
     ///
     /// The project name is used as a prefix for container names and creates an isolated
@@ -127,464 +135,366 @@ impl<P, A> DockerComposeCmd<NoProjectName, P, A> {
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/#use--p-to-specify-a-project-name)
     /// for more information about the `--project-name` option.
-    pub fn with_project_name<S>(mut self, name: S) -> DockerComposeCmd<WithProjectName, P, A>
+    pub fn with_project_name<S>(self, name: S) -> DockerComposeCmd<NameSet, F, E, P, A>
     where
         S: AsRef<str>,
     {
-        self.0.arg("--project-name").arg(name.as_ref());
-        DockerComposeCmd(self.0, PhantomData)
+        let name = name.as_ref().to_string();
+
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: NameSet(name),
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: self.progress_opt,
+            ansi_opt: self.ansi_opt,
+        }
     }
 }
 
-impl<N, A> DockerComposeCmd<N, ProgressAuto, A> {
+impl<N, E, P, A> DockerComposeCmd<N, ProjectFileNotSet, E, P, A> {
+    /// Specify an alternate compose file.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
+    /// for more information about the `--file` option.
+    pub fn with_file<S>(self, file: S) -> DockerComposeCmd<N, ProjectFileSet, E, P, A>
+    where
+        S: AsRef<OsStr>,
+    {
+        let file = PathBuf::from(&file).into_boxed_path();
+
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: ProjectFileSet(file),
+            env_file_opt: self.env_file_opt,
+            progress_opt: self.progress_opt,
+            ansi_opt: self.ansi_opt,
+        }
+    }
+}
+
+impl<N, F, P, A> DockerComposeCmd<N, F, EnvFileNotSet, P, A> {
+    /// Specify an alternate environment file.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/overview/)
+    /// for more information about the `--env-file` option.
+    pub fn with_env_file<T>(self, env_file: T) -> DockerComposeCmd<N, F, EnvFileSet, P, A>
+    where
+        T: AsRef<OsStr>,
+    {
+        let file = PathBuf::from(&env_file).into_boxed_path();
+
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: EnvFileSet(file),
+            progress_opt: self.progress_opt,
+            ansi_opt: self.ansi_opt,
+        }
+    }
+}
+
+impl<N, F, E, A> DockerComposeCmd<N, F, E, ProgressNotSet, A> {
+    /// Set the type of progress output to auto (default).
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
+    /// for more information.
+    pub fn with_auto_progress(self) -> DockerComposeCmd<N, F, E, ProgressSet, A> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: ProgressSet(Progress::Auto),
+            ansi_opt: self.ansi_opt,
+        }
+    }
+
     /// Set the type of progress output to TTY
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
     /// for more information.
-    pub fn with_tty_progress(mut self) -> DockerComposeCmd<N, ProgressTty, A> {
-        self.0.arg("--progress").arg("tty");
-        DockerComposeCmd(self.0, PhantomData)
+    pub fn with_tty_progress(self) -> DockerComposeCmd<N, F, E, ProgressSet, A> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: ProgressSet(Progress::Tty),
+            ansi_opt: self.ansi_opt,
+        }
     }
 
     /// Set the type of progress output to plain text
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
     /// for more information.
-    pub fn with_plain_progress(mut self) -> DockerComposeCmd<N, ProgressPlain, A> {
-        self.0.arg("--progress").arg("plain");
-        DockerComposeCmd(self.0, PhantomData)
+    pub fn with_plain_progress(self) -> DockerComposeCmd<N, F, E, ProgressSet, A> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: ProgressSet(Progress::Plain),
+            ansi_opt: self.ansi_opt,
+        }
     }
 
     /// Set the type of progress output to JSON
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
     /// for more information.
-    pub fn with_json_progress(mut self) -> DockerComposeCmd<N, ProgressJson, A> {
-        self.0.arg("--progress").arg("json");
-        DockerComposeCmd(self.0, PhantomData)
+    pub fn with_json_progress(self) -> DockerComposeCmd<N, F, E, ProgressSet, A> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: ProgressSet(Progress::Json),
+            ansi_opt: self.ansi_opt,
+        }
     }
 
     /// Set the type of progress output to quiet (no output)
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/#progress)
     /// for more information.
-    pub fn with_quiet_progress(mut self) -> DockerComposeCmd<N, ProgressQuiet, A> {
-        self.0.arg("--progress").arg("quiet");
-        DockerComposeCmd(self.0, PhantomData)
+    pub fn with_quiet_progress(self) -> DockerComposeCmd<N, F, E, ProgressSet, A> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: ProgressSet(Progress::Quiet),
+            ansi_opt: self.ansi_opt,
+        }
     }
 }
 
-impl<N, P, A> IntoCommand for DockerComposeCmd<N, P, A> {
-    fn into_command(self) -> tokio::process::Command {
-        self.0
+impl<N, F, E, P> DockerComposeCmd<N, F, E, P, AnsiNotSet> {
+    /// Automatically detect whether to print ANSI control characters (default).
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
+    /// for more information about the `--ansi` option.
+    pub fn with_ansi_auto(self) -> DockerComposeCmd<N, F, E, P, AnsiSet> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: self.progress_opt,
+            ansi_opt: AnsiSet(Ansi::Auto),
+        }
+    }
+
+    /// Always print ANSI control characters.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
+    /// for more information about the `--ansi` option.
+    pub fn with_ansi_always(self) -> DockerComposeCmd<N, F, E, P, AnsiSet> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: self.progress_opt,
+            ansi_opt: AnsiSet(Ansi::Always),
+        }
+    }
+
+    /// Never print ANSI control characters.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/)
+    /// for more information about the `--ansi` option.
+    pub fn with_ansi_never(self) -> DockerComposeCmd<N, F, E, P, AnsiSet> {
+        DockerComposeCmd {
+            cmd: self.cmd,
+            name_opt: self.name_opt,
+            project_file_opt: self.project_file_opt,
+            env_file_opt: self.env_file_opt,
+            progress_opt: self.progress_opt,
+            ansi_opt: AnsiSet(Ansi::Never),
+        }
     }
 }
 
-pub mod opts {
-    // Progress markers
-    pub trait ProgressOpt: _priv::Sealed {}
+// Project name markers
+#[allow(private_bounds)]
+pub trait NameOpt: IntoCmdOptValue<String> + _priv::Sealed {}
 
-    pub struct ProgressAuto;
-    impl ProgressOpt for ProgressAuto {}
-    impl _priv::Sealed for ProgressAuto {}
+pub struct NameNotSet;
 
-    pub struct ProgressTty;
-    impl ProgressOpt for ProgressTty {}
-    impl _priv::Sealed for ProgressTty {}
+impl NameOpt for NameNotSet {}
+impl _priv::Sealed for NameNotSet {}
 
-    pub struct ProgressPlain;
-    impl ProgressOpt for ProgressPlain {}
-    impl _priv::Sealed for ProgressPlain {}
-
-    pub struct ProgressJson;
-    impl ProgressOpt for ProgressJson {}
-    impl _priv::Sealed for ProgressJson {}
-
-    pub struct ProgressQuiet;
-    impl ProgressOpt for ProgressQuiet {}
-    impl _priv::Sealed for ProgressQuiet {}
-
-    // Project name markers
-    pub trait ProjectNameOpt: _priv::Sealed {}
-
-    pub struct NoProjectName;
-    impl ProjectNameOpt for NoProjectName {}
-    impl _priv::Sealed for NoProjectName {}
-
-    pub struct WithProjectName;
-    impl ProjectNameOpt for WithProjectName {}
-    impl _priv::Sealed for WithProjectName {}
-
-    // ANSI control characters markers
-    pub trait AnsiOpt: _priv::Sealed {}
-
-    pub struct AnsiAuto;
-    impl AnsiOpt for AnsiAuto {}
-    impl _priv::Sealed for AnsiAuto {}
-
-    pub struct AnsiAlways;
-    impl AnsiOpt for AnsiAlways {}
-    impl _priv::Sealed for AnsiAlways {}
-
-    pub struct AnsiNever;
-    impl AnsiOpt for AnsiNever {}
-    impl _priv::Sealed for AnsiNever {}
-
-    // Private module for sealing traits
-    #[allow(dead_code)]
-    mod _priv {
-        pub trait Sealed {}
+impl IntoCmdOptValue<String> for NameNotSet {
+    fn into_value(self) -> Option<String> {
+        None
     }
 }
 
-pub mod build {
-    use std::marker::PhantomData;
+pub struct NameSet(String);
 
-    use super::IntoCommand;
+impl NameOpt for NameSet {}
+impl _priv::Sealed for NameSet {}
 
-    pub struct DockerComposeBuildCmd<S = NoServices> {
-        cmd: tokio::process::Command,
-        _args: PhantomData<S>,
-    }
-
-    impl<S> DockerComposeBuildCmd<S>
-    where
-        S: ServicesOpt,
-    {
-        pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
-            cmd.arg("build");
-            Self {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    impl<S> IntoCommand for DockerComposeBuildCmd<S>
-    where
-        S: ServicesOpt,
-    {
-        fn into_command(self) -> tokio::process::Command {
-            self.cmd
-        }
-    }
-
-    impl DockerComposeBuildCmd<NoServices> {
-        /// Specify which services to build.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
-        /// for more information.
-        pub fn with_services<I, S>(self, services: I) -> DockerComposeBuildCmd<WithServices>
-        where
-            I: IntoIterator<Item = S>,
-            S: AsRef<str>,
-        {
-            let mut cmd = self.cmd;
-            for service in services {
-                cmd.arg(service.as_ref());
-            }
-            DockerComposeBuildCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-
-        /// Specify a single service to build.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
-        /// for more information.
-        pub fn with_service<S>(self, service: S) -> DockerComposeBuildCmd<WithServices>
-        where
-            S: AsRef<str>,
-        {
-            self.with_services([service])
-        }
-
-        /// Add a build argument in the form of `<key>=<value>`.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
-        /// for more information.
-        pub fn with_build_arg<S>(self, arg: S) -> Self
-        where
-            S: AsRef<str>,
-        {
-            let mut cmd = self.cmd;
-            cmd.arg("--build-arg").arg(arg.as_ref());
-            DockerComposeBuildCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-
-        /// Add multiple build arguments.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
-        /// for more information.
-        pub fn with_build_args<I, S>(self, args: I) -> Self
-        where
-            I: IntoIterator<Item = S>,
-            S: AsRef<str>,
-        {
-            let mut cmd = self.cmd;
-            for arg in args {
-                cmd.arg("--build-arg").arg(arg.as_ref());
-            }
-            DockerComposeBuildCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    /// Marker trait for services options.
-    pub trait ServicesOpt {}
-
-    /// Marker type for no services specified.
-    pub struct NoServices;
-    impl ServicesOpt for NoServices {}
-
-    /// Marker type for services specified.
-    pub struct WithServices;
-    impl ServicesOpt for WithServices {}
-}
-
-pub mod up {
-    use std::marker::PhantomData;
-
-    use super::IntoCommand;
-
-    pub struct DockerComposeUpCmd<D = NotDetached, B = NoBuild, S = NoServices> {
-        cmd: tokio::process::Command,
-        _args: PhantomData<(D, B, S)>,
-    }
-
-    impl<D, B, S> DockerComposeUpCmd<D, B, S>
-    where
-        D: DetachedOpt,
-        B: BuildOpt,
-        S: ServicesOpt,
-    {
-        pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
-            cmd.arg("up");
-            Self {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    impl<D, B, S> IntoCommand for DockerComposeUpCmd<D, B, S>
-    where
-        D: DetachedOpt,
-        B: BuildOpt,
-        S: ServicesOpt,
-    {
-        fn into_command(self) -> tokio::process::Command {
-            self.cmd
-        }
-    }
-
-    impl<B> DockerComposeUpCmd<NotDetached, B, NoServices>
-    where
-        B: BuildOpt,
-    {
-        /// Run containers in the background with the `--detached` flag.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
-        /// for more information.
-        pub fn with_detached(self) -> DockerComposeUpCmd<Detached, B, NoServices> {
-            let mut cmd = self.cmd;
-            cmd.arg("--detached");
-            DockerComposeUpCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    impl<D> DockerComposeUpCmd<D, NoBuild, NoServices>
-    where
-        D: DetachedOpt,
-    {
-        /// Build images before starting containers with the `--build` flag.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
-        /// for more information.
-        pub fn with_build(self) -> DockerComposeUpCmd<D, WithBuild, NoServices> {
-            let mut cmd = self.cmd;
-            cmd.arg("--build");
-            DockerComposeUpCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    impl<D, B> DockerComposeUpCmd<D, B, NoServices>
-    where
-        D: DetachedOpt,
-        B: BuildOpt,
-    {
-        /// Specify one or more services to start.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
-        /// for more information.
-        pub fn with_services<I, S>(self, services: I) -> DockerComposeUpCmd<D, B, WithServices>
-        where
-            I: IntoIterator<Item = S>,
-            S: AsRef<str>,
-        {
-            let mut cmd = self.cmd;
-            for service in services {
-                cmd.arg(service.as_ref());
-            }
-            DockerComposeUpCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-
-        /// Specify a single service to include.
-        ///
-        /// This is a convenience method for `with_services([service])`.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
-        /// for more information.
-        pub fn with_service<S>(self, service: S) -> DockerComposeUpCmd<D, B, WithServices>
-        where
-            S: AsRef<str>,
-        {
-            self.with_services([service])
-        }
-    }
-
-    /// A trait that represents the detached option for the `docker compose up` command.
-    pub trait DetachedOpt: _priv::Sealed {}
-
-    pub struct NotDetached;
-
-    impl DetachedOpt for NotDetached {}
-    impl _priv::Sealed for NotDetached {}
-
-    pub struct Detached;
-
-    impl DetachedOpt for Detached {}
-    impl _priv::Sealed for Detached {}
-
-    /// A trait that represents the build option for the `docker compose up` command.
-    pub trait BuildOpt: _priv::Sealed {}
-
-    pub struct NoBuild;
-
-    impl BuildOpt for NoBuild {}
-    impl _priv::Sealed for NoBuild {}
-
-    pub struct WithBuild;
-
-    impl BuildOpt for WithBuild {}
-    impl _priv::Sealed for WithBuild {}
-
-    /// A trait that represents whether services have been specified for the `docker compose up` command.
-    pub trait ServicesOpt: _priv::Sealed {}
-
-    pub struct NoServices;
-
-    impl ServicesOpt for NoServices {}
-    impl _priv::Sealed for NoServices {}
-
-    pub struct WithServices;
-
-    impl ServicesOpt for WithServices {}
-    impl _priv::Sealed for WithServices {}
-
-    #[allow(dead_code)]
-    mod _priv {
-        pub trait Sealed {}
+impl IntoCmdOptValue<String> for NameSet {
+    fn into_value(self) -> Option<String> {
+        Some(self.0)
     }
 }
 
-pub mod down {
-    use std::marker::PhantomData;
+// Project file markers
+#[allow(private_bounds)]
+pub trait ProjectFileOpt: IntoCmdOptValue<Box<Path>> + _priv::Sealed {}
 
-    use super::IntoCommand;
+pub struct ProjectFileNotSet;
 
-    pub struct DockerComposeDownCmd<V = NoVolumes> {
-        cmd: tokio::process::Command,
-        _args: PhantomData<V>,
-    }
+impl ProjectFileOpt for ProjectFileNotSet {}
+impl _priv::Sealed for ProjectFileNotSet {}
 
-    impl<V> DockerComposeDownCmd<V>
-    where
-        V: VolumesOpt,
-    {
-        pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
-            cmd.arg("down");
-            Self {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    impl<V> IntoCommand for DockerComposeDownCmd<V>
-    where
-        V: VolumesOpt,
-    {
-        fn into_command(self) -> tokio::process::Command {
-            self.cmd
-        }
-    }
-
-    impl DockerComposeDownCmd<NoVolumes> {
-        /// Remove named volumes declared in the `volumes` section of the Compose file
-        /// and anonymous volumes attached to containers.
-        ///
-        /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/down/)
-        /// for more information.
-        pub fn with_volumes(self) -> DockerComposeDownCmd<WithVolumes> {
-            let mut cmd = self.cmd;
-            cmd.arg("--volumes");
-            DockerComposeDownCmd {
-                cmd,
-                _args: PhantomData,
-            }
-        }
-    }
-
-    /// A trait that represents the volumes option for the `docker compose down` command.
-    pub trait VolumesOpt: _priv::Sealed {}
-
-    /// Marker type for no volumes option specified.
-    pub struct NoVolumes;
-    impl VolumesOpt for NoVolumes {}
-    impl _priv::Sealed for NoVolumes {}
-
-    /// Marker type for volumes option specified.
-    pub struct WithVolumes;
-    impl VolumesOpt for WithVolumes {}
-    impl _priv::Sealed for WithVolumes {}
-
-    #[allow(dead_code)]
-    mod _priv {
-        pub trait Sealed {}
+impl IntoCmdOptValue<Box<Path>> for ProjectFileNotSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        None
     }
 }
 
-pub mod pull {
-    use super::IntoCommand;
+pub struct ProjectFileSet(Box<Path>);
 
-    pub struct DockerComposePullCmd(tokio::process::Command);
+impl ProjectFileOpt for ProjectFileSet {}
+impl _priv::Sealed for ProjectFileSet {}
 
-    impl DockerComposePullCmd {
-        pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
-            cmd.arg("pull");
-            Self(cmd)
-        }
+impl IntoCmdOptValue<Box<Path>> for ProjectFileSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        Some(self.0)
     }
+}
 
-    impl IntoCommand for DockerComposePullCmd {
-        fn into_command(self) -> tokio::process::Command {
-            self.0
-        }
+// Environment file markers
+#[allow(private_bounds)]
+pub trait EnvFileOpt: IntoCmdOptValue<Box<Path>> + _priv::Sealed {}
+
+pub struct EnvFileNotSet;
+
+impl EnvFileOpt for EnvFileNotSet {}
+impl _priv::Sealed for EnvFileNotSet {}
+
+impl IntoCmdOptValue<Box<Path>> for EnvFileNotSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        None
     }
+}
+
+pub struct EnvFileSet(Box<Path>);
+
+impl EnvFileOpt for EnvFileSet {}
+impl _priv::Sealed for EnvFileSet {}
+
+impl IntoCmdOptValue<Box<Path>> for EnvFileSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        Some(self.0)
+    }
+}
+
+// Progress output type
+#[derive(Debug, Clone, Copy, Default)]
+pub enum Progress {
+    #[default]
+    Auto,
+    Tty,
+    Plain,
+    Json,
+    Quiet,
+}
+
+impl std::fmt::Display for Progress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Auto => "auto",
+            Self::Tty => "tty",
+            Self::Plain => "plain",
+            Self::Json => "json",
+            Self::Quiet => "quiet",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+// Progress output type markers
+#[allow(private_bounds)]
+pub trait ProgressOpt: IntoCmdOptValue<Progress> + _priv::Sealed {}
+
+pub struct ProgressNotSet;
+
+impl ProgressOpt for ProgressNotSet {}
+impl _priv::Sealed for ProgressNotSet {}
+
+impl IntoCmdOptValue<Progress> for ProgressNotSet {
+    fn into_value(self) -> Option<Progress> {
+        None
+    }
+}
+
+pub struct ProgressSet(Progress);
+
+impl ProgressOpt for ProgressSet {}
+impl _priv::Sealed for ProgressSet {}
+
+impl IntoCmdOptValue<Progress> for ProgressSet {
+    fn into_value(self) -> Option<Progress> {
+        Some(self.0)
+    }
+}
+
+// ANSI control characters type
+#[derive(Debug, Clone, Copy, Default)]
+pub enum Ansi {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+impl std::fmt::Display for Ansi {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Auto => "auto",
+            Self::Always => "always",
+            Self::Never => "never",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+// ANSI control characters markers
+#[allow(private_bounds)]
+pub trait AnsiOpt: IntoCmdOptValue<Ansi> + _priv::Sealed {}
+
+pub struct AnsiNotSet;
+
+impl AnsiOpt for AnsiNotSet {}
+impl _priv::Sealed for AnsiNotSet {}
+
+impl IntoCmdOptValue<Ansi> for AnsiNotSet {
+    fn into_value(self) -> Option<Ansi> {
+        None
+    }
+}
+
+pub struct AnsiSet(Ansi);
+
+impl AnsiOpt for AnsiSet {}
+impl _priv::Sealed for AnsiSet {}
+
+impl IntoCmdOptValue<Ansi> for AnsiSet {
+    fn into_value(self) -> Option<Ansi> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
 }

--- a/seahaven-docker/src/cmd/compose/build.rs
+++ b/seahaven-docker/src/cmd/compose/build.rs
@@ -1,0 +1,261 @@
+use super::{IntoCmdOptValue, IntoCommand};
+
+pub struct DockerComposeBuildCmd<D = DryRunNotSet, B = BuildArgsNotSet, S = ServicesNotSet> {
+    cmd: tokio::process::Command,
+    dry_run_opt: D,
+    build_args_opt: B,
+    services_opt: S,
+}
+
+impl DockerComposeBuildCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self {
+            cmd: cmd.into_command(),
+            dry_run_opt: DryRunNotSet,
+            build_args_opt: BuildArgsNotSet,
+            services_opt: ServicesNotSet,
+        }
+    }
+}
+
+impl<D, B, S> IntoCommand for DockerComposeBuildCmd<D, B, S>
+where
+    D: DryRunOpt,
+    B: BuildArgsOpt,
+    S: ServicesOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `build` subcommand
+        cmd.arg("build");
+
+        // --dry-run
+        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+            cmd.arg("--dry-run");
+        }
+
+        // --build-arg <key>=<value>
+        if let Some(build_args) = self.build_args_opt.into_value() {
+            for (key, value) in build_args {
+                cmd.arg("--build-arg").arg(format!("{}={}", key, value));
+            }
+        }
+
+        // [SERVICES...]
+        if let Some(services) = self.services_opt.into_value() {
+            cmd.args(services);
+        }
+        cmd
+    }
+}
+
+impl<D, S> DockerComposeBuildCmd<D, BuildArgsNotSet, S>
+where
+    D: DryRunOpt,
+    S: ServicesOpt,
+{
+    /// Add multiple build arguments.
+    ///
+    /// If the build argument key is empty, the key-value pair will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+    /// for more information.
+    pub fn with_build_args<I, K, V>(self, args: I) -> DockerComposeBuildCmd<D, BuildArgsSet, S>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let build_args = args
+            .into_iter()
+            .filter_map(|(key, value)| {
+                // Filter out empty key build arguments
+                let key = key.as_ref();
+                let value = value.as_ref();
+                if key.is_empty() {
+                    None
+                } else {
+                    Some((key.to_string(), value.to_string()))
+                }
+            })
+            .collect();
+
+        DockerComposeBuildCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            build_args_opt: BuildArgsSet(build_args),
+            services_opt: self.services_opt,
+        }
+    }
+
+    /// Add a build argument in the form of `<key>=<value>`.
+    ///
+    /// If the build argument key is empty, the key-value pair will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+    /// for more information.
+    pub fn with_build_arg<K, V>(self, key: K, value: V) -> DockerComposeBuildCmd<D, BuildArgsSet, S>
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        self.with_build_args([(key, value)])
+    }
+}
+
+impl<D, S> DockerComposeBuildCmd<D, BuildArgsSet, S>
+where
+    D: DryRunOpt,
+    S: ServicesOpt,
+{
+    pub fn with_build_arg<K, V>(self, key: K, value: V) -> DockerComposeBuildCmd<D, BuildArgsSet, S>
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let BuildArgsSet(mut args) = self.build_args_opt;
+
+        // Filter out empty key build arguments
+        if !key.as_ref().is_empty() {
+            args.push((key.as_ref().to_string(), value.as_ref().to_string()));
+        }
+
+        DockerComposeBuildCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            build_args_opt: BuildArgsSet(args),
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<D, B> DockerComposeBuildCmd<D, B, ServicesNotSet>
+where
+    D: DryRunOpt,
+    B: BuildArgsOpt,
+{
+    /// Specify which services to build.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+    /// for more information.
+    pub fn with_services<I, T>(self, services: I) -> DockerComposeBuildCmd<D, B, ServicesSet>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let services = services
+            .into_iter()
+            .filter_map(|s| {
+                // Filter out empty service names
+                let service = s.as_ref();
+                if service.is_empty() {
+                    None
+                } else {
+                    Some(service.to_string())
+                }
+            })
+            .collect();
+
+        DockerComposeBuildCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            build_args_opt: self.build_args_opt,
+            services_opt: ServicesSet(services),
+        }
+    }
+
+    /// Specify a single service to build.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/build/)
+    /// for more information.
+    pub fn with_service<T>(self, service: T) -> DockerComposeBuildCmd<D, B, ServicesSet>
+    where
+        T: AsRef<str>,
+    {
+        self.with_services([service])
+    }
+}
+
+/// Marker trait for dry-run option
+#[allow(private_bounds)]
+pub trait DryRunOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct DryRunNotSet;
+impl DryRunOpt for DryRunNotSet {}
+impl _priv::Sealed for DryRunNotSet {}
+
+impl IntoCmdOptValue<bool> for DryRunNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct DryRunSet(bool);
+impl DryRunOpt for DryRunSet {}
+impl _priv::Sealed for DryRunSet {}
+
+impl IntoCmdOptValue<bool> for DryRunSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// Marker trait for build arguments options
+#[allow(private_bounds)]
+pub trait BuildArgsOpt: IntoCmdOptValue<Vec<(String, String)>> + _priv::Sealed {}
+
+pub struct BuildArgsNotSet;
+impl BuildArgsOpt for BuildArgsNotSet {}
+impl _priv::Sealed for BuildArgsNotSet {}
+
+impl IntoCmdOptValue<Vec<(String, String)>> for BuildArgsNotSet {
+    fn into_value(self) -> Option<Vec<(String, String)>> {
+        None
+    }
+}
+
+pub struct BuildArgsSet(pub(super) Vec<(String, String)>);
+
+impl BuildArgsOpt for BuildArgsSet {}
+impl _priv::Sealed for BuildArgsSet {}
+
+impl IntoCmdOptValue<Vec<(String, String)>> for BuildArgsSet {
+    fn into_value(self) -> Option<Vec<(String, String)>> {
+        Some(self.0)
+    }
+}
+
+/// Marker trait for services options
+#[allow(private_bounds)]
+pub trait ServicesOpt: IntoCmdOptValue<Box<[String]>> + _priv::Sealed {}
+
+pub struct ServicesNotSet;
+impl ServicesOpt for ServicesNotSet {}
+impl _priv::Sealed for ServicesNotSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesNotSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        None
+    }
+}
+
+pub struct ServicesSet(Box<[String]>);
+
+impl ServicesOpt for ServicesSet {}
+impl _priv::Sealed for ServicesSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/compose/down.rs
+++ b/seahaven-docker/src/cmd/compose/down.rs
@@ -1,0 +1,81 @@
+use super::{IntoCmdOptValue, IntoCommand};
+
+pub struct DockerComposeDownCmd<V = VolumesNotSet> {
+    cmd: tokio::process::Command,
+    volumes_opt: V,
+}
+
+impl DockerComposeDownCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self {
+            cmd: cmd.into_command(),
+            volumes_opt: VolumesNotSet,
+        }
+    }
+}
+
+impl<V> IntoCommand for DockerComposeDownCmd<V>
+where
+    V: VolumesOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `down` subcommand
+        cmd.arg("down");
+
+        // --volumes
+        if matches!(self.volumes_opt.into_value(), Some(true)) {
+            cmd.arg("--volumes");
+        }
+
+        cmd
+    }
+}
+
+impl DockerComposeDownCmd<VolumesNotSet> {
+    /// Remove named volumes declared in the `volumes` section of the Compose file
+    /// and anonymous volumes attached to containers.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/down/)
+    /// for more information.
+    pub fn with_volumes(self, volumes: bool) -> DockerComposeDownCmd<VolumesSet> {
+        DockerComposeDownCmd {
+            cmd: self.cmd,
+            volumes_opt: VolumesSet(volumes),
+        }
+    }
+}
+
+/// A trait that represents the volumes option for the `docker compose down` command.
+#[allow(private_bounds)]
+pub trait VolumesOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+/// Marker type for no volumes option specified.
+pub struct VolumesNotSet;
+
+impl VolumesOpt for VolumesNotSet {}
+impl _priv::Sealed for VolumesNotSet {}
+
+impl IntoCmdOptValue<bool> for VolumesNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+/// Marker type for volumes option specified.
+pub struct VolumesSet(bool);
+
+impl VolumesOpt for VolumesSet {}
+impl _priv::Sealed for VolumesSet {}
+
+impl IntoCmdOptValue<bool> for VolumesSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/compose/pull.rs
+++ b/seahaven-docker/src/cmd/compose/pull.rs
@@ -1,0 +1,20 @@
+use super::IntoCommand;
+
+pub struct DockerComposePullCmd(tokio::process::Command);
+
+impl DockerComposePullCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self(cmd.into_command())
+    }
+}
+
+impl IntoCommand for DockerComposePullCmd {
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.0;
+
+        // Add the `pull` subcommand
+        cmd.arg("pull");
+
+        cmd
+    }
+}

--- a/seahaven-docker/src/cmd/compose/up.rs
+++ b/seahaven-docker/src/cmd/compose/up.rs
@@ -1,0 +1,222 @@
+use super::{IntoCmdOptValue, IntoCommand};
+
+pub struct DockerComposeUpCmd<D = DetachedNotSet, B = BuildNotSet, S = ServicesNotSet> {
+    cmd: tokio::process::Command,
+    detached_opt: D,
+    build_opt: B,
+    services_opt: S,
+}
+
+impl DockerComposeUpCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> DockerComposeUpCmd {
+        DockerComposeUpCmd {
+            cmd: cmd.into_command(),
+            detached_opt: DetachedNotSet,
+            build_opt: BuildNotSet,
+            services_opt: ServicesNotSet,
+        }
+    }
+}
+
+impl<D, B, S> IntoCommand for DockerComposeUpCmd<D, B, S>
+where
+    D: DetachedOpt,
+    B: BuildOpt,
+    S: ServicesOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `up` subcommand
+        cmd.arg("up");
+
+        // --build
+        if matches!(self.build_opt.into_value(), Some(true)) {
+            cmd.arg("--build");
+        }
+
+        // --detached
+        if matches!(self.detached_opt.into_value(), Some(true)) {
+            cmd.arg("--detached");
+        }
+
+        // [SERVICES...]
+        if let Some(services) = self.services_opt.into_value() {
+            cmd.args(services);
+        }
+
+        cmd
+    }
+}
+
+impl<B, S> DockerComposeUpCmd<DetachedNotSet, B, S>
+where
+    B: BuildOpt,
+    S: ServicesOpt,
+{
+    /// Run containers in the background with the `--detached` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+    /// for more information.
+    pub fn with_detached(self, detached: bool) -> DockerComposeUpCmd<DetachedSet, B, S> {
+        DockerComposeUpCmd {
+            cmd: self.cmd,
+            detached_opt: DetachedSet(detached),
+            build_opt: self.build_opt,
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<D, S> DockerComposeUpCmd<D, BuildNotSet, S>
+where
+    D: DetachedOpt,
+    S: ServicesOpt,
+{
+    /// Build images before starting containers with the `--build` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+    /// for more information.
+    pub fn with_build(self, build: bool) -> DockerComposeUpCmd<D, BuildSet, S> {
+        DockerComposeUpCmd {
+            cmd: self.cmd,
+            detached_opt: self.detached_opt,
+            build_opt: BuildSet(build),
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<D, B> DockerComposeUpCmd<D, B, ServicesNotSet>
+where
+    D: DetachedOpt,
+    B: BuildOpt,
+{
+    /// Specify one or more services to start.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+    /// for more information.
+    pub fn with_services<I, T>(self, services: I) -> DockerComposeUpCmd<D, B, ServicesSet>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let services = services
+            .into_iter()
+            .filter_map(|s| {
+                // Filter out empty service names
+                let service = s.as_ref();
+                if service.is_empty() {
+                    None
+                } else {
+                    Some(service.to_string())
+                }
+            })
+            .collect();
+
+        DockerComposeUpCmd {
+            cmd: self.cmd,
+            detached_opt: self.detached_opt,
+            build_opt: self.build_opt,
+            services_opt: ServicesSet(services),
+        }
+    }
+
+    /// Specify a single service to include.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
+    /// for more information.
+    pub fn with_service<T>(self, service: T) -> DockerComposeUpCmd<D, B, ServicesSet>
+    where
+        T: AsRef<str>,
+    {
+        self.with_services([service])
+    }
+}
+
+/// A trait that represents the detached option for the `docker compose up` command.
+#[allow(private_bounds)]
+pub trait DetachedOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct DetachedNotSet;
+
+impl DetachedOpt for DetachedNotSet {}
+impl _priv::Sealed for DetachedNotSet {}
+
+impl IntoCmdOptValue<bool> for DetachedNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct DetachedSet(bool);
+
+impl DetachedOpt for DetachedSet {}
+impl _priv::Sealed for DetachedSet {}
+
+impl IntoCmdOptValue<bool> for DetachedSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the build option for the `docker compose up` command.
+#[allow(private_bounds)]
+pub trait BuildOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct BuildNotSet;
+
+impl BuildOpt for BuildNotSet {}
+impl _priv::Sealed for BuildNotSet {}
+
+impl IntoCmdOptValue<bool> for BuildNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct BuildSet(bool);
+
+impl BuildOpt for BuildSet {}
+impl _priv::Sealed for BuildSet {}
+
+impl IntoCmdOptValue<bool> for BuildSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents whether services have been specified for the `docker compose up` command.
+#[allow(private_bounds)]
+pub trait ServicesOpt: IntoCmdOptValue<Box<[String]>> + _priv::Sealed {}
+
+pub struct ServicesNotSet;
+
+impl ServicesOpt for ServicesNotSet {}
+impl _priv::Sealed for ServicesNotSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesNotSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        None
+    }
+}
+
+pub struct ServicesSet(Box<[String]>);
+
+impl ServicesOpt for ServicesSet {}
+impl _priv::Sealed for ServicesSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/root.rs
+++ b/seahaven-docker/src/cmd/root.rs
@@ -44,17 +44,17 @@ impl DockerCmd {
 impl DockerCmd {
     /// Create a new `docker version` command
     pub fn version(self) -> DockerVersionCmd {
-        DockerVersionCmd::new(self.0)
+        DockerVersionCmd::new(self)
     }
 
     /// Create a new `docker system` command
     pub fn system(self) -> DockerSystemCmd {
-        DockerSystemCmd::new(self.0)
+        DockerSystemCmd::new(self)
     }
 
     /// Create a new `docker compose` command
     pub fn compose(self) -> DockerComposeCmd {
-        DockerComposeCmd::new(self.0)
+        DockerComposeCmd::new(self)
     }
 }
 

--- a/seahaven-docker/src/cmd/system.rs
+++ b/seahaven-docker/src/cmd/system.rs
@@ -5,8 +5,12 @@ pub struct DockerSystemCmd(tokio::process::Command);
 
 impl DockerSystemCmd {
     /// Create a new `docker system` command
-    pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        let mut cmd = cmd.into_command();
+
+        // Add the `system` subcommand
         cmd.arg("system");
+
         Self(cmd)
     }
 
@@ -39,8 +43,12 @@ pub mod info {
 
     impl<F> DockerSystemInfoCmd<F> {
         /// Create a new `docker system info` command
-        pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
+        pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+            let mut cmd = cmd.into_command();
+
+            // Add the `info` subcommand
             cmd.arg("info");
+
             Self {
                 cmd,
                 _format: PhantomData,
@@ -124,8 +132,12 @@ pub mod prune {
         A: AllOpt,
         F: ForceOpt,
     {
-        pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
+        pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+            let mut cmd = cmd.into_command();
+
+            // Add the `prune` subcommand
             cmd.arg("prune");
+
             Self {
                 cmd,
                 _phantom: PhantomData,

--- a/seahaven-docker/src/cmd/tests/it_compose.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose.rs
@@ -46,7 +46,7 @@ async fn run_docker_compose_down_with_volumes() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .down()
-        .with_volumes()
+        .with_volumes(true)
         .into_command();
 
     //* When
@@ -197,10 +197,10 @@ async fn run_docker_compose_with_progress_and_project_name() {
         args,
         [
             "compose",
-            "--progress",
-            "plain",
             "--project-name",
             "test-project",
+            "--progress",
+            "plain",
             "up"
         ]
     );
@@ -225,37 +225,6 @@ async fn run_docker_compose_with_file() {
     let args = parse_fixture_exe_output(&output);
 
     assert_eq!(args, ["compose", "--file", "docker-compose.prod.yml", "up"]);
-}
-
-#[tokio::test]
-async fn run_docker_compose_with_multiple_files() {
-    //* Given
-    let exe = fixture_exe();
-
-    let mut cmd = DockerCmd::with_executable(exe)
-        .compose()
-        .with_files(["docker-compose.yml", "docker-compose.override.yml"])
-        .up()
-        .into_command();
-
-    //* When
-    let res = cmd.kill_on_drop(true).output().await;
-
-    //* Then
-    let output = res.expect("Failed to run docker compose with multiple files");
-    let args = parse_fixture_exe_output(&output);
-
-    assert_eq!(
-        args,
-        [
-            "compose",
-            "--file",
-            "docker-compose.yml",
-            "--file",
-            "docker-compose.override.yml",
-            "up"
-        ]
-    );
 }
 
 #[tokio::test]
@@ -346,12 +315,12 @@ async fn run_docker_compose_with_all_options() {
         args,
         [
             "compose",
+            "--project-name",
+            "test-project",
             "--file",
             "docker-compose.prod.yml",
             "--env-file",
             ".env.prod",
-            "--project-name",
-            "test-project",
             "--progress",
             "quiet",
             "up"
@@ -454,7 +423,7 @@ async fn run_docker_compose_with_ansi_and_progress() {
 
     assert_eq!(
         args,
-        ["compose", "--ansi", "always", "--progress", "plain", "up"]
+        ["compose", "--progress", "plain", "--ansi", "always", "up"]
     );
 }
 
@@ -481,10 +450,10 @@ async fn run_docker_compose_with_ansi_and_project_name() {
         args,
         [
             "compose",
-            "--ansi",
-            "never",
             "--project-name",
             "test-project",
+            "--ansi",
+            "never",
             "up"
         ]
     );
@@ -516,16 +485,16 @@ async fn run_docker_compose_with_all_options_including_ansi() {
         args,
         [
             "compose",
+            "--project-name",
+            "test-project",
             "--file",
             "docker-compose.prod.yml",
             "--env-file",
             ".env.prod",
-            "--ansi",
-            "always",
-            "--project-name",
-            "test-project",
             "--progress",
             "quiet",
+            "--ansi",
+            "always",
             "up"
         ]
     );

--- a/seahaven-docker/src/cmd/tests/it_compose_build.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_build.rs
@@ -49,12 +49,13 @@ async fn run_docker_compose_build_with_build_arg() {
     //* Given
     let exe = fixture_exe();
 
-    let arg = "FOO=bar";
+    let build_arg_key = "FOO";
+    let build_arg_value = "bar";
 
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .build()
-        .with_build_arg(arg)
+        .with_build_arg(build_arg_key, build_arg_value)
         .into_command();
 
     //* When
@@ -72,7 +73,7 @@ async fn run_docker_compose_build_with_multiple_build_args() {
     //* Given
     let exe = fixture_exe();
 
-    let build_args = ["FOO=bar", "BAZ=qux"];
+    let build_args = [("FOO", "bar"), ("BAZ", "qux")];
 
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
@@ -106,12 +107,13 @@ async fn run_docker_compose_build_with_single_service_and_build_arg() {
     let exe = fixture_exe();
 
     let service = "api-service";
-    let arg = "NODE_ENV=production";
+    let build_arg_key = "NODE_ENV";
+    let build_arg_value = "production";
 
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .build()
-        .with_build_arg(arg)
+        .with_build_arg(build_arg_key, build_arg_value)
         .with_service(service)
         .into_command();
 
@@ -140,7 +142,7 @@ async fn run_docker_compose_build_with_multiple_services_and_build_args() {
     let exe = fixture_exe();
 
     let services = ["api-service", "web-service"];
-    let build_args = ["NODE_ENV=production", "DEBUG=false"];
+    let build_args = [("NODE_ENV", "production"), ("DEBUG", "false")];
 
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()

--- a/seahaven-docker/src/cmd/tests/it_compose_up.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_up.rs
@@ -29,7 +29,7 @@ async fn run_docker_compose_up_detached() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_detached()
+        .with_detached(true)
         .into_command();
 
     //* When
@@ -50,7 +50,7 @@ async fn run_docker_compose_up_with_build() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_build()
+        .with_build(true)
         .into_command();
 
     //* When
@@ -117,8 +117,8 @@ async fn run_docker_compose_up_detached_with_build() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_build()
-        .with_detached()
+        .with_build(true)
+        .with_detached(true)
         .into_command();
 
     //* When
@@ -141,7 +141,7 @@ async fn run_docker_compose_up_detached_with_services() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_detached()
+        .with_detached(true)
         .with_services(services)
         .into_command();
 
@@ -168,7 +168,7 @@ async fn run_docker_compose_up_with_build_and_services() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_build()
+        .with_build(true)
         .with_services(services)
         .into_command();
 
@@ -195,8 +195,8 @@ async fn run_docker_compose_up_with_all_options() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_build()
-        .with_detached()
+        .with_build(true)
+        .with_detached(true)
         .with_services(services)
         .into_command();
 
@@ -231,7 +231,7 @@ async fn run_docker_compose_up_with_build_and_single_service() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_build()
+        .with_build(true)
         .with_service(service)
         .into_command();
 
@@ -255,7 +255,7 @@ async fn run_docker_compose_up_detached_with_single_service() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_detached()
+        .with_detached(true)
         .with_service(service)
         .into_command();
 
@@ -280,8 +280,8 @@ async fn run_docker_compose_up_with_detached_build_and_single_service() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_build()
-        .with_detached()
+        .with_build(true)
+        .with_detached(true)
         .with_service(service)
         .into_command();
 

--- a/seahaven-docker/src/cmd/version.rs
+++ b/seahaven-docker/src/cmd/version.rs
@@ -10,8 +10,12 @@ pub struct DockerVersionCmd<F = NoFormatOpt> {
 
 impl<F> DockerVersionCmd<F> {
     /// Create a new `docker version` command
-    pub(crate) fn new(mut cmd: tokio::process::Command) -> Self {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        let mut cmd = cmd.into_command();
+
+        // Add the `version` subcommand
         cmd.arg("version");
+
         Self {
             cmd,
             _args: PhantomData,


### PR DESCRIPTION
- Refactored the 'up' command to simplify the construction of Docker commands by integrating conditional flags directly into the command chain.
- Removed the previous match statement for command options and replaced it with a more concise method of setting flags for detached mode, build, and services.
- Enhanced the `DockerComposeCmd` structure to support optional command arguments through new traits for better type safety and clarity.