### PR TITLE
feat(seahaven-cli): add `--justfile` option to run command

### DIFF
--- a/seahaven-cli/src/cmd/run.rs
+++ b/seahaven-cli/src/cmd/run.rs
@@ -14,6 +14,8 @@ pub fn cmd() -> clap::Command {
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
+            clap::arg!(--justfile <FILE> "Path to the justfile to use")
+                .value_parser(clap::value_parser!(PathBuf)),
             clap::arg!([ARGUMENTS] ... "Overrides and recipe(s) to run, defaulting to the first recipe in the justfile")
                 .action(clap::ArgAction::Append),
         ])
@@ -57,6 +59,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
 
     // Create and run the just command
     let mut command = JustCmd::new()
+        .with_justfile::<&PathBuf>(matches.get_one::<PathBuf>("justfile"))
         .with_env_file(env_file_path)
         .with_dry_run(matches.get_flag("dry-run"))
         .with_args(matches.get_many::<String>("ARGUMENTS").unwrap_or_default())

--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -123,11 +123,13 @@ impl<E, W, D, A> JustCmd<JustfileNotSet, E, W, D, A> {
     ///
     /// See the [Just documentation](https://github.com/casey/just)
     /// for more information about the `--justfile` option.
-    pub fn with_justfile<P>(self, file: P) -> JustCmd<JustfileSet, E, W, D, A>
+    pub fn with_justfile<P>(self, file: impl Into<Option<P>>) -> JustCmd<JustfileSet, E, W, D, A>
     where
         P: AsRef<OsStr>,
     {
-        let file = PathBuf::from(&file).into_boxed_path();
+        let file: Option<Box<Path>> = file
+            .into()
+            .map(|path| PathBuf::from(path.as_ref()).into_boxed_path());
 
         JustCmd {
             cmd: self.cmd,
@@ -249,14 +251,14 @@ impl IntoCmdOptValue<Box<Path>> for JustfileNotSet {
     }
 }
 
-pub struct JustfileSet(Box<Path>);
+pub struct JustfileSet(Option<Box<Path>>);
 
 impl JustfileOpt for JustfileSet {}
 impl _priv::Sealed for JustfileSet {}
 
 impl IntoCmdOptValue<Box<Path>> for JustfileSet {
     fn into_value(self) -> Option<Box<Path>> {
-        Some(self.0)
+        self.0
     }
 }
 


### PR DESCRIPTION
- Introduced a new argument `--justfile <FILE>` in the `run` command to allow users to specify a custom justfile path.
- Updated the `with_justfile` method to accept an optional path, enhancing flexibility in command execution.