### PR TITLE
feat(seahaven-cli): add 'down' command

### DIFF
--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -1,4 +1,5 @@
 mod build;
+mod down;
 mod pull;
 mod setup;
 mod up;
@@ -8,7 +9,13 @@ use crate::result::Result;
 /// Create and execute the DIPs CLI command line interface
 pub async fn run() -> Result<()> {
     let matches = clap::command!()
-        .subcommands([setup::cmd(), up::cmd(), pull::cmd(), build::cmd()])
+        .subcommands([
+            setup::cmd(),
+            up::cmd(),
+            pull::cmd(),
+            build::cmd(),
+            down::cmd(),
+        ])
         .infer_long_args(true)
         .infer_subcommands(true)
         .get_matches();
@@ -18,6 +25,7 @@ pub async fn run() -> Result<()> {
         Some((up::CMD, matches)) => up::run(matches).await,
         Some((pull::CMD, matches)) => pull::run(matches).await,
         Some((build::CMD, matches)) => build::run(matches).await,
+        Some((down::CMD, matches)) => down::run(matches).await,
         _ => Err(anyhow::anyhow!("No command specified").into()),
     }
 }

--- a/seahaven-cli/src/cmd/down.rs
+++ b/seahaven-cli/src/cmd/down.rs
@@ -1,0 +1,108 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+
+use crate::result::{Error, Result};
+
+/// The `down` command name
+pub(super) const CMD: &str = "down";
+
+/// Create the `down` command
+pub(super) fn cmd() -> clap::Command {
+    clap::command!(CMD)
+        .about("Stop and remove containers, networks, images, and volumes")
+        .args([
+            clap::arg!(-f --file <FILE> "The seahaven setup file")
+                .default_value("setup.yaml")
+                .value_parser(clap::value_parser!(PathBuf)),
+            clap::arg!(-v --volumes "Remove named volumes declared in the volumes section of the Compose file")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!(--dry-run "Execute command in dry run mode")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!([SERVICE] ... "The services to stop and remove")
+                .action(clap::ArgAction::Append),
+        ])
+}
+
+/// The `down` command implementation
+pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    let setup_file = matches
+        .get_one::<PathBuf>("file")
+        .expect("Failed to get setup file");
+    if !setup_file.exists() {
+        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
+    }
+
+    // Load the setup file
+    let setup_file = File::open(setup_file)
+        .map(BufReader::new)
+        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
+    let (env, content) = seahaven_file::from_reader(setup_file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?
+        .unpack();
+
+    // Transform the content into a compose file
+    let compose = seahaven_file::try_into_compose_file(content)
+        .map_err(|err| anyhow::anyhow!("Invalid setup file: {err}"))?;
+
+    // Create a tempfile for the env and the content
+    let temp_dir = tempfile::Builder::new()
+        .prefix("seahaven-")
+        .tempdir()
+        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
+    let temp_dir_path = temp_dir.path();
+    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
+
+    let env_file_path = temp_dir_path.join(".env");
+    let content_file_path = temp_dir_path.join("docker-compose.yaml");
+
+    {
+        let env_file = File::create(&env_file_path)
+            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
+
+        let content_file = File::create(&content_file_path)
+            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
+
+        tracing::debug!("Writing .env file: {}", env_file_path.display());
+        seahaven_file::serde_envfile::to_writer(env_file, &env)
+            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
+
+        tracing::debug!(
+            "Writing docker-compose.yaml file: {}",
+            content_file_path.display()
+        );
+        seahaven_file::seahaven_compose_file::ser::to_writer(content_file, &compose)
+            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
+    }
+
+    let mut command = DockerCmd::new()
+        .compose()
+        .with_file(content_file_path)
+        .with_env_file(env_file_path)
+        .with_plain_progress()
+        .down()
+        .with_volumes(matches.get_flag("volumes"))
+        .with_dry_run(matches.get_flag("dry-run"))
+        .with_services(matches.get_many::<String>("SERVICE").unwrap_or_default())
+        .into_command();
+
+    tracing::debug!("Running command: {:?}", command.as_std());
+
+    let mut child = command
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("Failed to spawn docker compose down command: {err}"))?;
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to wait for docker compose down command: {err}"))?;
+    if !status.success() {
+        return Err(
+            Error::new(anyhow::anyhow!("Docker compose down command failed"))
+                .with_code(status.code().unwrap_or(1)),
+        );
+    }
+
+    Ok(())
+}

--- a/seahaven-docker/src/cmd/compose/down.rs
+++ b/seahaven-docker/src/cmd/compose/down.rs
@@ -1,8 +1,10 @@
 use super::{IntoCmdOptValue, IntoCommand};
 
-pub struct DockerComposeDownCmd<V = VolumesNotSet> {
+pub struct DockerComposeDownCmd<V = VolumesNotSet, DR = DryRunNotSet, S = ServicesNotSet> {
     cmd: tokio::process::Command,
     volumes_opt: V,
+    dry_run_opt: DR,
+    services_opt: S,
 }
 
 impl DockerComposeDownCmd {
@@ -10,13 +12,17 @@ impl DockerComposeDownCmd {
         Self {
             cmd: cmd.into_command(),
             volumes_opt: VolumesNotSet,
+            dry_run_opt: DryRunNotSet,
+            services_opt: ServicesNotSet,
         }
     }
 }
 
-impl<V> IntoCommand for DockerComposeDownCmd<V>
+impl<V, DR, S> IntoCommand for DockerComposeDownCmd<V, DR, S>
 where
     V: VolumesOpt,
+    DR: DryRunOpt,
+    S: ServicesOpt,
 {
     fn into_command(self) -> tokio::process::Command {
         let mut cmd = self.cmd;
@@ -29,20 +35,78 @@ where
             cmd.arg("--volumes");
         }
 
+        // --dry-run
+        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+            cmd.arg("--dry-run");
+        }
+
+        // Add services if specified
+        if let Some(services) = self.services_opt.into_value() {
+            cmd.args(services);
+        }
+
         cmd
     }
 }
 
