### PR TITLE
feat(seahaven-just): add `working-directory` and arguments support to just command

### DIFF
--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -11,11 +11,19 @@ use super::{
 };
 use crate::exe::{Executable, resolve_cli_executable};
 
-pub struct JustCmd<F = JustfileNotSet, E = EnvFileNotSet, D = DryRunNotSet> {
+pub struct JustCmd<
+    F = JustfileNotSet,
+    E = EnvFileNotSet,
+    W = WorkdirNotSet,
+    D = DryRunNotSet,
+    A = ArgsNotSet,
+> {
     cmd: tokio::process::Command,
     justfile_opt: F,
     env_file_opt: E,
+    workdir_opt: W,
     dry_run_opt: D,
+    args_opt: A,
 }
 
 impl Default for JustCmd {
@@ -51,7 +59,9 @@ impl JustCmd {
             cmd: tokio::process::Command::new(exe.borrow()),
             justfile_opt: JustfileNotSet,
             env_file_opt: EnvFileNotSet,
+            workdir_opt: WorkdirNotSet,
             dry_run_opt: DryRunNotSet,
+            args_opt: ArgsNotSet,
         }
     }
 }
@@ -68,11 +78,13 @@ impl JustCmd {
     }
 }
 
-impl<F, E, D> IntoCommand for JustCmd<F, E, D>
+impl<F, E, W, D, A> IntoCommand for JustCmd<F, E, W, D, A>
 where
     F: JustfileOpt,
     E: EnvFileOpt,
+    W: WorkdirOpt,
     D: DryRunOpt,
+    A: ArgsOpt,
 {
     fn into_command(self) -> tokio::process::Command {
         let mut cmd = self.cmd;
@@ -87,21 +99,31 @@ where
             cmd.arg("--dotenv-path").arg(env_file.as_ref());
         }
 
+        // --working-directory <path>
+        if let Some(workdir) = self.workdir_opt.into_value() {
+            cmd.arg("--working-directory").arg(workdir.as_ref());
+        }
+
         // --dry-run
         if matches!(self.dry_run_opt.into_value(), Some(true)) {
             cmd.arg("--dry-run");
+        }
+
+        // [ARGUMENTS]...
+        if let Some(args) = self.args_opt.into_value() {
+            cmd.args(args);
         }
 
         cmd
     }
 }
 
