### PR TITLE
feat(seahaven-file): add setup specification schema and build script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +365,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -487,6 +505,17 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -1059,6 +1088,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1186,16 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "regress"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
+dependencies = [
+ "hashbrown 0.15.2",
+ "memchr",
+]
 
 [[package]]
 name = "reqwest"
@@ -1287,6 +1336,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "seahaven-cli"
 version = "0.1.0"
 dependencies = [
@@ -1297,7 +1370,7 @@ dependencies = [
  "seahaven-file",
  "seahaven-just",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1312,7 +1385,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "testlib-file-testdata",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1325,7 +1398,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "test-with",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "which",
 ]
@@ -1336,12 +1409,18 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "indoc",
+ "prettyplease",
+ "regress",
+ "schemars",
  "seahaven-compose-file",
  "serde",
  "serde-envfile",
+ "serde_json",
  "serde_yaml",
+ "syn",
  "testlib-file-testdata",
- "thiserror",
+ "thiserror 2.0.12",
+ "typify",
 ]
 
 [[package]]
@@ -1350,7 +1429,7 @@ version = "0.1.0"
 dependencies = [
  "semver",
  "test-with",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "which",
 ]
@@ -1420,6 +1499,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1429,6 +1519,18 @@ dependencies = [
  "memchr",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_tokenstream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64060d864397305347a78851c51588fd283767e7e7589829e8121d65512340f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
 ]
 
 [[package]]
@@ -1641,11 +1743,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.12",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1864,6 +1986,53 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typify"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c644dda9862f0fef3a570d8ddb3c2cfb1d5ac824a1f2ddfa7bc8f071a5ad8a"
+dependencies = [
+ "typify-impl",
+ "typify-macro",
+]
+
+[[package]]
+name = "typify-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ab345b6c0d8ae9500b9ff334a4c7c0d316c1c628dc55726b95887eb8dbd11"
+dependencies = [
+ "heck",
+ "log",
+ "proc-macro2",
+ "quote",
+ "regress",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "syn",
+ "thiserror 1.0.69",
+ "unicode-ident",
+]
+
+[[package]]
+name = "typify-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "785e2cdcef0df8160fdd762ed548a637aaec1e83704fdbc14da0df66013ee8d0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "schemars",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_tokenstream",
+ "syn",
+ "typify-impl",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/seahaven-file/Cargo.toml
+++ b/seahaven-file/Cargo.toml
@@ -9,6 +9,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = "1.0"
+regress = "0.10"
 seahaven-compose-file = { version = "0.1.0", path = "../seahaven-compose-file", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "ad00e40" }
@@ -18,3 +19,10 @@ thiserror = "2.0"
 [dev-dependencies]
 indoc = "2.0"
 testlib-file-testdata = { path = "../testlib/file-testdata" }
+
+[build-dependencies]
+typify = "0.2"
+serde_json = "1.0"
+schemars = "0.8"
+prettyplease = "0.2"
+syn = "2.0"

