### PR TITLE
chore: add Justfile for project tasks management

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,25 @@
+# Seahaven Project Justfile
+#
+# This justfile provides commands for managing the Seahaven project, a workspace management
+# tool for blockchain development environments. Seahaven helps streamline the setup and
+# management of blockchain development workspaces with Docker-based components.
+
+# Default target - displays available commands and their descriptions
+default:
+    @just --list
+
+# Run all project tests
+test:
+    cargo nextest run
+
+# Format all Rust code (requires nightly toolchain)
+fmt:
+    cargo +nightly fmt --all
+
+# Check code for common issues using clippy
+clippy:
+    cargo clippy --tests -- -D warnings --force-warn dead_code --force-warn deprecated
+
+# Clean build artifacts and temporary files
+clean:
+    cargo clean


### PR DESCRIPTION
- Introduced a Justfile to streamline commands for managing the Seahaven project.
- Added commands for testing, formatting, linting, and cleaning Rust code.
- Default target displays available commands and their descriptions.