### PR TITLE
refactor(seahaven-docker): restructure docker version cmd typestate

### DIFF
--- a/seahaven-docker/src/cmd/version.rs
+++ b/seahaven-docker/src/cmd/version.rs
@@ -1,46 +1,48 @@
-use std::marker::PhantomData;
+use super::common::{IntoCmdOptValue, IntoCommand};
 
-use self::opts::{JsonFormatOpt, NoFormatOpt, WithCustomFormat};
-use super::common::IntoCommand;
-
-pub struct DockerVersionCmd<F = NoFormatOpt> {
+pub struct DockerVersionCmd<F = FormatNotSet> {
     cmd: tokio::process::Command,
-    _args: PhantomData<F>,
+    format_opt: F,
 }
 
-impl<F> DockerVersionCmd<F> {
+impl DockerVersionCmd {
     /// Create a new `docker version` command
     pub(crate) fn new(cmd: impl IntoCommand) -> Self {
-        let mut cmd = cmd.into_command();
-
-        // Add the `version` subcommand
-        cmd.arg("version");
-
         Self {
-            cmd,
-            _args: PhantomData,
+            cmd: cmd.into_command(),
+            format_opt: FormatNotSet,
         }
     }
 }
 
-impl<F> IntoCommand for DockerVersionCmd<F> {
+impl<F> IntoCommand for DockerVersionCmd<F>
+where
+    F: FormatOpt,
+{
     fn into_command(self) -> tokio::process::Command {
-        self.cmd
+        let mut cmd = self.cmd;
+
+        // Add the `version` subcommand
+        cmd.arg("version");
+
+        // --format <format>
+        if let Some(format) = self.format_opt.into_value() {
+            cmd.arg("--format").arg(format.to_string());
+        }
+
+        cmd
     }
 }
 
-impl DockerVersionCmd<NoFormatOpt> {
+impl DockerVersionCmd<FormatNotSet> {
     /// Create a new `docker version` command with the `json` format.
     ///
     /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/version/#options)
     /// for more information.
-    pub fn with_json_format(self) -> DockerVersionCmd<JsonFormatOpt> {
-        let mut cmd = self.cmd;
-        cmd.arg("--format");
-        cmd.arg("json");
+    pub fn with_json_format(self) -> DockerVersionCmd<FormatSet> {
         DockerVersionCmd {
-            cmd,
-            _args: PhantomData,
+            cmd: self.cmd,
+            format_opt: FormatSet(Format::Json),
         }
     }
 
@@ -48,38 +50,62 @@ impl DockerVersionCmd<NoFormatOpt> {
     ///
     /// See the [Docker CLI documentation](https://docs.docker.com/engine/reference/commandline/version/#options)
     /// for more information.
-    pub fn with_custom_format(self, format: &str) -> DockerVersionCmd<WithCustomFormat> {
-        let mut cmd = self.cmd;
-        cmd.arg("--format");
-        cmd.arg(format);
+    pub fn with_custom_format<T>(self, format: T) -> DockerVersionCmd<FormatSet>
+    where
+        T: Into<String>,
+    {
         DockerVersionCmd {
-            cmd,
-            _args: PhantomData,
+            cmd: self.cmd,
+            format_opt: FormatSet(Format::Custom(format.into())),
         }
     }
 }
 
-pub mod opts {
-    /// A trait that represents a format option for the `docker version` command.
-    pub trait FormatOpt: _priv::Sealed {}
+// The format option for the `docker version` command.
+#[derive(Debug, Clone)]
+pub enum Format {
+    Json,
+    Custom(String),
+}
 
-    pub struct NoFormatOpt;
+impl std::fmt::Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Json => "json",
+            Self::Custom(s) => s.as_str(),
+        };
 
-    impl FormatOpt for NoFormatOpt {}
-    impl _priv::Sealed for NoFormatOpt {}
-
-    pub struct JsonFormatOpt;
-
-    impl FormatOpt for JsonFormatOpt {}
-    impl _priv::Sealed for JsonFormatOpt {}
-
-    pub struct WithCustomFormat;
-
-    impl FormatOpt for WithCustomFormat {}
-    impl _priv::Sealed for WithCustomFormat {}
-
-    #[allow(dead_code)]
-    mod _priv {
-        pub trait Sealed {}
+        write!(f, "{}", s)
     }
+}
+
+/// A trait that represents a format option for the `docker version` command.
+#[allow(private_bounds)]
+pub trait FormatOpt: IntoCmdOptValue<Format> + _priv::Sealed {}
+
+pub struct FormatNotSet;
+
+impl FormatOpt for FormatNotSet {}
+impl _priv::Sealed for FormatNotSet {}
+
+impl IntoCmdOptValue<Format> for FormatNotSet {
+    fn into_value(self) -> Option<Format> {
+        None
+    }
+}
+
+pub struct FormatSet(Format);
+
+impl FormatOpt for FormatSet {}
+impl _priv::Sealed for FormatSet {}
+
+impl IntoCmdOptValue<Format> for FormatSet {
+    fn into_value(self) -> Option<Format> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
 }


### PR DESCRIPTION
- Updated the `DockerVersionCmd` structure to support format options through a new typestate system.
- Introduced `FormatSet` and `FormatNotSet` to manage command formatting more effectively.
- Refactored methods for setting JSON and custom formats, improving type safety and clarity in command construction.
- Adjusted the `into_command` implementation to conditionally include format arguments based on the current state.