### PR TITLE
refactor(seahaven-cli): make `--file` argument global

### DIFF
--- a/seahaven-cli/src/cmd/build.rs
+++ b/seahaven-cli/src/cmd/build.rs
@@ -5,16 +5,13 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use crate::result::{Error, Result};
 
 /// The `build` command name
-pub(super) const CMD: &str = "build";
+pub const CMD: &str = "build";
 
 /// Create the `build` command
-pub(super) fn cmd() -> clap::Command {
+pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Build the development environment images using docker compose")
         .args([
-            clap::arg!(-f --file <FILE> "The seahaven setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf)),
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
             clap::arg!(--"build-arg" <KEY_VALUE> "Set build-time variables")
@@ -25,7 +22,7 @@ pub(super) fn cmd() -> clap::Command {
 }
 
 /// The `build` command implementation
-pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");

--- a/seahaven-cli/src/cmd/down.rs
+++ b/seahaven-cli/src/cmd/down.rs
@@ -5,16 +5,13 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use crate::result::{Error, Result};
 
 /// The `down` command name
-pub(super) const CMD: &str = "down";
+pub const CMD: &str = "down";
 
 /// Create the `down` command
-pub(super) fn cmd() -> clap::Command {
+pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Stop and remove containers, networks, images, and volumes")
         .args([
-            clap::arg!(-f --file <FILE> "The seahaven setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf)),
             clap::arg!(-v --volumes "Remove named volumes declared in the volumes section of the Compose file")
                 .action(clap::ArgAction::SetTrue),
             clap::arg!(--"dry-run" "Execute command in dry run mode")
@@ -25,7 +22,7 @@ pub(super) fn cmd() -> clap::Command {
 }
 
 /// The `down` command implementation
-pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");

--- a/seahaven-cli/src/cmd/pull.rs
+++ b/seahaven-cli/src/cmd/pull.rs
@@ -5,16 +5,13 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use crate::result::{Error, Result};
 
 /// The `pull` command name
-pub(super) const CMD: &str = "pull";
+pub const CMD: &str = "pull";
 
 /// Create the `pull` command
-pub(super) fn cmd() -> clap::Command {
+pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Pull the images for the development environment")
         .args([
-            clap::arg!(-f --file <FILE> "The seahaven setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf)),
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
             clap::arg!([SERVICE] ... "The services to pull").action(clap::ArgAction::Append),
@@ -22,7 +19,7 @@ pub(super) fn cmd() -> clap::Command {
 }
 
 /// The `pull` command implementation
-pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use super::{build, down, pull, run, setup, up};
 use crate::result::Result;
 
@@ -12,6 +14,12 @@ pub async fn cmd_run() -> Result<()> {
             setup::cmd(),
             up::cmd(),
         ])
+        .arg(
+            clap::arg!(-f --file <FILE> "The seahaven setup file")
+                .default_value("setup.yaml")
+                .value_parser(clap::value_parser!(PathBuf))
+                .global(true),
+        )
         .infer_long_args(true)
         .infer_subcommands(true)
         .get_matches();

--- a/seahaven-cli/src/cmd/run.rs
+++ b/seahaven-cli/src/cmd/run.rs
@@ -5,16 +5,13 @@ use seahaven_just::cmd::{IntoCommand, JustCmd};
 use crate::result::{Error, Result};
 
 /// The `run` command name
-pub(super) const CMD: &str = "run";
+pub const CMD: &str = "run";
 
 /// Create the `run` command
-pub(super) fn cmd() -> clap::Command {
+pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("run the development environment images using docker compose")
         .args([
-            clap::arg!(-f --file <FILE> "The seahaven setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf)),
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
             clap::arg!([ARGUMENTS] ... "Overrides and recipe(s) to run, defaulting to the first recipe in the justfile")
@@ -23,7 +20,7 @@ pub(super) fn cmd() -> clap::Command {
 }
 
 /// The `run` command implementation
-pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");

--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -3,17 +3,17 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 use crate::result::Result;
 
 /// The `setup` command name
-pub(super) const CMD: &str = "setup";
+pub const CMD: &str = "setup";
 
 /// Create the `setup` command
-pub(super) fn cmd() -> clap::Command {
+pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Manage local development environment setup")
         .subcommands([env::cmd(), compose::cmd(), eject::cmd()])
 }
 
 /// The `setup` command implementation
-pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     match matches.subcommand() {
         Some((env::CMD, matches)) => env::run(matches).await,
         Some((compose::CMD, matches)) => compose::run(matches).await,
@@ -30,11 +30,7 @@ mod env {
 
     /// Create the `setup env` sub-command
     pub fn cmd() -> clap::Command {
-        clap::command!("env")
-            .about("Print the .env file contents")
-            .args([clap::arg!(-f --file <FILE> "The setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf))])
+        clap::command!(CMD).about("Print the .env file contents")
     }
 
     /// The `setup env` command
@@ -85,11 +81,7 @@ mod compose {
 
     /// Create the `setup compose` sub-command
     pub fn cmd() -> clap::Command {
-        clap::command!("compose")
-            .about("Print the docker-compose.yaml file contents")
-            .args([clap::arg!(-f --file <FILE> "The setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf))])
+        clap::command!(CMD).about("Print the docker-compose.yaml file contents")
     }
 
     /// The `setup compose` command
@@ -138,16 +130,11 @@ mod eject {
 
     /// Create the `setup eject` sub-command
     pub fn cmd() -> clap::Command {
-        clap::command!("eject")
+        clap::command!(CMD)
             .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
-            .args([
-                clap::arg!(-f --file <FILE> "The setup file")
-                    .default_value("setup.yaml")
-                    .value_parser(clap::value_parser!(PathBuf)),
-                clap::arg!(-o --"output-dir" <DIR> "The output directory")
-                    .default_value(".")
-                    .value_parser(clap::value_parser!(PathBuf)),
-            ])
+            .args([clap::arg!(-o --"output-dir" <DIR> "The output directory")
+                .default_value(".")
+                .value_parser(clap::value_parser!(PathBuf))])
     }
 
     /// The `setup eject` command

--- a/seahaven-cli/src/cmd/up.rs
+++ b/seahaven-cli/src/cmd/up.rs
@@ -5,16 +5,13 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use crate::result::{Error, Result};
 
 /// The `up` command name
-pub(super) const CMD: &str = "up";
+pub const CMD: &str = "up";
 
 /// Create the `up` command
-pub(super) fn cmd() -> clap::Command {
+pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Start the development environment using docker compose")
         .args([
-            clap::arg!(-f --file <FILE> "The seahaven setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf)),
             clap::arg!(-d --detach "Detached mode: Run containers in the background")
                 .action(clap::ArgAction::SetTrue),
             clap::arg!(--build "Build images before starting containers")
@@ -26,7 +23,7 @@ pub(super) fn cmd() -> clap::Command {
 }
 
 /// The `up` command implementation
-pub(super) async fn run(matches: &clap::ArgMatches) -> Result<()> {
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");


### PR DESCRIPTION
- Updated all CLI commands (`build`, `down`, `pull`, `run`, `setup`, `up`) to remove the `-f/--file` argument from their definitions.
- Changed visibility of command functions from `pub(super)` to `pub` for better accessibility.
- Enhanced the `root` command to include the `-f/--file` argument globally, ensuring consistent setup file handling across commands.