### PR TITLE
feat(seahaven-cli): add `init` command for project initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -201,6 +202,18 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.97"
-clap = { version = "4.5", features = ["cargo"] }
+clap = { version = "4.5", features = ["cargo", "derive"] }
 indoc = "2.0.6"
 seahaven-docker = { version = "0.1.0", path = "../seahaven-docker" }
 seahaven-file = { version = "0.1.0", path = "../seahaven-file" }

--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -1,5 +1,6 @@
 mod build;
 mod down;
+mod init;
 mod pull;
 mod root;
 mod run;

--- a/seahaven-cli/src/cmd/init.rs
+++ b/seahaven-cli/src/cmd/init.rs
@@ -1,0 +1,250 @@
+use std::path::PathBuf;
+
+use clap::ArgMatches;
+use tokio::process::Command;
+
+use crate::result::Result;
+
+pub const CMD: &str = "init";
+
+/// The template for the setup.yaml file
+const SETUP_YAML_TEMPLATE: &str = indoc::indoc! {r#"
+    ---
+    # The port where the app will be listening
+    APP_PORT=8080
+    ---
+
+    name: {name}
+    services:
+      app: # https://github.com/nginxinc/NGINX-Demos/tree/e76e10522f6de1df2ffeddb8ea6ac279cc81463d/nginx-hello
+        image: nginxdemos/hello:plain-text
+        ports: ["${APP_PORT}:80"]
+"#};
+
+/// The template for the justfile
+const JUSTFILE_TEMPLATE: &str = indoc::indoc! {r#"
+    # This justfile provides commands for interacting with the Seahaven setup.
+    # For more information on just, see https://just.systems/man/en/
+
+    # Default target - displays available commands and their descriptions
+    default:
+        @just --list
+
+    # Send an HTTP request to the app, and print the response
+    send-request:
+        @curl http://localhost:${APP_PORT}
+
+"#};
+
+/// The template for the README.md file
+const README_MD_TEMPLATE: &str = indoc::indoc! {r#"
+    # {name}
+
+    This is a Seahaven project:
+
+    - The [`setup.yaml`](./setup.yaml) file describes the services that make up the app.
+    - The [`justfile`](./justfile) describes various tasks for interacting with the app.
+
+    ## Bring up the app
+
+    Similar to `docker compose up`, pull the images, start the services, and detach.
+
+    ```
+    truman up --detach
+    ```
+
+    ## Bring down the app
+
+    Similar to `docker compose down`, stop the services, and teardown the setup.
+
+    ```
+    truman down
+    ```
+
+    ## Run a task
+
+    For example, send an HTTP request to the app, and print out the response:
+
+    ```
+    truman run send-request
+    ```
+
+"#};
+
+/// Create the init command
+pub fn cmd() -> clap::Command {
+    clap::Command::new(CMD)
+        .about("Initialize a new Seahaven project")
+        .args([
+            clap::arg!(--name <NAME> "Set the resulting package name, defaults to the directory name")
+                .value_parser(clap::value_parser!(String)),
+            clap::arg!(--vcs <VCS> "Initialize a version control repository")
+                .default_value("git")
+                .value_parser(clap::value_parser!(Vcs)),
+            clap::arg!(--"dry-run" "Execute command in dry run mode")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!([PATH] "The path to initialize the project in")
+                .default_value(".")
+                .value_parser(clap::value_parser!(PathBuf)),
+        ])
+}
+
+/// Run the init command
+pub async fn run(matches: &ArgMatches) -> Result<()> {
+    let target_dir = matches
+        .get_one::<PathBuf>("PATH")
+        .expect("Failed to get target directory");
+    let vcs = matches
+        .get_one::<Vcs>("vcs")
+        .expect("Failed to get VCS type");
+    let dry_run = matches.get_flag("dry-run");
+
+    // Initialize VCS if requested
+    if !dry_run {
+        match vcs {
+            Vcs::Git => {
+                // If the directory already exists, and it's a git repository, error out
+                if target_dir.join(".git").is_dir() {
+                    return Err(anyhow::anyhow!(
+                        "git repository already initialized in: {}",
+                        target_dir.join(".git").display()
+                    )
+                    .into());
+                }
+
+                git_init(target_dir).await?;
+            }
+            Vcs::Hg => {
+                // If the directory already exists, and it's a mercurial repository, error out
+                if target_dir.join(".hg").is_dir() {
+                    return Err(anyhow::anyhow!(
+                        "mercurial repository already initialized in: {}",
+                        target_dir.join(".hg").display()
+                    )
+                    .into());
+                }
+
+                hg_init(target_dir).await?;
+            }
+            Vcs::None => {
+                // If the directory already exists, error out
+                if target_dir.is_dir() {
+                    return Err(anyhow::anyhow!(
+                        "directory already exists: {}",
+                        target_dir.display()
+                    )
+                    .into());
+                }
+
+                tracing::debug!(
+                    "No VCS selected, creating directory: {}",
+                    target_dir.display()
+                );
+                std::fs::create_dir_all(target_dir)
+                    .map_err(|err| anyhow::anyhow!("directory creation failed: {}", err))?;
+            }
+        }
+    }
+    println!("Created directory: {}", target_dir.display());
+
+    // Get the project name, defaulting to the directory name if not provided
+    let name = match matches.get_one::<String>("name") {
+        Some(name) => name.to_string(),
+        None => target_dir
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Failed to get directory name"))?
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("Failed to convert directory name to string"))?
+            .to_string(),
+    };
+
+    // Create setup.yaml
+    let setup_yaml_path = target_dir.join("setup.yaml");
+    if !dry_run {
+        let setup_yaml_content = SETUP_YAML_TEMPLATE.replace("{name}", &name);
+
+        tracing::debug!("Creating setup.yaml: {}", setup_yaml_path.display());
+        std::fs::write(&setup_yaml_path, setup_yaml_content)
+            .map_err(|err| anyhow::anyhow!("Failed to write setup.yaml: {}", err))?;
+    }
+    println!("Added setup.yaml: {}", setup_yaml_path.display());
+
+    // Create justfile
+    let justfile_path = target_dir.join("justfile");
+    if !dry_run {
+        tracing::debug!("Creating justfile: {}", justfile_path.display());
+        std::fs::write(&justfile_path, JUSTFILE_TEMPLATE)
+            .map_err(|err| anyhow::anyhow!("Failed to write justfile: {}", err))?;
+    }
+    println!("Added justfile: {}", justfile_path.display());
+
+    // Create README.md
+    let readme_path = target_dir.join("README.md");
+    if !dry_run {
+        let readme_content = README_MD_TEMPLATE.replace("{name}", &name);
+
+        tracing::debug!("Creating README.md: {}", readme_path.display());
+        std::fs::write(&readme_path, readme_content)
+            .map_err(|err| anyhow::anyhow!("Failed to write README.md: {}", err))?;
+    }
+    println!("Added README.md: {}", readme_path.display());
+
+    indoc::printdoc!(
+        r#"
+        ==================================================
+        New Seahaven setup initialized: {}
+        ===================================================
+        "#,
+        setup_yaml_path.display(),
+    );
+
+    Ok(())
+}
+/// Version control system to initialize
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum Vcs {
+    /// Git version control
+    #[default]
+    Git,
+    /// Mercurial version control
+    Hg,
+    /// No version control
+    None,
+}
+
+async fn git_init(target_dir: &PathBuf) -> Result<()> {
+    tracing::debug!("git init: {}", target_dir.display());
+
+    let status = Command::new("git")
+        .arg("init")
+        .arg("--quiet")
+        .arg(target_dir)
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("git init failed: {}", err))?
+        .wait()
+        .await
+        .map_err(|err| anyhow::anyhow!("git init failed: {}", err))?;
+    if !status.success() {
+        return Err(anyhow::anyhow!("git init failed: {}", status).into());
+    }
+
+    Ok(())
+}
+async fn hg_init(target_dir: &PathBuf) -> Result<()> {
+    tracing::debug!("hg init: {}", target_dir.display());
+
+    let status = Command::new("hg")
+        .arg("init")
+        .arg("--quiet")
+        .arg(target_dir)
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("hg init failed: {}", err))?
+        .wait()
+        .await
+        .map_err(|err| anyhow::anyhow!("hg init failed: {}", err))?;
+    if !status.success() {
+        return Err(anyhow::anyhow!("hg init failed: {}", status).into());
+    }
+
+    Ok(())
+}

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{build, down, pull, run, setup, up};
+use super::{build, down, init, pull, run, setup, up};
 use crate::result::Result;
 
 /// Create and execute the DIPs CLI command line interface