-impl DockerComposeDownCmd<VolumesNotSet> {
+impl<DR, S> DockerComposeDownCmd<VolumesNotSet, DR, S>
+where
+    DR: DryRunOpt,
+    S: ServicesOpt,
+{
     /// Remove named volumes declared in the `volumes` section of the Compose file
     /// and anonymous volumes attached to containers.
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/down/)
     /// for more information.
-    pub fn with_volumes(self, volumes: bool) -> DockerComposeDownCmd<VolumesSet> {
+    pub fn with_volumes(self, volumes: bool) -> DockerComposeDownCmd<VolumesSet, DR, S> {
         DockerComposeDownCmd {
             cmd: self.cmd,
             volumes_opt: VolumesSet(volumes),
+            dry_run_opt: self.dry_run_opt,
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<V, S> DockerComposeDownCmd<V, DryRunNotSet, S>
+where
+    V: VolumesOpt,
+    S: ServicesOpt,
+{
+    /// Run the command in dry run mode with the `--dry-run` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/down/)
+    /// for more information.
+    pub fn with_dry_run(self, dry_run: bool) -> DockerComposeDownCmd<V, DryRunSet, S> {
+        DockerComposeDownCmd {
+            cmd: self.cmd,
+            volumes_opt: self.volumes_opt,
+            dry_run_opt: DryRunSet(dry_run),
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<V, DR> DockerComposeDownCmd<V, DR, ServicesNotSet>
+where
+    V: VolumesOpt,
+    DR: DryRunOpt,
+{
+    /// Specify the services to stop and remove.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/down/)
+    /// for more information.
+    pub fn with_services<I>(self, services: I) -> DockerComposeDownCmd<V, DR, ServicesSet>
+    where
+        I: IntoIterator,
+        I::Item: Into<String>,
+    {
+        DockerComposeDownCmd {
+            cmd: self.cmd,
+            volumes_opt: self.volumes_opt,
+            dry_run_opt: self.dry_run_opt,
+            services_opt: ServicesSet(services.into_iter().map(Into::into).collect()),
         }
     }
 }
@@ -71,6 +135,62 @@ impl _priv::Sealed for VolumesSet {}
 
 impl IntoCmdOptValue<bool> for VolumesSet {
     fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the dry run option for the `docker compose down` command.
+#[allow(private_bounds)]
+pub trait DryRunOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+/// Marker type for no dry run option specified.
+pub struct DryRunNotSet;
+
+impl DryRunOpt for DryRunNotSet {}
+impl _priv::Sealed for DryRunNotSet {}
+
+impl IntoCmdOptValue<bool> for DryRunNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+/// Marker type for dry run option specified.
+pub struct DryRunSet(bool);
+
+impl DryRunOpt for DryRunSet {}
+impl _priv::Sealed for DryRunSet {}
+
+impl IntoCmdOptValue<bool> for DryRunSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the services option for the `docker compose down` command.
+#[allow(private_bounds)]
+pub trait ServicesOpt: IntoCmdOptValue<Vec<String>> + _priv::Sealed {}
+
+/// Marker type for no services option specified.
+pub struct ServicesNotSet;
+
+impl ServicesOpt for ServicesNotSet {}
+impl _priv::Sealed for ServicesNotSet {}
+
+impl IntoCmdOptValue<Vec<String>> for ServicesNotSet {
+    fn into_value(self) -> Option<Vec<String>> {
+        None
+    }
+}
+
+/// Marker type for services option specified.
+pub struct ServicesSet(Vec<String>);
+
+impl ServicesOpt for ServicesSet {}
+impl _priv::Sealed for ServicesSet {}
+
+impl IntoCmdOptValue<Vec<String>> for ServicesSet {
+    fn into_value(self) -> Option<Vec<String>> {
         Some(self.0)
     }
 }

--- a/seahaven-docker/src/cmd/tests/it_compose_down.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_down.rs
@@ -41,3 +41,166 @@ async fn run_docker_compose_down_with_volumes() {
 
     assert_eq!(args, ["compose", "down", "--volumes"]);
 }
+
+#[tokio::test]
+async fn run_docker_compose_down_with_dry_run() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .down()
+        .with_dry_run(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with dry-run");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "down", "--dry-run"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_down_with_single_service() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .down()
+        .with_services(["api-service"])
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with single service");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "down", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_down_with_multiple_services() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service", "db-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .down()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with multiple services");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "down",
+            "api-service",
+            "web-service",
+            "db-service"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_down_with_services_and_volumes() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .down()
+        .with_services(services)
+        .with_volumes(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with services and volumes");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        ["compose", "down", "--volumes", "api-service", "web-service"]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_down_with_services_and_dry_run() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .down()
+        .with_services(services)
+        .with_dry_run(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with services and dry run");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        ["compose", "down", "--dry-run", "api-service", "web-service"]
+    );
+}
+
+#[tokio::test]
+async fn run_docker_compose_down_with_all_options() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .down()
+        .with_services(services)
+        .with_volumes(true)
+        .with_dry_run(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose down with all options");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "down",
+            "--volumes",
+            "--dry-run",
+            "api-service",
+            "web-service"
+        ]
+    );
+}


### PR DESCRIPTION
- Introduced a new `down` command to the CLI for stopping and removing Docker containers, networks, images, and volumes.
- Updated the command structure to include the `down` command alongside existing commands.
- Enhanced the `run` function to handle the new `down` command and its arguments, including support for a dry run mode and service specification.