### PR TITLE
feat(seahaven-compose-file): enhance build script for schema updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.18"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525046617d8376e3db1deffb079e91cef90a89fc3ca5c185bbf8c9ecdd15cd5c"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "shlex",
 ]
@@ -178,18 +178,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -268,6 +268,15 @@ checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "diffy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+dependencies = [
+ "nu-ansi-term 0.50.1",
 ]
 
 [[package]]
@@ -931,6 +940,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1289,6 +1307,7 @@ dependencies = [
 name = "seahaven-compose-file"
 version = "0.1.0"
 dependencies = [
+ "diffy",
  "reqwest",
  "serde",
  "serde_yaml",
@@ -1829,7 +1848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/seahaven-compose-file/Cargo.toml
+++ b/seahaven-compose-file/Cargo.toml
@@ -13,11 +13,11 @@ edition.workspace = true
 serde = ["dep:serde"]
 
 # Enables automatic schema updates from the official Compose specification
-# When enabled, the build script will:
+# When enabled, the build script will ensure the library stays in sync with the latest Compose format
 # 1. Download the latest Compose specification from GitHub
 # 2. Update the local schema files in the schemas directory
-# 3. Ensure the library stays in sync with the latest Compose format
-update-spec-file = []
+# 3. Apply patches to the schema file
+update-spec-file = ["dep:reqwest", "dep:diffy"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -28,4 +28,5 @@ thiserror = "2.0"
 testlib-file-testdata = { path = "../testlib/file-testdata" }
 
 [build-dependencies]
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.12", features = ["blocking"], optional = true }
+diffy = { version = "0.4.2", optional = true }

--- a/seahaven-compose-file/build.rs
+++ b/seahaven-compose-file/build.rs
@@ -1,28 +1,27 @@
-use std::{env, fs, path::PathBuf};
-
 /// The URL to the compose spec file (main branch)
+#[cfg(feature = "update-spec-file")]
 const COMPOSE_SPEC_FILE_URL: &str =
     "https://github.com/compose-spec/compose-spec/raw/refs/heads/main/schema/compose-spec.json";
 
 /// The path to the compose spec file
+#[cfg(feature = "update-spec-file")]
 const COMPOSE_SPEC_FILE_PATH: &str = "schemas/compose-spec.json";
 
+/// The path to the patches directory
+#[cfg(feature = "update-spec-file")]
+const COMPOSE_SPEC_PATCHES_DIR: &str = "schemas/patches";
+
 fn main() {
-    // Check if update-spec-file feature is enabled
-    if cfg!(feature = "update-spec-file") {
-        let spec_path = {
-            let manifest_dir = env::var("CARGO_MANIFEST_DIR")
-                .map(PathBuf::from)
-                .expect("Failed to get CARGO_MANIFEST_DIR");
-            manifest_dir.join(COMPOSE_SPEC_FILE_PATH)
-        };
+    #[cfg(feature = "update-spec-file")]
+    {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("Failed to get CARGO_MANIFEST_DIR");
 
-        // Create schemas directory if it doesn't exist
-        if let Some(parent) = spec_path.parent() {
-            fs::create_dir_all(parent).expect("Failed to create schemas directory");
-        }
+        let compose_spec_file_path = manifest_dir.join(COMPOSE_SPEC_FILE_PATH);
+        let compose_spec_patches_dir = manifest_dir.join(COMPOSE_SPEC_PATCHES_DIR);
 
-        // Download the spec using reqwest
+        // Download the spec file using reqwest
         let client = reqwest::blocking::Client::new();
         let response = client
             .get(COMPOSE_SPEC_FILE_URL)
@@ -31,17 +30,57 @@ fn main() {
 
         if !response.status().is_success() {
             panic!(
-                "Failed to download compose spec: HTTP request failed with status {}",
+                "Failed to download compose-spec.json file: {}",
                 response.status()
             );
         }
 
-        let content = response
+        let mut content = response
             .text()
             .expect("Failed to read compose spec response body");
 
-        fs::write(spec_path, content).expect("Failed to write compose-spec.json to file");
+        // Apply patches
+        let mut patch_files = std::fs::read_dir(&compose_spec_patches_dir)
+            .expect("Failed to read patches directory")
+            .filter_map(|entry| {
+                let path = entry.ok()?.path();
+                if path.extension()?.to_str()? == "patch" {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<std::path::PathBuf>>();
 
-        println!("cargo:warning=Downloaded latest version of compose-spec.json from GitHub");
+        patch_files.sort_by_key(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("")
+                .to_owned()
+        });
+
+        for patch_file in patch_files {
+            let patch_content = std::fs::read_to_string(&patch_file).unwrap_or_else(|err| {
+                panic!(
+                    "Failed to read patch file {}: {}",
+                    patch_file.display(),
+                    err
+                )
+            });
+            let patch = diffy::Patch::from_str(&patch_content).unwrap_or_else(|err| {
+                panic!("Failed to parse patch {}: {}", patch_file.display(), err)
+            });
+            content = diffy::apply(&content, &patch).unwrap_or_else(|err| {
+                panic!("Failed to apply patch {}: {}", patch_file.display(), err)
+            });
+        }
+
+        // Write the final content back to the file
+        std::fs::write(&compose_spec_file_path, content)
+            .expect("Failed to write compose-spec.json to file");
+
+        println!(
+            "cargo:warning=Downloaded latest version of compose-spec.json from GitHub and applied patches"
+        );
     }
 }

--- a/seahaven-compose-file/schemas/compose-spec.json
+++ b/seahaven-compose-file/schemas/compose-spec.json
@@ -431,7 +431,7 @@
                       "propagation": {"type": "string"},
                       "create_host_path": {"type": ["boolean", "string"]},
                       "recursive": {"type": "string", "enum": ["enabled", "disabled", "writable", "readonly"]},
-                      "selinux": {"type": "string", "enum": ["z", "Z"]}
+                      "selinux": {"type": "string", "pattern": "^[zZ]$"}
                     },
                     "additionalProperties": false,
                     "patternProperties": {"^x-": {}}

--- a/seahaven-compose-file/schemas/patches/0001-typify-selinux-z-case-fix.patch
+++ b/seahaven-compose-file/schemas/patches/0001-typify-selinux-z-case-fix.patch
@@ -1,0 +1,11 @@
+--- a/schemas/compose-spec.json
++++ b/schemas/compose-spec.json
+@@ -431,7 +431,7 @@
+                       "propagation": {"type": "string"},
+                       "create_host_path": {"type": ["boolean", "string"]},
+                       "recursive": {"type": "string", "enum": ["enabled", "disabled", "writable", "readonly"]},
+-                      "selinux": {"type": "string", "enum": ["z", "Z"]}
++                      "selinux": {"type": "string", "pattern": "^[zZ]$"}
+                     },
+                     "additionalProperties": false,
+                     "patternProperties": {"^x-": {}}


### PR DESCRIPTION
- Updated the build script to download the latest Compose specification and apply patches when the `update-spec-file` feature is enabled.
- Introduced a new patch for the `selinux` property in `compose-spec.json` to use a regex pattern instead of an enum.
- Added `diffy` as an optional dependency for applying patches.