### PR TITLE
refactor(seahaven-cli): remove `no-interpolation` flag from setup command

### DIFF
--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -9,210 +9,238 @@ pub(super) const CMD: &str = "setup";
 pub(super) fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Manage local development environment setup")
-        .subcommands([
-            clap::command!("env")
-                .about("Print the .env file contents")
-                .args([
-                    clap::arg!(-f --file <FILE> "The setup file")
-                        .default_value("setup.yaml")
-                        .value_parser(clap::value_parser!(PathBuf)),
-                    clap::arg!(--"no-interpolation" "Do not interpolate the environment values"),
-                ]),
-            clap::command!("compose")
-                .about("Print the docker-compose.yaml file contents")
-                .args([
-                    clap::arg!(-f --file <FILE> "The setup file")
-                        .default_value("setup.yaml")
-                        .value_parser(clap::value_parser!(PathBuf)),
-                    clap::arg!(--"no-interpolation" "Do not interpolate the environment values"),
-                ]),
-            clap::command!("eject")
-                .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
-                .args([
-                    clap::arg!(-f --file <FILE> "The setup file")
-                        .default_value("setup.yaml")
-                        .value_parser(clap::value_parser!(PathBuf)),
-                    clap::arg!(-o --"output-dir" <DIR> "The output directory")
-                        .default_value(".")
-                        .value_parser(clap::value_parser!(PathBuf)),
-                    clap::arg!(--"no-interpolation" "Do not interpolate the environment values"),
-                ]),
-        ])
+        .subcommands([env::cmd(), compose::cmd(), eject::cmd()])
 }
 
 /// The `setup` command implementation
 pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
     match matches.subcommand() {
-        Some(("env", matches)) => env(matches).await,
-        Some(("compose", matches)) => compose(matches).await,
-        Some(("eject", matches)) => eject(matches).await,
+        Some((env::CMD, matches)) => env::run(matches).await,
+        Some((compose::CMD, matches)) => compose::run(matches).await,
+        Some((eject::CMD, matches)) => eject::run(matches).await,
         _ => Err(anyhow::anyhow!("No setup command specified").into()),
     }
 }
 
