### PR TITLE
feat(seahaven-just): add justfile and envfile options

### DIFF
--- a/seahaven-just/src/cmd/common.rs
+++ b/seahaven-just/src/cmd/common.rs
@@ -11,3 +11,11 @@ impl IntoCommand for tokio::process::Command {
         self
     }
 }
+
+/// A trait that converts a command option into its value.
+///
+/// This trait is used to convert command options into their values when building the command.
+pub trait IntoCmdOptValue<T> {
+    /// Convert the option into its value.
+    fn into_value(self) -> Option<T>;
+}

--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -1,9 +1,20 @@
-use std::borrow::Borrow;
+use std::{
+    borrow::Borrow,
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
-use super::{common::IntoCommand, version::JustVersionCmd};
+use super::{
+    common::{IntoCmdOptValue, IntoCommand},
+    version::JustVersionCmd,
+};
 use crate::exe::{Executable, resolve_cli_executable};
 
-pub struct JustCmd(tokio::process::Command);
+pub struct JustCmd<F = JustfileNotSet, E = EnvFileNotSet> {
+    cmd: tokio::process::Command,
+    justfile_opt: F,
+    env_file_opt: E,
+}
 
 impl Default for JustCmd {
     /// Create a new just command
@@ -34,7 +45,11 @@ impl JustCmd {
     where
         B: Borrow<Executable>,
     {
-        Self(tokio::process::Command::new(exe.borrow()))
+        Self {
+            cmd: tokio::process::Command::new(exe.borrow()),
+            justfile_opt: JustfileNotSet,
+            env_file_opt: EnvFileNotSet,
+        }
     }
 }
 
@@ -45,8 +60,119 @@ impl JustCmd {
     }
 }
 
-impl IntoCommand for JustCmd {
+impl<F, E> IntoCommand for JustCmd<F, E>
+where
+    F: JustfileOpt,
+    E: EnvFileOpt,
+{
     fn into_command(self) -> tokio::process::Command {
-        self.0
+        let mut cmd = self.cmd;
+
+        // --justfile <path>
+        if let Some(justfile) = self.justfile_opt.into_value() {
+            cmd.arg("--justfile").arg(justfile.as_ref());
+        }
+
+        // --dotenv-path <path>
+        if let Some(env_file) = self.env_file_opt.into_value() {
+            cmd.arg("--dotenv-path").arg(env_file.as_ref());
+        }
+
+        cmd
     }
+}
+
+impl<E> JustCmd<JustfileNotSet, E> {
+    /// Specify an alternate justfile.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just)
+    /// for more information about the `--justfile` option.
+    pub fn with_justfile<P>(self, file: P) -> JustCmd<JustfileSet, E>
+    where
+        P: AsRef<OsStr>,
+    {
+        let file = PathBuf::from(&file).into_boxed_path();
+
+        JustCmd {
+            cmd: self.cmd,
+            justfile_opt: JustfileSet(file),
+            env_file_opt: self.env_file_opt,
+        }
+    }
+}
+
+impl<F> JustCmd<F, EnvFileNotSet> {
+    /// Specify an alternate environment file.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just)
+    /// for more information about the `--dotenv-path` option.
+    pub fn with_env_file<P>(self, file: P) -> JustCmd<F, EnvFileSet>
+    where
+        P: AsRef<OsStr>,
+    {
+        let file = PathBuf::from(&file).into_boxed_path();
+
+        JustCmd {
+            cmd: self.cmd,
+            justfile_opt: self.justfile_opt,
+            env_file_opt: EnvFileSet(file),
+        }
+    }
+}
+
+// Justfile option markers
+#[allow(private_bounds)]
+pub trait JustfileOpt: IntoCmdOptValue<Box<Path>> + _priv::Sealed {}
+
+pub struct JustfileNotSet;
+
+impl JustfileOpt for JustfileNotSet {}
+impl _priv::Sealed for JustfileNotSet {}
+
+impl IntoCmdOptValue<Box<Path>> for JustfileNotSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        None
+    }
+}
+
+pub struct JustfileSet(Box<Path>);
+
+impl JustfileOpt for JustfileSet {}
+impl _priv::Sealed for JustfileSet {}
+
+impl IntoCmdOptValue<Box<Path>> for JustfileSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        Some(self.0)
+    }
+}
+
+// Environment file markers
+#[allow(private_bounds)]
+pub trait EnvFileOpt: IntoCmdOptValue<Box<Path>> + _priv::Sealed {}
+
+pub struct EnvFileNotSet;
+
+impl EnvFileOpt for EnvFileNotSet {}
+impl _priv::Sealed for EnvFileNotSet {}
+
+impl IntoCmdOptValue<Box<Path>> for EnvFileNotSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        None
+    }
+}
+
+pub struct EnvFileSet(Box<Path>);
+
+impl EnvFileOpt for EnvFileSet {}
+impl _priv::Sealed for EnvFileSet {}
+
+impl IntoCmdOptValue<Box<Path>> for EnvFileSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
 }

--- a/seahaven-just/src/cmd/tests/it_root.rs
+++ b/seahaven-just/src/cmd/tests/it_root.rs
@@ -17,3 +17,43 @@ async fn run_just_root() {
 
     assert_eq!(args, ["<no-args>"]);
 }
+
+#[tokio::test]
+async fn run_just_root_with_justfile() {
+    //* Given
+    let exe = fixture_exe();
+    let justfile = "test/justfile";
+
+    let mut cmd = JustCmd::with_executable(exe)
+        .with_justfile(justfile)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just root command with justfile");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--justfile", "test/justfile"]);
+}
+
+#[tokio::test]
+async fn run_just_root_with_env_file() {
+    //* Given
+    let exe = fixture_exe();
+    let env_file = "test/.env";
+
+    let mut cmd = JustCmd::with_executable(exe)
+        .with_env_file(env_file)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just root command with env file");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--dotenv-path", "test/.env"]);
+}


### PR DESCRIPTION
- Added a new trait `IntoCmdOptValue` for converting command options into their values.
- Updated `JustCmd` to support optional justfile and environment file parameters.
- Implemented methods `with_justfile` and `with_env_file` for specifying these options.
- Added tests to verify functionality for running commands with justfile and env file arguments.