### PR TITLE
refactor(seahaven-docker): restructure docker system cmd typestate

### DIFF
--- a/seahaven-docker/src/cmd/system.rs
+++ b/seahaven-docker/src/cmd/system.rs
@@ -1,263 +1,35 @@
+pub mod info;
+pub mod prune;
+
 use self::{info::DockerSystemInfoCmd, prune::DockerSystemPruneCmd};
-use super::common::IntoCommand;
+use super::common::{IntoCmdOptValue, IntoCommand};
 
 pub struct DockerSystemCmd(tokio::process::Command);
 
 impl DockerSystemCmd {
     /// Create a new `docker system` command
     pub(crate) fn new(cmd: impl IntoCommand) -> Self {
-        let mut cmd = cmd.into_command();
-
-        // Add the `system` subcommand
-        cmd.arg("system");
-
-        Self(cmd)
+        Self(cmd.into_command())
     }
 
     /// Create a new `docker system info` command
     pub fn info(self) -> DockerSystemInfoCmd {
-        DockerSystemInfoCmd::new(self.0)
+        DockerSystemInfoCmd::new(self)
     }
 
     /// Create a new `docker system prune` command
     pub fn prune(self) -> DockerSystemPruneCmd {
-        DockerSystemPruneCmd::new(self.0)
+        DockerSystemPruneCmd::new(self)
     }
 }
 
 impl IntoCommand for DockerSystemCmd {
     fn into_command(self) -> tokio::process::Command {
-        self.0
-    }
-}
+        let mut cmd = self.0;
 
