### PR TITLE
refactor(seahaven-cli): restructure CLI command execution

### DIFF
--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -1,34 +1,9 @@
 mod build;
 mod down;
 mod pull;
+mod root;
 mod run;
 mod setup;
 mod up;
 
-use crate::result::Result;
-
-/// Create and execute the DIPs CLI command line interface
-pub async fn run() -> Result<()> {
-    let matches = clap::command!()
-        .subcommands([
-            build::cmd(),
-            down::cmd(),
-            pull::cmd(),
-            run::cmd(),
-            setup::cmd(),
-            up::cmd(),
-        ])
-        .infer_long_args(true)
-        .infer_subcommands(true)
-        .get_matches();
-
-    match matches.subcommand() {
-        Some((build::CMD, matches)) => build::run(matches).await,
-        Some((down::CMD, matches)) => down::run(matches).await,
-        Some((pull::CMD, matches)) => pull::run(matches).await,
-        Some((run::CMD, matches)) => run::run(matches).await,
-        Some((setup::CMD, matches)) => setup::run(matches).await,
-        Some((up::CMD, matches)) => up::run(matches).await,
-        _ => Err(anyhow::anyhow!("No command specified").into()),
-    }
-}
+pub use root::cmd_run as run;

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,0 +1,28 @@
+use super::{build, down, pull, run, setup, up};
+use crate::result::Result;
+
+/// Create and execute the DIPs CLI command line interface
+pub async fn cmd_run() -> Result<()> {
+    let matches = clap::command!()
+        .subcommands([
+            build::cmd(),
+            down::cmd(),
+            pull::cmd(),
+            run::cmd(),
+            setup::cmd(),
+            up::cmd(),
+        ])
+        .infer_long_args(true)
+        .infer_subcommands(true)
+        .get_matches();
+
+    match matches.subcommand() {
+        Some((build::CMD, matches)) => build::run(matches).await,
+        Some((down::CMD, matches)) => down::run(matches).await,
+        Some((pull::CMD, matches)) => pull::run(matches).await,
+        Some((run::CMD, matches)) => run::run(matches).await,
+        Some((setup::CMD, matches)) => setup::run(matches).await,
+        Some((up::CMD, matches)) => up::run(matches).await,
+        _ => Err(anyhow::anyhow!("No command specified").into()),
+    }
+}


### PR DESCRIPTION
- Moved the command execution logic from `cmd.rs` to a new `root.rs` file for better organization.
- Updated the `run` function to use the new `cmd_run` function from `root.rs`.
- Enhanced code clarity and maintainability by separating command handling into its own module.