### PR TITLE
feat(seahaven-compose-file): enhance build script and generate types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,11 +1381,17 @@ name = "seahaven-compose-file"
 version = "0.1.0"
 dependencies = [
  "diffy",
+ "prettyplease",
+ "regress",
  "reqwest",
+ "schemars",
  "serde",
+ "serde_json",
  "serde_yaml",
+ "syn",
  "testlib-file-testdata",
  "thiserror 2.0.12",
+ "typify",
 ]
 
 [[package]]

--- a/seahaven-compose-file/Cargo.toml
+++ b/seahaven-compose-file/Cargo.toml
@@ -20,7 +20,9 @@ serde = ["dep:serde"]
 update-spec-file = ["dep:reqwest", "dep:diffy"]
 
 [dependencies]
+regress = "0.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = "1.0"
 serde_yaml = "0.9"
 thiserror = "2.0"
 
@@ -28,5 +30,10 @@ thiserror = "2.0"
 testlib-file-testdata = { path = "../testlib/file-testdata" }
 
 [build-dependencies]
-reqwest = { version = "0.12", features = ["blocking"], optional = true }
 diffy = { version = "0.4.2", optional = true }
+prettyplease = "0.2"
+reqwest = { version = "0.12", features = ["blocking"], optional = true }
+schemars = "0.8"
+serde_json = "1.0"
+syn = "2.0"
+typify = "0.2"

--- a/seahaven-compose-file/build.rs
+++ b/seahaven-compose-file/build.rs
@@ -3,13 +3,15 @@
 const COMPOSE_SPEC_FILE_URL: &str =
     "https://github.com/compose-spec/compose-spec/raw/refs/heads/main/schema/compose-spec.json";
 
-/// The path to the compose spec file
-#[cfg(feature = "update-spec-file")]
-const COMPOSE_SPEC_FILE_PATH: &str = "schemas/compose-spec.json";
-
 /// The path to the patches directory
 #[cfg(feature = "update-spec-file")]
 const COMPOSE_SPEC_PATCHES_DIR: &str = "schemas/patches";
+
+/// The path to the compose spec file
+const COMPOSE_SPEC_FILE_PATH: &str = "schemas/compose-spec.json";
+
+/// The path to the generated types file
+const GENERATED_TYPES_FILE_PATH: &str = "codegen/src/compose_spec.rs";
 
 fn main() {
     #[cfg(feature = "update-spec-file")]
@@ -81,6 +83,54 @@ fn main() {
 
         println!(
             "cargo:warning=Downloaded latest version of compose-spec.json from GitHub and applied patches"
+        );
+    }
+
+    // Generate the compose-spec.json Rust types
+    {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("Failed to get CARGO_MANIFEST_DIR");
+        let out_dir = std::env::var("OUT_DIR")
+            .map(std::path::PathBuf::from)
+            .expect("Failed to get OUT_DIR");
+
+        let compose_spec_file_path = manifest_dir.join(COMPOSE_SPEC_FILE_PATH);
+        let generated_types_file_path = out_dir.join(GENERATED_TYPES_FILE_PATH);
+
+        // Read the spec file from the local filesystem
+        let content = std::fs::read_to_string(&compose_spec_file_path)
+            .expect("Failed to read compose spec file");
+
+        // Parse the JSON schema
+        let schema = serde_json::from_str::<schemars::schema::RootSchema>(&content)
+            .expect("Failed to parse compose spec as JSON schema");
+
+        // Generate Rust types using typify
+        let mut type_space =
+            typify::TypeSpace::new(typify::TypeSpaceSettings::default().with_struct_builder(true));
+        type_space
+            .add_root_schema(schema)
+            .expect("Failed to add schema to type space");
+
+        let contents = prettyplease::unparse(
+            &syn::parse2::<syn::File>(type_space.to_stream())
+                .expect("Failed to parse generated code"),
+        );
+
+        // Create the output directory if it doesn't exist
+        if let Some(parent) = generated_types_file_path.parent() {
+            std::fs::create_dir_all(parent).expect("Failed to create output directory");
+        }
+
+        // Write the generated types to the file
+        std::fs::write(&generated_types_file_path, contents)
+            .expect("Failed to write generated types to file");
+
+        // Re-run the build if the compose-spec.json file changes
+        println!(
+            "cargo:rerun-if-changed={}",
+            compose_spec_file_path.display()
         );
     }
 }

--- a/seahaven-compose-file/src/lib.rs
+++ b/seahaven-compose-file/src/lib.rs
@@ -73,6 +73,17 @@ pub struct ComposeFile {
     pub secrets: Option<serde_yaml::Mapping>,
 }
 
+mod internal {
+    // Allow the generated code to be used without warnings
+    #![allow(dead_code)]
+    #![allow(irrefutable_let_patterns)]
+    #![allow(clippy::clone_on_copy)]
+    #![allow(clippy::large_enum_variant)]
+    #![allow(clippy::enum_variant_names)]
+
+    include!(concat!(env!("OUT_DIR"), "/codegen/src/compose_spec.rs"));
+}
+
 /// Module containing serialization functionality
 #[cfg(feature = "serde")]
 pub mod ser {


### PR DESCRIPTION
- Updated the build script to generate Rust types from the Compose specification JSON schema using the `typify` crate.
- Added new dependencies: `prettyplease`, `regress`, `schemars`, `serde_json`, `syn`, and `typify` to facilitate code generation and schema handling.
- Included a new module to allow the generated code to be used without warnings.