-pub mod info {
-    use std::marker::PhantomData;
+        // Add the `system` subcommand
+        cmd.arg("system");
 
-    use super::IntoCommand;
-
-    pub struct DockerSystemInfoCmd<F = DefaultFormat> {
-        cmd: tokio::process::Command,
-        _format: PhantomData<F>,
-    }
-
-    impl<F> DockerSystemInfoCmd<F> {
-        /// Create a new `docker system info` command
-        pub(crate) fn new(cmd: impl IntoCommand) -> Self {
-            let mut cmd = cmd.into_command();
-
-            // Add the `info` subcommand
-            cmd.arg("info");
-
-            Self {
-                cmd,
-                _format: PhantomData,
-            }
-        }
-    }
-
-    impl<F> IntoCommand for DockerSystemInfoCmd<F> {
-        fn into_command(self) -> tokio::process::Command {
-            self.cmd
-        }
-    }
-
-    impl DockerSystemInfoCmd<DefaultFormat> {
-        /// Create a new `docker system info` command with the `json` format.
-        ///
-        /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_info/#options)
-        /// for more information.
-        pub fn with_json_format(self) -> DockerSystemInfoCmd<WithJsonFormat> {
-            let mut cmd = self.cmd;
-            cmd.arg("--format");
-            cmd.arg("json");
-            DockerSystemInfoCmd::<WithJsonFormat> {
-                cmd,
-                _format: std::marker::PhantomData,
-            }
-        }
-
-        /// Create a new `docker system info` command with a custom template format.
-        ///
-        /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_info/#options)
-        /// for more information.
-        pub fn with_custom_format(self, format: &str) -> DockerSystemInfoCmd<WithCustomFormat> {
-            let mut cmd = self.cmd;
-            cmd.arg("--format");
-            cmd.arg(format);
-            DockerSystemInfoCmd::<WithCustomFormat> {
-                cmd,
-                _format: std::marker::PhantomData,
-            }
-        }
-    }
-
-    /// A trait that represents a format option for the `docker system info` command.
-    pub trait FormatOpt: _priv::Sealed {}
-
-    pub struct DefaultFormat;
-
-    impl FormatOpt for DefaultFormat {}
-    impl _priv::Sealed for DefaultFormat {}
-
-    pub struct WithJsonFormat;
-
-    impl FormatOpt for WithJsonFormat {}
-    impl _priv::Sealed for WithJsonFormat {}
-
-    pub struct WithCustomFormat;
-
-    impl FormatOpt for WithCustomFormat {}
-    impl _priv::Sealed for WithCustomFormat {}
-
-    #[allow(dead_code)]
-    mod _priv {
-        pub trait Sealed {}
-    }
-}
-
-pub mod prune {
-    use std::marker::PhantomData;
-
-    use super::IntoCommand;
-
-    pub struct DockerSystemPruneCmd<V = NoVolumes, A = NotAll, F = NoForce> {
-        cmd: tokio::process::Command,
-        _phantom: PhantomData<(V, A, F)>,
-    }
-
-    impl<V, A, F> DockerSystemPruneCmd<V, A, F>
-    where
-        V: VolumesOpt,
-        A: AllOpt,
-        F: ForceOpt,
-    {
-        pub(crate) fn new(cmd: impl IntoCommand) -> Self {
-            let mut cmd = cmd.into_command();
-
-            // Add the `prune` subcommand
-            cmd.arg("prune");
-
-            Self {
-                cmd,
-                _phantom: PhantomData,
-            }
-        }
-    }
-
-    impl<V, A, F> IntoCommand for DockerSystemPruneCmd<V, A, F>
-    where
-        V: VolumesOpt,
-        A: AllOpt,
-        F: ForceOpt,
-    {
-        fn into_command(self) -> tokio::process::Command {
-            self.cmd
-        }
-    }
-
-    impl<A, F> DockerSystemPruneCmd<NoVolumes, A, F>
-    where
-        A: AllOpt,
-        F: ForceOpt,
-    {
-        /// Add the `--volumes` flag to the `docker system prune` command.
-        ///
-        /// This will remove all volumes not used by at least one container.
-        ///
-        /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_prune/#options)
-        /// for more information.
-        pub fn with_volumes(self) -> DockerSystemPruneCmd<Volumes, A, F> {
-            let mut cmd = self.cmd;
-            cmd.arg("--volumes");
-            DockerSystemPruneCmd::<Volumes, A, F> {
-                cmd,
-                _phantom: PhantomData,
-            }
-        }
-    }
-
-    impl<V, F> DockerSystemPruneCmd<V, NotAll, F>
-    where
-        V: VolumesOpt,
-        F: ForceOpt,
-    {
-        /// Removes all unused images, not just dangling ones.
-        ///
-        /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_prune/#options)
-        /// for more information.
-        pub fn with_all(self) -> DockerSystemPruneCmd<V, All, F> {
-            let mut cmd = self.cmd;
-            cmd.arg("--all");
-            DockerSystemPruneCmd::<V, All, F> {
-                cmd,
-                _phantom: PhantomData,
-            }
-        }
-    }
-
-    impl<V, A> DockerSystemPruneCmd<V, A, NoForce>
-    where
-        V: VolumesOpt,
-        A: AllOpt,
-    {
-        /// Add the `--force` flag to the `docker system prune` command.
-        ///
-        /// This will bypass the confirmation prompt.
-        ///
-        /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_prune/#options)
-        /// for more information.
-        pub fn with_force(self) -> DockerSystemPruneCmd<V, A, Force> {
-            let mut cmd = self.cmd;
-            cmd.arg("--force");
-            DockerSystemPruneCmd::<V, A, Force> {
-                cmd,
-                _phantom: PhantomData,
-            }
-        }
-    }
-
-    /// A trait that represents the volume option for the `docker system prune` command.
-    pub trait VolumesOpt: _priv::Sealed {}
-
-    pub struct NoVolumes;
-
-    impl VolumesOpt for NoVolumes {}
-    impl _priv::Sealed for NoVolumes {}
-
-    pub struct Volumes;
-
-    impl VolumesOpt for Volumes {}
-    impl _priv::Sealed for Volumes {}
-
-    /// A trait that represents the force option for the `docker system prune` command.
-    pub trait ForceOpt: _priv::Sealed {}
-
-    pub struct NoForce;
-
-    impl ForceOpt for NoForce {}
-    impl _priv::Sealed for NoForce {}
-
-    pub struct Force;
-
-    impl ForceOpt for Force {}
-    impl _priv::Sealed for Force {}
-
-    /// A trait that represents the all option for the `docker system prune` command.
-    pub trait AllOpt: _priv::Sealed {}
-
-    pub struct NotAll;
-
-    impl AllOpt for NotAll {}
-    impl _priv::Sealed for NotAll {}
-
-    pub struct All;
-
-    impl AllOpt for All {}
-    impl _priv::Sealed for All {}
-
-    #[allow(dead_code)]
-    mod _priv {
-        pub trait Sealed {}
+        cmd
     }
 }