@@ -9,6 +9,7 @@ pub async fn cmd_run() -> Result<()> {
         .subcommands([
             build::cmd(),
             down::cmd(),
+            init::cmd(),
             pull::cmd(),
             run::cmd(),
             setup::cmd(),
@@ -27,6 +28,7 @@ pub async fn cmd_run() -> Result<()> {
     match matches.subcommand() {
         Some((build::CMD, matches)) => build::run(matches).await,
         Some((down::CMD, matches)) => down::run(matches).await,
+        Some((init::CMD, matches)) => init::run(matches).await,
         Some((pull::CMD, matches)) => pull::run(matches).await,
         Some((run::CMD, matches)) => run::run(matches).await,
         Some((setup::CMD, matches)) => setup::run(matches).await,

--- a/seahaven-cli/src/cmd/up.rs
+++ b/seahaven-cli/src/cmd/up.rs
@@ -80,7 +80,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .with_plain_progress()
         .up()
         .with_build(matches.get_flag("build"))
-        .with_detached(matches.get_flag("detach"))
+        .with_detach(matches.get_flag("detach"))
         .with_services(matches.get_many::<String>("SERVICE").unwrap_or_default())
         .with_dry_run(matches.get_flag("dry-run"))
         .into_command();

--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -45,7 +45,7 @@
 //! let mut compose_cmd = DockerCmd::new()
 //!     .compose()
 //!     .up()
-//!     .with_detached(true)
+//!     .with_detach(true)
 //!     .with_service("my-service");
 //!
 //! let command = compose_cmd.into_command();
@@ -60,7 +60,7 @@
 //!     .compose()
 //!     .up()
 //!     .with_progress_json() // ❌ Error!
-//!     .with_detached();
+//!     .with_detach();
 //! ```
 
 mod common;

--- a/seahaven-docker/src/cmd/compose/up.rs
+++ b/seahaven-docker/src/cmd/compose/up.rs
@@ -1,13 +1,13 @@
 use super::{IntoCmdOptValue, IntoCommand};
 
 pub struct DockerComposeUpCmd<
-    D = DetachedNotSet,
+    D = DetachNotSet,
     B = BuildNotSet,
     DR = DryRunNotSet,
     S = ServicesNotSet,
 > {
     cmd: tokio::process::Command,
-    detached_opt: D,
+    detach_opt: D,
     build_opt: B,
     dry_run_opt: DR,
     services_opt: S,
@@ -17,7 +17,7 @@ impl DockerComposeUpCmd {
     pub(crate) fn new(cmd: impl IntoCommand) -> DockerComposeUpCmd {
         DockerComposeUpCmd {
             cmd: cmd.into_command(),
-            detached_opt: DetachedNotSet,
+            detach_opt: DetachNotSet,
             build_opt: BuildNotSet,
             dry_run_opt: DryRunNotSet,
             services_opt: ServicesNotSet,
@@ -27,7 +27,7 @@ impl DockerComposeUpCmd {
 
 impl<D, B, DR, S> IntoCommand for DockerComposeUpCmd<D, B, DR, S>
 where
-    D: DetachedOpt,
+    D: DetachOpt,
     B: BuildOpt,
     DR: DryRunOpt,
     S: ServicesOpt,
@@ -43,9 +43,9 @@ where
             cmd.arg("--build");
         }
 
-        // --detached
-        if matches!(self.detached_opt.into_value(), Some(true)) {
-            cmd.arg("--detached");
+        // --detach
+        if matches!(self.detach_opt.into_value(), Some(true)) {
+            cmd.arg("--detach");
         }
 
         // --dry-run
@@ -62,20 +62,20 @@ where
     }
 }
 
-impl<B, DR, S> DockerComposeUpCmd<DetachedNotSet, B, DR, S>
+impl<B, DR, S> DockerComposeUpCmd<DetachNotSet, B, DR, S>
 where
     B: BuildOpt,
     DR: DryRunOpt,
     S: ServicesOpt,
 {
-    /// Run containers in the background with the `--detached` flag.
+    /// Run containers in the background with the `--detach` flag.
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/up/)
     /// for more information.
-    pub fn with_detached(self, detached: bool) -> DockerComposeUpCmd<DetachedSet, B, DR, S> {
+    pub fn with_detach(self, detach: bool) -> DockerComposeUpCmd<DetachSet, B, DR, S> {
         DockerComposeUpCmd {
             cmd: self.cmd,
-            detached_opt: DetachedSet(detached),
+            detach_opt: DetachSet(detach),
             build_opt: self.build_opt,
             dry_run_opt: self.dry_run_opt,
             services_opt: self.services_opt,
@@ -85,7 +85,7 @@ where
 
 impl<D, DR, S> DockerComposeUpCmd<D, BuildNotSet, DR, S>
 where
-    D: DetachedOpt,
+    D: DetachOpt,
     DR: DryRunOpt,
     S: ServicesOpt,
 {
@@ -96,7 +96,7 @@ where
     pub fn with_build(self, build: bool) -> DockerComposeUpCmd<D, BuildSet, DR, S> {
         DockerComposeUpCmd {
             cmd: self.cmd,
-            detached_opt: self.detached_opt,
+            detach_opt: self.detach_opt,
             build_opt: BuildSet(build),
             dry_run_opt: self.dry_run_opt,
             services_opt: self.services_opt,
@@ -106,7 +106,7 @@ where
 
 impl<D, B, S> DockerComposeUpCmd<D, B, DryRunNotSet, S>
 where
-    D: DetachedOpt,
+    D: DetachOpt,
     B: BuildOpt,
     S: ServicesOpt,
 {
@@ -117,7 +117,7 @@ where
     pub fn with_dry_run(self, dry_run: bool) -> DockerComposeUpCmd<D, B, DryRunSet, S> {
         DockerComposeUpCmd {
             cmd: self.cmd,
-            detached_opt: self.detached_opt,
+            detach_opt: self.detach_opt,
             build_opt: self.build_opt,
             dry_run_opt: DryRunSet(dry_run),
             services_opt: self.services_opt,
@@ -127,7 +127,7 @@ where
 
 impl<D, B, DR> DockerComposeUpCmd<D, B, DR, ServicesNotSet>
 where
-    D: DetachedOpt,
+    D: DetachOpt,
     B: BuildOpt,
     DR: DryRunOpt,
 {
@@ -157,7 +157,7 @@ where
 
         DockerComposeUpCmd {
             cmd: self.cmd,
-            detached_opt: self.detached_opt,
+            detach_opt: self.detach_opt,
             build_opt: self.build_opt,
             dry_run_opt: self.dry_run_opt,
             services_opt: ServicesSet(services),
@@ -178,27 +178,27 @@ where
     }
 }
 
-/// A trait that represents the detached option for the `docker compose up` command.
+/// A trait that represents the detach option for the `docker compose up` command.
 #[allow(private_bounds)]
-pub trait DetachedOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+pub trait DetachOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
 
-pub struct DetachedNotSet;
+pub struct DetachNotSet;
 
-impl DetachedOpt for DetachedNotSet {}
-impl _priv::Sealed for DetachedNotSet {}
+impl DetachOpt for DetachNotSet {}
+impl _priv::Sealed for DetachNotSet {}
 
-impl IntoCmdOptValue<bool> for DetachedNotSet {
+impl IntoCmdOptValue<bool> for DetachNotSet {
     fn into_value(self) -> Option<bool> {
         None
     }
 }
 
-pub struct DetachedSet(bool);
+pub struct DetachSet(bool);
 
-impl DetachedOpt for DetachedSet {}
-impl _priv::Sealed for DetachedSet {}
+impl DetachOpt for DetachSet {}
+impl _priv::Sealed for DetachSet {}
 
-impl IntoCmdOptValue<bool> for DetachedSet {
+impl IntoCmdOptValue<bool> for DetachSet {
     fn into_value(self) -> Option<bool> {
         Some(self.0)
     }

--- a/seahaven-docker/src/cmd/tests/it_compose_up.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_up.rs
@@ -29,7 +29,7 @@ async fn run_docker_compose_up_detached() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_detached(true)
+        .with_detach(true)
         .into_command();
 
     //* When
@@ -39,7 +39,7 @@ async fn run_docker_compose_up_detached() {
     let output = res.expect("Failed to run docker compose up with detached flag");
     let args = parse_fixture_exe_output(&output);
 
-    assert_eq!(args, ["compose", "up", "--detached"]);
+    assert_eq!(args, ["compose", "up", "--detach"]);
 }
 
 #[tokio::test]
@@ -118,7 +118,7 @@ async fn run_docker_compose_up_detached_with_build() {
         .compose()
         .up()
         .with_build(true)
-        .with_detached(true)
+        .with_detach(true)
         .into_command();
 
     //* When
@@ -128,7 +128,7 @@ async fn run_docker_compose_up_detached_with_build() {
     let output = res.expect("Failed to run docker compose up with build and detached flags");
     let args = parse_fixture_exe_output(&output);
 
-    assert_eq!(args, ["compose", "up", "--build", "--detached"]);
+    assert_eq!(args, ["compose", "up", "--build", "--detach"]);
 }
 
 #[tokio::test]
@@ -141,7 +141,7 @@ async fn run_docker_compose_up_detached_with_services() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_detached(true)
+        .with_detach(true)
         .with_services(services)
         .into_command();
 
@@ -154,7 +154,7 @@ async fn run_docker_compose_up_detached_with_services() {
 
     assert_eq!(
         args,
-        ["compose", "up", "--detached", "api-service", "web-service"]
+        ["compose", "up", "--detach", "api-service", "web-service"]
     );
 }
 
@@ -196,7 +196,7 @@ async fn run_docker_compose_up_with_all_options() {
         .compose()
         .up()
         .with_build(true)
-        .with_detached(true)
+        .with_detach(true)
         .with_services(services)
         .into_command();
 
@@ -213,7 +213,7 @@ async fn run_docker_compose_up_with_all_options() {
             "compose",
             "up",
             "--build",
-            "--detached",
+            "--detach",
             "api-service",
             "web-service",
             "db-service"
@@ -255,7 +255,7 @@ async fn run_docker_compose_up_detached_with_single_service() {
     let mut cmd = DockerCmd::with_executable(exe)
         .compose()
         .up()
-        .with_detached(true)
+        .with_detach(true)
         .with_service(service)
         .into_command();
 
@@ -267,7 +267,7 @@ async fn run_docker_compose_up_detached_with_single_service() {
         res.expect("Failed to run docker compose up with detached flag and single service");
     let args = parse_fixture_exe_output(&output);
 
-    assert_eq!(args, ["compose", "up", "--detached", "api-service"]);
+    assert_eq!(args, ["compose", "up", "--detach", "api-service"]);
 }
 
 #[tokio::test]
@@ -281,7 +281,7 @@ async fn run_docker_compose_up_with_detached_build_and_single_service() {
         .compose()
         .up()
         .with_build(true)
-        .with_detached(true)
+        .with_detach(true)
         .with_service(service)
         .into_command();
 
@@ -294,7 +294,7 @@ async fn run_docker_compose_up_with_detached_build_and_single_service() {
 
     assert_eq!(
         args,
-        ["compose", "up", "--build", "--detached", "api-service"]
+        ["compose", "up", "--build", "--detach", "api-service"]
     );
 }
 


### PR DESCRIPTION
- Introduced a new `init` command to initialize a Seahaven project, creating necessary files such as `setup.yaml`, `justfile`, and `README.md`.
- Updated `Cargo.toml` to include the `derive` feature for the `clap` dependency.
- Modified the command structure to incorporate the new `init` command in the CLI.