### PR TITLE
feat(seahaven-just): add just `dump` command

### DIFF
--- a/seahaven-just/src/cmd.rs
+++ b/seahaven-just/src/cmd.rs
@@ -17,15 +17,19 @@
 //! - `just --version`
 
 mod common;
+pub mod dump;
 mod root;
 pub mod version;
 
 pub use common::IntoCommand;
-pub use root::JustCmd;
+pub use root::{
+    EnvFileNotSet, EnvFileOpt, EnvFileSet, JustCmd, JustfileNotSet, JustfileOpt, JustfileSet,
+};
 
 #[cfg(test)]
 mod tests {
     mod common;
+    mod it_dump;
     mod it_root;
     mod it_version;
 }

--- a/seahaven-just/src/cmd/dump.rs
+++ b/seahaven-just/src/cmd/dump.rs
@@ -1,0 +1,110 @@
+use super::common::{IntoCmdOptValue, IntoCommand};
+
+pub struct JustDumpCmd<F = DumpFormatNotSet> {
+    cmd: tokio::process::Command,
+    format_opt: F,
+}
+
+impl JustDumpCmd {
+    /// Create a new `just --dump` command
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self {
+            cmd: cmd.into_command(),
+            format_opt: DumpFormatNotSet,
+        }
+    }
+}
+
+impl<F> IntoCommand for JustDumpCmd<F>
+where
+    F: DumpFormatOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `dump` subcommand
+        cmd.arg("--dump");
+
+        // --format <format>
+        if let Some(format) = self.format_opt.into_value() {
+            cmd.arg("--format").arg(format.as_str());
+        }
+
+        cmd
+    }
+}
+
+impl JustDumpCmd<DumpFormatNotSet> {
+    /// Configures the command to use the "just" format for dumping.
+    /// This format outputs the justfile in its original format.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just) for more information.
+    pub fn with_dump_just_format(self) -> JustDumpCmd<DumpFormatSet> {
+        JustDumpCmd {
+            cmd: self.cmd,
+            format_opt: DumpFormatSet(DumpFormat::Just),
+        }
+    }
+
+    /// Configures the command to use the "json" format for dumping.
+    /// This format outputs the justfile as a JSON object.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just) for more information.
+    pub fn with_dump_json_format(self) -> JustDumpCmd<DumpFormatSet> {
+        JustDumpCmd {
+            cmd: self.cmd,
+            format_opt: DumpFormatSet(DumpFormat::Json),
+        }
+    }
+}
+
+/// Available formats for the `just --dump` command output.
+///
+/// See the [Just documentation](https://github.com/casey/just#dump) for more information.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DumpFormat {
+    /// Output the justfile in its original format
+    Just,
+    /// Output the justfile as a JSON object
+    Json,
+}
+
+impl DumpFormat {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Just => "just",
+            Self::Json => "json",
+        }
+    }
+}
+
+// Dump format option markers
+#[allow(private_bounds)]
+pub trait DumpFormatOpt: IntoCmdOptValue<DumpFormat> + _priv::Sealed {}
+
+pub struct DumpFormatNotSet;
+
+impl DumpFormatOpt for DumpFormatNotSet {}
+impl _priv::Sealed for DumpFormatNotSet {}
+
+impl IntoCmdOptValue<DumpFormat> for DumpFormatNotSet {
+    fn into_value(self) -> Option<DumpFormat> {
+        None
+    }
+}
+
+pub struct DumpFormatSet(DumpFormat);
+
+impl DumpFormatOpt for DumpFormatSet {}
+impl _priv::Sealed for DumpFormatSet {}
+
+impl IntoCmdOptValue<DumpFormat> for DumpFormatSet {
+    fn into_value(self) -> Option<DumpFormat> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -6,6 +6,7 @@ use std::{
 
 use super::{
     common::{IntoCmdOptValue, IntoCommand},
+    dump::JustDumpCmd,
     version::JustVersionCmd,
 };
 use crate::exe::{Executable, resolve_cli_executable};
@@ -54,9 +55,14 @@ impl JustCmd {
 }
 
 impl JustCmd {
-    /// Create a new `just version` command
+    /// Create a new `just --version` command
     pub fn version(self) -> JustVersionCmd {
         JustVersionCmd::new(self)
+    }
+
+    /// Create a new `just --dump` command
+    pub fn dump(self) -> JustDumpCmd {
+        JustDumpCmd::new(self)
     }
 }
 

--- a/seahaven-just/src/cmd/tests/it_dump.rs
+++ b/seahaven-just/src/cmd/tests/it_dump.rs
@@ -1,0 +1,59 @@
+use super::common::{fixture_exe, parse_fixture_exe_output};
+use crate::cmd::{IntoCommand, JustCmd};
+
+#[tokio::test]
+async fn run_just_dump() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = JustCmd::with_executable(exe).dump().into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just dump command");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--dump"]);
+}
+
+#[tokio::test]
+async fn run_just_dump_with_just_format() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = JustCmd::with_executable(exe)
+        .dump()
+        .with_dump_just_format()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just dump command with just format option");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--dump", "--format", "just"]);
+}
+
+#[tokio::test]
+async fn run_just_dump_with_json_format() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = JustCmd::with_executable(exe)
+        .dump()
+        .with_dump_json_format()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just dump command with json format option");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--dump", "--format", "json"]);
+}


### PR DESCRIPTION
- Added a new `JustDumpCmd` struct to handle the `just --dump` command.
- Implemented methods for configuring output formats: `with_dump_just_format` and `with_dump_json_format`.
- Updated `JustCmd` to include a method for creating a `JustDumpCmd`.
- Added tests to verify the correct command construction and output format handling.