--- a/seahaven-docker/src/cmd/system/info.rs
+++ b/seahaven-docker/src/cmd/system/info.rs
@@ -1,0 +1,107 @@
+use super::{IntoCmdOptValue, IntoCommand};
+
+pub struct DockerSystemInfoCmd<F = FormatNotSet> {
+    cmd: tokio::process::Command,
+    format_opt: F,
+}
+
+impl DockerSystemInfoCmd {
+    /// Create a new `docker system info` command
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self {
+            cmd: cmd.into_command(),
+            format_opt: FormatNotSet,
+        }
+    }
+}
+
+impl<F> IntoCommand for DockerSystemInfoCmd<F>
+where
+    F: FormatOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `info` subcommand
+        cmd.arg("info");
+
+        // --format <format>
+        if let Some(format) = self.format_opt.into_value() {
+            cmd.arg("--format").arg(format.to_string());
+        }
+
+        cmd
+    }
+}
+
+impl DockerSystemInfoCmd<FormatNotSet> {
+    /// Create a new `docker system info` command with the `json` format.
+    ///
+    /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_info/#options)
+    /// for more information.
+    pub fn with_json_format(self) -> DockerSystemInfoCmd<FormatSet> {
+        DockerSystemInfoCmd {
+            cmd: self.cmd,
+            format_opt: FormatSet(Format::Json),
+        }
+    }
+
+    /// Create a new `docker system info` command with a custom template format.
+    ///
+    /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_info/#options)
+    /// for more information.
+    pub fn with_custom_format(self, format: &str) -> DockerSystemInfoCmd<FormatSet> {
+        DockerSystemInfoCmd {
+            cmd: self.cmd,
+            format_opt: FormatSet(Format::Custom(format.to_string())),
+        }
+    }
+}
+
+/// A trait that represents a format option for the `docker system info` command.
+#[allow(private_bounds)]
+pub trait FormatOpt: IntoCmdOptValue<Format> + _priv::Sealed {}
+
+#[derive(Debug, Clone)]
+pub enum Format {
+    Json,
+    Custom(String),
+}
+
+impl std::fmt::Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Json => "json",
+            Self::Custom(s) => s.as_str(),
+        };
+
+        write!(f, "{}", s)
+    }
+}
+
+pub struct FormatNotSet;
+
+impl FormatOpt for FormatNotSet {}
+impl _priv::Sealed for FormatNotSet {}
+
+impl IntoCmdOptValue<Format> for FormatNotSet {
+    fn into_value(self) -> Option<Format> {
+        None
+    }
+}
+
+pub struct FormatSet(Format);
+
+impl FormatOpt for FormatSet {}
+impl _priv::Sealed for FormatSet {}
+
+impl IntoCmdOptValue<Format> for FormatSet {
+    fn into_value(self) -> Option<Format> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/system/prune.rs
+++ b/seahaven-docker/src/cmd/system/prune.rs
@@ -1,0 +1,194 @@
+use super::{IntoCmdOptValue, IntoCommand};
+
+pub struct DockerSystemPruneCmd<V = VolumesNotSet, A = AllNotSet, F = ForceNotSet> {
+    cmd: tokio::process::Command,
+    volumes_opt: V,
+    all_opt: A,
+    force_opt: F,
+}
+
+impl DockerSystemPruneCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self {
+            cmd: cmd.into_command(),
+            volumes_opt: VolumesNotSet,
+            all_opt: AllNotSet,
+            force_opt: ForceNotSet,
+        }
+    }
+}
+
+impl<V, A, F> IntoCommand for DockerSystemPruneCmd<V, A, F>
+where
+    V: VolumesOpt,
+    A: AllOpt,
+    F: ForceOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `prune` subcommand
+        cmd.arg("prune");
+
+        // --volumes
+        if matches!(self.volumes_opt.into_value(), Some(true)) {
+            cmd.arg("--volumes");
+        }
+
+        // --all
+        if matches!(self.all_opt.into_value(), Some(true)) {
+            cmd.arg("--all");
+        }
+
+        // --force
+        if matches!(self.force_opt.into_value(), Some(true)) {
+            cmd.arg("--force");
+        }
+
+        cmd
+    }
+}
+
+impl<A, F> DockerSystemPruneCmd<VolumesNotSet, A, F>
+where
+    A: AllOpt,
+    F: ForceOpt,
+{
+    /// Add the `--volumes` flag to the `docker system prune` command.
+    ///
+    /// This will remove all volumes not used by at least one container.
+    ///
+    /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_prune/#options)
+    /// for more information.
+    pub fn with_volumes(self, volumes: bool) -> DockerSystemPruneCmd<VolumesSet, A, F> {
+        DockerSystemPruneCmd {
+            cmd: self.cmd,
+            volumes_opt: VolumesSet(volumes),
+            all_opt: self.all_opt,
+            force_opt: self.force_opt,
+        }
+    }
+}
+
+impl<V, F> DockerSystemPruneCmd<V, AllNotSet, F>
+where
+    V: VolumesOpt,
+    F: ForceOpt,
+{
+    /// Removes all unused images, not just dangling ones.
+    ///
+    /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_prune/#options)
+    /// for more information.
+    pub fn with_all(self, all: bool) -> DockerSystemPruneCmd<V, AllSet, F> {
+        DockerSystemPruneCmd {
+            cmd: self.cmd,
+            volumes_opt: self.volumes_opt,
+            all_opt: AllSet(all),
+            force_opt: self.force_opt,
+        }
+    }
+}
+
+impl<V, A> DockerSystemPruneCmd<V, A, ForceNotSet>
+where
+    V: VolumesOpt,
+    A: AllOpt,
+{
+    /// Add the `--force` flag to the `docker system prune` command.
+    ///
+    /// This will bypass the confirmation prompt.
+    ///
+    /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/system_prune/#options)
+    /// for more information.
+    pub fn with_force(self, force: bool) -> DockerSystemPruneCmd<V, A, ForceSet> {
+        DockerSystemPruneCmd {
+            cmd: self.cmd,
+            volumes_opt: self.volumes_opt,
+            all_opt: self.all_opt,
+            force_opt: ForceSet(force),
+        }
+    }
+}
+
+/// A trait that represents the volume option for the `docker system prune` command.
+#[allow(private_bounds)]
+pub trait VolumesOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct VolumesNotSet;
+
+impl VolumesOpt for VolumesNotSet {}
+impl _priv::Sealed for VolumesNotSet {}
+
+impl IntoCmdOptValue<bool> for VolumesNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct VolumesSet(bool);
+
+impl VolumesOpt for VolumesSet {}
+impl _priv::Sealed for VolumesSet {}
+
+impl IntoCmdOptValue<bool> for VolumesSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the force option for the `docker system prune` command.
+#[allow(private_bounds)]
+pub trait ForceOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct ForceNotSet;
+
+impl ForceOpt for ForceNotSet {}
+impl _priv::Sealed for ForceNotSet {}
+
+impl IntoCmdOptValue<bool> for ForceNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct ForceSet(bool);
+
+impl ForceOpt for ForceSet {}
+impl _priv::Sealed for ForceSet {}
+
+impl IntoCmdOptValue<bool> for ForceSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the all option for the `docker system prune` command.
+#[allow(private_bounds)]
+pub trait AllOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct AllNotSet;
+
+impl AllOpt for AllNotSet {}
+impl _priv::Sealed for AllNotSet {}
+
+impl IntoCmdOptValue<bool> for AllNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct AllSet(bool);
+
+impl AllOpt for AllSet {}
+impl _priv::Sealed for AllSet {}
+
+impl IntoCmdOptValue<bool> for AllSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/tests/it_system.rs
+++ b/seahaven-docker/src/cmd/tests/it_system.rs
@@ -110,7 +110,7 @@ async fn run_docker_system_prune_with_volumes() {
     let mut cmd = DockerCmd::with_executable(exe)
         .system()
         .prune()
-        .with_volumes()
+        .with_volumes(true)
         .into_command();
 
     //* When
@@ -131,7 +131,7 @@ async fn run_docker_system_prune_with_all() {
     let mut cmd = DockerCmd::with_executable(exe)
         .system()
         .prune()
-        .with_all()
+        .with_all(true)
         .into_command();
 
     //* When
@@ -152,7 +152,7 @@ async fn run_docker_system_prune_with_force() {
     let mut cmd = DockerCmd::with_executable(exe)
         .system()
         .prune()
-        .with_force()
+        .with_force(true)
         .into_command();
 
     //* When
@@ -173,9 +173,9 @@ async fn run_docker_system_prune_with_all_options() {
     let mut cmd = DockerCmd::with_executable(exe)
         .system()
         .prune()
-        .with_volumes()
-        .with_all()
-        .with_force()
+        .with_volumes(true)
+        .with_all(true)
+        .with_force(true)
         .into_command();
 
     //* When


### PR DESCRIPTION
- Introduced new modules for `DockerSystemInfoCmd` and `DockerSystemPruneCmd` to handle the respective Docker commands.
- Enhanced the command structure to support optional flags for formatting and pruning options.
- Updated the `DockerSystemCmd` to utilize the new command modules and improved type safety for command options.
- Modified tests to reflect changes in the command usage for pruning options.