-/// The `setup env` command
-///
-/// This function prints the .env file contents to the console with all the interpolated values.
-pub async fn env(matches: &clap::ArgMatches) -> Result<()> {
-    // Get the setup file path from the command line (required)
-    let setup_file_path = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file path");
-    if !setup_file_path.is_file() {
-        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
+mod env {
+    use super::*;
+
+    /// The `setup env` command name
+    pub const CMD: &str = "env";
+
+    /// Create the `setup env` sub-command
+    pub fn cmd() -> clap::Command {
+        clap::command!("env")
+            .about("Print the .env file contents")
+            .args([clap::arg!(-f --file <FILE> "The setup file")
+                .default_value("setup.yaml")
+                .value_parser(clap::value_parser!(PathBuf))])
     }
 
-    // Read and parse the setup file
-    let file = File::open(setup_file_path)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let env = seahaven_file::fileenv_from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
-
-    // If no environment is present, print a warning and return
-    let env = match env {
-        Some(env) => env,
-        None => {
-            eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: No env found in the setup file");
-            return Ok(());
+    /// The `setup env` command
+    ///
+    /// This function prints the .env file contents to the console.
+    pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+        // Get the setup file path from the command line (required)
+        let setup_file_path = matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file path");
+        if !setup_file_path.is_file() {
+            return Err(
+                anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into(),
+            );
         }
-    };
 
-    // Check if we need to interpolate the environment variables
-    if !matches.get_flag("no-interpolation") {
-        // TODO: Implement interpolation
-        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation unavailable");
-    }
+        // Read and parse the setup file
+        let file = File::open(setup_file_path)
+            .map(BufReader::new)
+            .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+        let env = seahaven_file::fileenv_from_reader(file)
+            .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
-    // Serialize the environment variables to a string
-    let env_content = seahaven_file::serde_envfile::to_string(&env)
-        .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
+        // If no environment is present, print a warning and return
+        let env = match env {
+            Some(env) => env,
+            None => {
+                eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: No env found in the setup file");
+                return Ok(());
+            }
+        };
 
-    println!("{}", env_content);
-
-    Ok(())
-}
-
-/// The `setup compose` command
-///
-/// This function prints the docker-compose.yaml file contents to the console with all the interpolated values.
-pub async fn compose(matches: &clap::ArgMatches) -> Result<()> {
-    // Get the setup file path from the command line (required)
-    let setup_file_path = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file path");
-    if !setup_file_path.is_file() {
-        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
-    }
-
-    // Read and parse the setup file
-    let file = File::open(setup_file_path)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let (_env, content) = seahaven_file::from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
-        .unpack();
-
-    // Transform the content into a compose file
-    let compose_file = seahaven_file::try_into_compose_file(content)
-        .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
-
-    // Serialize the compose file to a string
-    let compose_content = seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
-        .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
-
-    // Interpolate the compose file (env_file -> compose_file)
-    if !matches.get_flag("no-interpolation") {
-        // TODO: Implement interpolation for the compose file
-        eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: Env variables interpolation unavailable");
-    }
-
-    println!("{}", compose_content);
-
-    Ok(())
-}
-
-/// The `setup eject` command
-///
-/// This function ejects the setup.yaml file to get the docker-compose.yaml and .env files.
-/// This is a one-way operation. Once ejected, you will need to manage the configuration manually.
-pub async fn eject(matches: &clap::ArgMatches) -> Result<()> {
-    // Display warning message about the one-way nature of the operation
-    indoc::eprintdoc! {r#"
-        \x1b[33m\x1b[1mWARNING\x1b[0m: This is a one-way operation. Once ejected, you will need to manage the configuration manually.
-        \x1b[33m\x1b[1mWARNING\x1b[0m: The ejected files will be created in the specified output directory.
-        \x1b[33m\x1b[1mWARNING\x1b[0m: You can always regenerate the setup.yaml file from the ejected files if needed.
-        \x1b[33m\x1b[1mWARNING\x1b[0m: Are you sure you want to continue? [y/N] "#
-    }
-
-    // Get user confirmation
-    let mut input = String::new();
-    std::io::stdin()
-        .read_line(&mut input)
-        .map_err(|err| anyhow::anyhow!("Failed to read user input: {err}"))?;
-    if !input.trim().to_lowercase().starts_with('y') {
-        eprintln!("Operation cancelled.");
-        return Ok(());
-    }
-
-    // Get the setup file path from the command line (required)
-    let setup_file_path = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file path");
-    if !setup_file_path.is_file() {
-        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
-    }
-
-    // Get the output directory from the command line (required)
-    let output_dir = matches
-        .get_one::<PathBuf>("output-dir")
-        .expect("Failed to get output directory");
-    if !output_dir.is_dir() {
-        return Err(anyhow::anyhow!("Invalid output directory: {}", output_dir.display()).into());
-    }
-
-    // Read and parse the setup file
-    let file = File::open(setup_file_path)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let (env, content) = seahaven_file::from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
-        .unpack();
-
-    // Transform the content into a compose file
-    let compose_file = seahaven_file::try_into_compose_file(content)
-        .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
-
-    // Serialize the compose file to a string
-    let compose_content = seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
-        .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
-
-    // Write the docker-compose.yaml file
-    let output_compose_file_path = output_dir.join("docker-compose.yaml");
-    std::fs::write(&output_compose_file_path, compose_content)
-        .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml: {}", err))?;
-    println!(
-        "Created docker-compose.yaml file at {}",
-        output_compose_file_path.display()
-    );
-
-    // If environment section is present, write the .env file
-    if let Some(env) = env {
         // Serialize the environment variables to a string
         let env_content = seahaven_file::serde_envfile::to_string(&env)
             .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
 
-        // Write the .env file
-        let output_env_file_path = output_dir.join(".env");
-        std::fs::write(&output_env_file_path, env_content)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {}", err))?;
-        println!("Created .env file at {}", output_env_file_path.display());
-    } else {
-        println!("No environment variables found in the setup file, skipping .env file creation");
+        println!("{}", env_content);
+
+        Ok(())
+    }
+}
+
+mod compose {
+    use super::*;
+
+    /// The `setup compose` command name
+    pub const CMD: &str = "compose";
+
+    /// Create the `setup compose` sub-command
+    pub fn cmd() -> clap::Command {
+        clap::command!("compose")
+            .about("Print the docker-compose.yaml file contents")
+            .args([clap::arg!(-f --file <FILE> "The setup file")
+                .default_value("setup.yaml")
+                .value_parser(clap::value_parser!(PathBuf))])
     }
 
-    println!("Ejection completed successfully!");
-    println!("You can now manage your configuration manually.");
+    /// The `setup compose` command
+    ///
+    /// This function prints the docker-compose.yaml file contents to the console.
+    pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+        // Get the setup file path from the command line (required)
+        let setup_file_path = matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file path");
+        if !setup_file_path.is_file() {
+            return Err(
+                anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into(),
+            );
+        }
 
-    Ok(())
+        // Read and parse the setup file
+        let file = File::open(setup_file_path)
+            .map(BufReader::new)
+            .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+        let (_env, content) = seahaven_file::from_reader(file)
+            .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
+            .unpack();
+
+        // Transform the content into a compose file
+        let compose_file = seahaven_file::try_into_compose_file(content).map_err(|err| {
+            anyhow::anyhow!("Failed to convert setup file to compose file: {}", err)
+        })?;
+
+        // Serialize the compose file to a string
+        let compose_content =
+            seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
+                .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
+
+        println!("{}", compose_content);
+
+        Ok(())
+    }
+}
+
+mod eject {
+    use super::*;
+
+    /// The `setup eject` command name
+    pub const CMD: &str = "eject";
+
+    /// Create the `setup eject` sub-command
+    pub fn cmd() -> clap::Command {
+        clap::command!("eject")
+            .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
+            .args([
+                clap::arg!(-f --file <FILE> "The setup file")
+                    .default_value("setup.yaml")
+                    .value_parser(clap::value_parser!(PathBuf)),
+                clap::arg!(-o --"output-dir" <DIR> "The output directory")
+                    .default_value(".")
+                    .value_parser(clap::value_parser!(PathBuf)),
+            ])
+    }
+
+    /// The `setup eject` command
+    ///
+    /// This function ejects the setup.yaml file to get the docker-compose.yaml and .env files.
+    /// This is a one-way operation. Once ejected, you will need to manage the configuration manually.
+    pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+        // Display warning message about the one-way nature of the operation
+        indoc::eprintdoc! {r#"
+            \x1b[33m\x1b[1mWARNING\x1b[0m: This is a one-way operation. Once ejected, you will need to manage the configuration manually.
+            \x1b[33m\x1b[1mWARNING\x1b[0m: The ejected files will be created in the specified output directory.
+            \x1b[33m\x1b[1mWARNING\x1b[0m: You can always regenerate the setup.yaml file from the ejected files if needed.
+            \x1b[33m\x1b[1mWARNING\x1b[0m: Are you sure you want to continue? [y/N] "#
+        }
+
+        // Get user confirmation
+        let mut input = String::new();
+        std::io::stdin()
+            .read_line(&mut input)
+            .map_err(|err| anyhow::anyhow!("Failed to read user input: {err}"))?;
+        if !input.trim().to_lowercase().starts_with('y') {
+            eprintln!("Operation cancelled.");
+            return Ok(());
+        }
+
+        // Get the setup file path from the command line (required)
+        let setup_file_path = matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file path");
+        if !setup_file_path.is_file() {
+            return Err(
+                anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into(),
+            );
+        }
+
+        // Get the output directory from the command line (required)
+        let output_dir = matches
+            .get_one::<PathBuf>("output-dir")
+            .expect("Failed to get output directory");
+        if !output_dir.is_dir() {
+            return Err(
+                anyhow::anyhow!("Invalid output directory: {}", output_dir.display()).into(),
+            );
+        }
+
+        // Read and parse the setup file
+        let file = File::open(setup_file_path)
+            .map(BufReader::new)
+            .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+        let (env, content) = seahaven_file::from_reader(file)
+            .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
+            .unpack();
+
+        // Transform the content into a compose file
+        let compose_file = seahaven_file::try_into_compose_file(content).map_err(|err| {
+            anyhow::anyhow!("Failed to convert setup file to compose file: {}", err)
+        })?;
+
+        // Serialize the compose file to a string
+        let compose_content =
+            seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
+                .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
+
+        // Write the docker-compose.yaml file
+        let output_compose_file_path = output_dir.join("docker-compose.yaml");
+        std::fs::write(&output_compose_file_path, compose_content)
+            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml: {}", err))?;
+        println!(
+            "Created docker-compose.yaml file at {}",
+            output_compose_file_path.display()
+        );
+
+        // If environment section is present, write the .env file
+        if let Some(env) = env {
+            // Serialize the environment variables to a string
+            let env_content = seahaven_file::serde_envfile::to_string(&env).map_err(|err| {
+                anyhow::anyhow!("Failed to serialize environment variables: {}", err)
+            })?;
+
+            // Write the .env file
+            let output_env_file_path = output_dir.join(".env");
+            std::fs::write(&output_env_file_path, env_content)
+                .map_err(|err| anyhow::anyhow!("Failed to write .env file: {}", err))?;
+            println!("Created .env file at {}", output_env_file_path.display());
+        } else {
+            println!(
+                "No environment variables found in the setup file, skipping .env file creation"
+            );
+        }
+
+        println!("Ejection completed successfully!");
+        println!("You can now manage your configuration manually.");
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
- Eliminated the `--no-interpolation` flag from the `setup`, `compose`, and `env` commands.
- Updated documentation to reflect changes in functionality, removing references to interpolation.
- Cleaned up related code sections to enhance clarity and maintainability.
- Restructured the code to improve readability and organization.