--- a/seahaven-file/build.rs
+++ b/seahaven-file/build.rs
@@ -1,0 +1,52 @@
+/// The path to the setup spec file
+const SETUP_SPEC_FILE_PATH: &str = "schemas/setup-spec.json";
+
+/// The path to the generated types file
+const GENERATED_TYPES_FILE_PATH: &str = "codegen/src/model/setup_spec.rs";
+
+fn main() {
+    // Generate the setup-spec.json Rust types
+    {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("Failed to get CARGO_MANIFEST_DIR");
+        let out_dir = std::env::var("OUT_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("Failed to get OUT_DIR");
+
+        let setup_spec_file_path = manifest_dir.join(SETUP_SPEC_FILE_PATH);
+        let generated_types_file_path = out_dir.join(GENERATED_TYPES_FILE_PATH);
+
+        // Read the spec file from the local filesystem
+        let content =
+            std::fs::read_to_string(&setup_spec_file_path).expect("Failed to read setup spec file");
+
+        // Parse the JSON schema
+        let schema = serde_json::from_str::<schemars::schema::RootSchema>(&content)
+            .expect("Failed to parse setup spec as JSON schema");
+
+        // Generate Rust types using typify
+        let mut type_space =
+            typify::TypeSpace::new(typify::TypeSpaceSettings::default().with_struct_builder(true));
+        type_space
+            .add_root_schema(schema)
+            .expect("Failed to add schema to type space");
+
+        let contents = prettyplease::unparse(
+            &syn::parse2::<syn::File>(type_space.to_stream())
+                .expect("Failed to parse generated code"),
+        );
+
+        // Create the output directory if it doesn't exist
+        if let Some(parent) = generated_types_file_path.parent() {
+            std::fs::create_dir_all(parent).expect("Failed to create output directory");
+        }
+
+        // Write the generated types to the file
+        std::fs::write(&generated_types_file_path, contents)
+            .expect("Failed to write generated types to file");
+
+        // Re-run the build if the setup-spec.json file changes
+        println!("cargo:rerun-if-changed={}", setup_spec_file_path.display());
+    }
+}

--- a/seahaven-file/schemas/setup-spec.json
+++ b/seahaven-file/schemas/setup-spec.json
@@ -1,0 +1,402 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "setup_spec.json",
+  "type": "object",
+  "title": "Setup Specification",
+  "description": "The setup file is a YAML file defining a multi-containers based application.",
+
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "define the setup file project name, until user defines one explicitly."
+    },
+
+    "services": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "init": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "networks": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
+      }
+    },
+
+    "volumes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "secrets": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/secret"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "configs": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/config"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+    "service": {
+      "type": "object",
+
+      "properties": {
+        "build": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+              "properties": {
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "dockerfile_inline": {"type": "string"},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "ssh": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "additional_contexts": {"$ref": "#/definitions/list_or_dict"},
+                "pull": {"type": ["boolean", "string"]},
+                "target": {"type": "string"},
+                "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+                "tags": {"type": "array", "items": {"type": "string"}}
+              }
+            }
+          ]
+        },
+        "command": {"$ref": "#/definitions/command"},
+        "configs": {"$ref": "#/definitions/service_config_or_secret"},
+        "container_name": {"type": "string"},
+        "depends_on": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {"^x-": {}},
+                  "properties": {
+                    "restart": {"type": ["boolean", "string"]},
+                    "required": {
+                      "type":  "boolean",
+                      "default": true
+                    },
+                    "condition": {
+                      "type": "string",
+                      "enum": ["service_started", "service_healthy", "service_completed_successfully"]
+                    }
+                  },
+                  "required": ["condition"]
+                }
+              }
+            }
+          ]
+        },
+        "entrypoint": {"$ref": "#/definitions/command"},
+        "env_file": {"$ref": "#/definitions/env_file"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "image": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "ports": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "number"},
+              {"type": "string"},
+              {
+                "type": "object",
+                "properties": {
+                  "name": {"type": "string"},
+                  "mode": {"type": "string"},
+                  "host_ip": {"type": "string"},
+                  "target": {"type": ["integer", "string"]},
+                  "published": {"type": ["string", "integer"]},
+                  "protocol": {"type": "string"},
+                  "app_protocol": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "post_start": {"type": "array", "items": {"$ref": "#/definitions/service_hook"}},
+        "pre_stop": {"type": "array", "items": {"$ref": "#/definitions/service_hook"}},
+        "profiles": {"$ref": "#/definitions/list_of_strings"},
+        "read_only": {"type": ["boolean", "string"]},
+        "restart": {"type": "string"},
+        "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+        "stop_signal": {"type": "string"},
+        "user": {"type": "string"},
+        "volumes": {
+         "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {"type": "string",
+                    "enum": ["bind", "volume", "tmpfs", "cluster", "image"]
+                  },
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "read_only": {"type": ["boolean", "string"]},
+                  "consistency": {"type": "string"},
+                  "bind": {
+                    "type": "object",
+                    "properties": {
+                      "propagation": {"type": "string"},
+                      "create_host_path": {"type": ["boolean", "string"]},
+                      "recursive": {"type": "string", "enum": ["enabled", "disabled", "writable", "readonly"]},
+                      "selinux": {"type": "string", "pattern": "^[zZ]$"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "volume": {
+                    "type": "object",
+                    "properties": {
+                      "labels": {"$ref": "#/definitions/list_or_dict"},
+                      "nocopy": {"type": ["boolean", "string"]},
+                      "subpath": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "tmpfs": {
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "oneOf": [
+                          {"type": "integer", "minimum": 0},
+                          {"type": "string"}
+                        ]
+                      },
+                      "mode": {"type": ["number", "string"]}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "subpath": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "volumes_from": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "working_dir": {"type": "string"}
+      }
+    },
+
+    "healthcheck": {
+      "type": "object",
+      "properties": {
+        "disable": {"type": ["boolean", "string"]},
+        "interval": {"type": "string"},
+        "retries": {"type": ["number", "string"]},
+        "test": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "timeout": {"type": "string"},
+        "start_period": {"type": "string"},
+        "start_interval": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "network": {
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"}
+      }
+    },
+
+    "volume": {
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"}
+      }
+    },
+
+    "secret": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"}
+      }
+    },
+
+    "config": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"}
+      }
+    },
+
+    "command": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "array","items": {"type": "string"}}
+      ]
+    },
+
+    "service_hook": {
+      "type": "object",
+      "properties": {
+        "command": {"$ref": "#/definitions/command"},
+        "user": {"type": "string"},
+        "privileged": {"type": ["boolean", "string"]},
+        "working_dir": {"type": "string"},
+        "environment": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}},
+      "required": ["command"]
+    },
+
+    "env_file": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": ["boolean", "string"],
+                    "default": true
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+
+    "list_of_strings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+
+    "list_or_dict": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "service_config_or_secret": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {
+            "type": "object",
+            "properties": {
+              "source": {"type": "string"},
+              "target": {"type": "string"},
+              "uid": {"type": "string"},
+              "gid": {"type": "string"},
+              "mode": {"type": ["number", "string"]}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
+        ]
+      }
+    }
+  }
+}

--- a/seahaven-file/src/model/content.rs
+++ b/seahaven-file/src/model/content.rs
@@ -45,6 +45,17 @@ pub struct Content {
     pub secrets: Option<serde_yaml::Mapping>,
 }
 
+mod internal {
+    // Allow the generated code to be used without warnings
+    #![allow(dead_code)]
+    #![allow(irrefutable_let_patterns)]
+    #![allow(clippy::clone_on_copy)]
+    #![allow(clippy::large_enum_variant)]
+    #![allow(clippy::enum_variant_names)]
+
+    include!(concat!(env!("OUT_DIR"), "/codegen/src/model/setup_spec.rs"));
+}
+
 /// Module containing serialization functionality
 pub mod ser {
     use super::Content;


### PR DESCRIPTION
- Introduced a new JSON schema for setup specifications to define multi-container applications.
- Implemented a build script to generate Rust types from the schema using the `typify` crate.
- Updated `Cargo.toml` to include necessary dependencies for schema handling and code generation.
- Added a new module to include generated code without warnings.