### PR TITLE
chore(ci): ignore renovate branches for commit-check workflow

### DIFF
--- a/.github/workflows/commit-check.yml
+++ b/.github/workflows/commit-check.yml
@@ -1,6 +1,8 @@
 name: commit-check
 on:
   pull_request:
+    branches-ignore:
+    - 'renovate/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
- Added 'branches-ignore' configuration to the commit-check workflow to exclude branches matching 'renovate/**' from triggering the workflow.