-impl<E, D> JustCmd<JustfileNotSet, E, D> {
+impl<E, W, D, A> JustCmd<JustfileNotSet, E, W, D, A> {
     /// Specify an alternate justfile.
     ///
     /// See the [Just documentation](https://github.com/casey/just)
     /// for more information about the `--justfile` option.
-    pub fn with_justfile<P>(self, file: P) -> JustCmd<JustfileSet, E, D>
+    pub fn with_justfile<P>(self, file: P) -> JustCmd<JustfileSet, E, W, D, A>
     where
         P: AsRef<OsStr>,
     {
@@ -111,17 +133,19 @@ impl<E, D> JustCmd<JustfileNotSet, E, D> {
             cmd: self.cmd,
             justfile_opt: JustfileSet(file),
             env_file_opt: self.env_file_opt,
+            workdir_opt: self.workdir_opt,
             dry_run_opt: self.dry_run_opt,
+            args_opt: self.args_opt,
         }
     }
 }
 
-impl<F, D> JustCmd<F, EnvFileNotSet, D> {
+impl<F, W, D, A> JustCmd<F, EnvFileNotSet, W, D, A> {
     /// Specify an alternate environment file.
     ///
     /// See the [Just documentation](https://github.com/casey/just)
     /// for more information about the `--dotenv-path` option.
-    pub fn with_env_file<P>(self, file: P) -> JustCmd<F, EnvFileSet, D>
+    pub fn with_env_file<P>(self, file: P) -> JustCmd<F, EnvFileSet, W, D, A>
     where
         P: AsRef<OsStr>,
     {
@@ -131,22 +155,82 @@ impl<F, D> JustCmd<F, EnvFileNotSet, D> {
             cmd: self.cmd,
             justfile_opt: self.justfile_opt,
             env_file_opt: EnvFileSet(file),
+            workdir_opt: self.workdir_opt,
             dry_run_opt: self.dry_run_opt,
+            args_opt: self.args_opt,
         }
     }
 }
 
-impl<F, E> JustCmd<F, E, DryRunNotSet> {
-    /// Enable dry-run mode.
+impl<E, D, A> JustCmd<JustfileSet, E, WorkdirNotSet, D, A> {
+    /// Specify a working directory.
+    ///
+    /// Requires the `--justfile` option to be set.
     ///
     /// See the [Just documentation](https://github.com/casey/just)
-    pub fn with_dry_run(self, dry_run: bool) -> JustCmd<F, E, DryRunSet> {
+    pub fn with_working_directory<P>(self, dir: P) -> JustCmd<JustfileSet, E, WorkdirSet, D, A>
+    where
+        P: AsRef<OsStr>,
+    {
+        let dir = PathBuf::from(&dir).into_boxed_path();
+
         JustCmd {
             cmd: self.cmd,
             justfile_opt: self.justfile_opt,
             env_file_opt: self.env_file_opt,
-            dry_run_opt: DryRunSet(dry_run),
+            workdir_opt: WorkdirSet(dir),
+            dry_run_opt: self.dry_run_opt,
+            args_opt: self.args_opt,
         }
+    }
+}
+
+impl<F, E, W, A> JustCmd<F, E, W, DryRunNotSet, A> {
+    /// Enable dry-run mode.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just)
+    pub fn with_dry_run(self, dry_run: bool) -> JustCmd<F, E, W, DryRunSet, A> {
+        JustCmd {
+            cmd: self.cmd,
+            justfile_opt: self.justfile_opt,
+            env_file_opt: self.env_file_opt,
+            workdir_opt: self.workdir_opt,
+            dry_run_opt: DryRunSet(dry_run),
+            args_opt: self.args_opt,
+        }
+    }
+}
+
+impl<F, E, W, D> JustCmd<F, E, W, D, ArgsNotSet> {
+    /// Add arguments to the command: overrides and recipe(s) to run.
+    ///
+    /// If empty, the first recipe in the justfile will be run.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just)
+    pub fn with_args<I>(self, args: I) -> JustCmd<F, E, W, D, ArgsSet>
+    where
+        I: IntoIterator,
+        I::Item: AsRef<str>,
+    {
+        let args = args.into_iter().map(|s| s.as_ref().to_string()).collect();
+
+        JustCmd {
+            cmd: self.cmd,
+            justfile_opt: self.justfile_opt,
+            env_file_opt: self.env_file_opt,
+            workdir_opt: self.workdir_opt,
+            dry_run_opt: self.dry_run_opt,
+            args_opt: ArgsSet(args),
+        }
+    }
+
+    /// Run the default recipe in the justfile.
+    ///
+    /// This is equivalent to calling the command with no arguments.
+    ///
+    /// See the [Just documentation](https://github.com/casey/just)
+    pub fn run_default_recipe(self) -> JustCmd<F, E, W, D, ArgsSet> {
+        self.with_args(Vec::<String>::new())
     }
 }
 
@@ -202,6 +286,32 @@ impl IntoCmdOptValue<Box<Path>> for EnvFileSet {
     }
 }
 
+// Workdir option markers
+#[allow(private_bounds)]
+pub trait WorkdirOpt: IntoCmdOptValue<Box<Path>> + _priv::Sealed {}
+
+pub struct WorkdirNotSet;
+
+impl WorkdirOpt for WorkdirNotSet {}
+impl _priv::Sealed for WorkdirNotSet {}
+
+impl IntoCmdOptValue<Box<Path>> for WorkdirNotSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        None
+    }
+}
+
+pub struct WorkdirSet(Box<Path>);
+
+impl WorkdirOpt for WorkdirSet {}
+impl _priv::Sealed for WorkdirSet {}
+
+impl IntoCmdOptValue<Box<Path>> for WorkdirSet {
+    fn into_value(self) -> Option<Box<Path>> {
+        Some(self.0)
+    }
+}
+
 // Dry run option markers
 #[allow(private_bounds)]
 pub trait DryRunOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
@@ -224,6 +334,32 @@ impl _priv::Sealed for DryRunSet {}
 
 impl IntoCmdOptValue<bool> for DryRunSet {
     fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+// Args option markers
+#[allow(private_bounds)]
+pub trait ArgsOpt: IntoCmdOptValue<Box<[String]>> + _priv::Sealed {}
+
+pub struct ArgsNotSet;
+
+impl ArgsOpt for ArgsNotSet {}
+impl _priv::Sealed for ArgsNotSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ArgsNotSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        None
+    }
+}
+
+pub struct ArgsSet(Box<[String]>);
+
+impl ArgsOpt for ArgsSet {}
+impl _priv::Sealed for ArgsSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ArgsSet {
+    fn into_value(self) -> Option<Box<[String]>> {
         Some(self.0)
     }
 }

--- a/seahaven-just/src/cmd/tests/it_root.rs
+++ b/seahaven-just/src/cmd/tests/it_root.rs
@@ -127,3 +127,69 @@ async fn run_just_root_with_all_options() {
         ]
     );
 }
+
+#[tokio::test]
+async fn run_just_root_with_working_directory() {
+    //* Given
+    let exe = fixture_exe();
+    let workdir = "test/dir";
+
+    let mut cmd = JustCmd::with_executable(exe)
+        .with_justfile("test/justfile") // Working directory requires justfile to be set
+        .with_working_directory(workdir)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just root command with working directory");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "--justfile",
+            "test/justfile",
+            "--working-directory",
+            "test/dir"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn run_just_root_with_args() {
+    //* Given
+    let exe = fixture_exe();
+    let args = vec!["recipe1", "arg1", "arg2"];
+
+    let mut cmd = JustCmd::with_executable(exe).with_args(args).into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just root command with args");
+    let cmd_args = parse_fixture_exe_output(&output);
+
+    assert_eq!(cmd_args, ["recipe1", "arg1", "arg2"]);
+}
+
+#[tokio::test]
+async fn run_just_root_with_default_recipe() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = JustCmd::with_executable(exe)
+        .run_default_recipe()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just root command with default recipe");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["<no-args>"]);
+}


### PR DESCRIPTION
- Extended the JustCmd struct to include options for specifying a working directory and command arguments.
- Implemented methods `with_working_directory` and `with_args` to facilitate these new options.
- Updated command construction to include `--working-directory` and additional arguments when applicable.
- Added tests to verify the functionality of the working directory and arguments features in various scenarios.