### PR TITLE
feat(seahaven-cli): integrate build-info for `version` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,10 +131,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "build-info"
+version = "0.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "288657edd15bfa5a7f30ca3b123c1af2c503eaf218e517fa10bc9063dbc2ad99"
+dependencies = [
+ "bincode",
+ "build-info-common",
+ "build-info-proc",
+]
+
+[[package]]
+name = "build-info-build"
+version = "0.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3146483d5bc5081ec26f9c4e60232e770980d750b2802d6cc2563cded665cc73"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "build-info-common",
+ "cargo_metadata",
+ "chrono",
+ "git2",
+ "glob",
+ "pretty_assertions",
+ "rustc_version",
+ "serde_json",
+ "zstd",
+]
+
+[[package]]
+name = "build-info-common"
+version = "0.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8524ad59f5958f37f95e66bf6c9a8fa8440c4f56c069247c44244434cfca3eb1"
+dependencies = [
+ "chrono",
+ "derive_more",
+ "semver",
+ "serde",
+]
+
+[[package]]
+name = "build-info-proc"
+version = "0.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b58fb02636d968e8327d84a5a256df9704ac27a1eda98429c35dbe50a278f69"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bincode",
+ "build-info-common",
+ "chrono",
+ "num-bigint",
+ "num-traits",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+ "zstd",
+]
 
 [[package]]
 name = "bumpalo"
@@ -149,11 +222,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -282,6 +389,33 @@ dependencies = [
  "powerfmt",
  "serde",
 ]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
@@ -469,6 +603,25 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "git2"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5220b8ba44c68a9a7f7a7659e864dd73692e417ef0211bea133c7b74e031eeb9"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -842,6 +995,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +1025,30 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.18.1+1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -968,10 +1155,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1076,6 +1282,16 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-error-attr2"
@@ -1233,6 +1449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,11 +1535,14 @@ name = "seahaven-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "build-info",
+ "build-info-build",
  "clap",
  "indoc",
  "seahaven-docker",
  "seahaven-file",
  "seahaven-just",
+ "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1444,6 +1672,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -1891,6 +2120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,6 +2570,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,4 +2646,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -14,13 +14,18 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.97"
+build-info = "0.0.40"
 clap = { version = "4.5", features = ["cargo", "derive"] }
 indoc = "2.0.6"
 seahaven-docker = { version = "0.1.0", path = "../seahaven-docker" }
 seahaven-file = { version = "0.1.0", path = "../seahaven-file" }
 seahaven-just = { version = "0.1.0", path = "../seahaven-just" }
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
 tempfile = "3.19.1"
 thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "macros"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+
+[build-dependencies]
+build-info-build = "0.0.40"

--- a/seahaven-cli/build.rs
+++ b/seahaven-cli/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    // Generates runtime-accessible build information.
+    // Collects metadata including:
+    // - Git commit hash
+    // - Build timestamp
+    // - Compiler version
+    // - Build profile
+    build_info_build::build_script();
+}

--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -6,5 +6,6 @@ mod root;
 mod run;
 mod setup;
 mod up;
+mod version;
 
 pub use root::cmd_run as run;

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{build, down, init, pull, run, setup, up};
+use super::{build, down, init, pull, run, setup, up, version};
 use crate::result::Result;
 
 /// Create and execute the DIPs CLI command line interface
@@ -14,6 +14,7 @@ pub async fn cmd_run() -> Result<()> {
             run::cmd(),
             setup::cmd(),
             up::cmd(),
+            version::cmd(),
         ])
         .arg(
             clap::arg!(-f --file <FILE> "The seahaven setup file")
@@ -33,6 +34,7 @@ pub async fn cmd_run() -> Result<()> {
         Some((run::CMD, matches)) => run::run(matches).await,
         Some((setup::CMD, matches)) => setup::run(matches).await,
         Some((up::CMD, matches)) => up::run(matches).await,
+        Some((version::CMD, matches)) => version::run(matches).await,
         _ => Err(anyhow::anyhow!("No command specified").into()),
     }
 }

--- a/seahaven-cli/src/cmd/version.rs
+++ b/seahaven-cli/src/cmd/version.rs
@@ -1,0 +1,160 @@
+use build_info::BuildInfo;
+
+use crate::result::Result;
+
+// Generate the build info function.
+build_info::build_info!(fn get_build_info);
+
+pub const CMD: &str = "version";
+
+pub fn cmd() -> clap::Command {
+    clap::Command::new(CMD)
+        .about("Print version information")
+        .args([
+            clap::arg!(--short "Print version information in short format")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!(--json "Print version information in JSON format")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!(--full "Print version information in full format")
+                .action(clap::ArgAction::SetTrue),
+        ])
+        .group(clap::ArgGroup::new("format").args(["short", "full", "json"]))
+}
+
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    let format = if matches.get_flag("short") {
+        Format::Short
+    } else if matches.get_flag("json") {
+        Format::Json
+    } else if matches.get_flag("full") {
+        Format::Full
+    } else {
+        Format::Default
+    };
+
+    let info = get_build_info();
+    match format {
+        Format::Short => {
+            println!("{}", info.crate_info.version);
+        }
+        Format::Default => {
+            println!(
+                "truman v{version} ({commit} {date})",
+                version = info.crate_info.version,
+                commit = format_build_info_commit_short_id(info),
+                date = format_build_info_commit_date(info)
+            );
+        }
+        Format::Json => {
+            let info_json = serde_json::to_string(&info)
+                .map_err(|err| anyhow::anyhow!("Failed to serialize build info: {}", err))?;
+            println!("{}", info_json);
+        }
+        Format::Full => {
+            indoc::printdoc! {
+                r#"
+                truman v{version}
+                commit: {commit} ({commit_date})
+                build:
+                  profile: {build_profile}
+                  date: {build_timestamp}
+                  target: {build_target}
+                  cpu: {build_target_cpu_arch} ({build_target_cpu_features})
+                compiler:
+                  version: rustc {compiler_version}
+                  channel: {compiler_channel}
+                  commit: {compiler_commit} ({compiler_commit_date})
+                  host: {compiler_host_triple}
+                "#,
+                version=info.crate_info.version,
+                commit=format_build_info_commit(info),
+                commit_date=format_build_info_commit_date(info),
+                build_profile=info.profile,
+                build_timestamp=info.timestamp,
+                build_target=info.target.triple,
+                build_target_cpu_arch=info.target.cpu.arch,
+                build_target_cpu_features=format_build_info_target_cpu_features(info),
+                compiler_version=info.compiler.version,
+                compiler_channel=info.compiler.channel,
+                compiler_commit=format_build_info_compiler_commit(info),
+                compiler_commit_date=format_build_info_compiler_commit_date(info),
+                compiler_host_triple=info.compiler.host_triple,
+            };
+        }
+    }
+
+    Ok(())
+}
+
+/// The format of the version information.
+#[derive(Debug, Clone, Copy)]
+enum Format {
+    /// Default format.
+    Default,
+    /// Print version information in short format.
+    Short,
+    /// Print version information in full format.
+    Full,
+    /// Print version information in JSON format.
+    Json,
+}
+
+/// Format the build commit hash (version_control.git.commit_short_id)
+fn format_build_info_commit_short_id(info: &BuildInfo) -> String {
+    match info.version_control.as_ref().and_then(|vc| vc.git()) {
+        Some(git) => {
+            let hash = &git.commit_short_id;
+            if git.dirty {
+                format!("{}-dirty", hash)
+            } else {
+                hash.clone()
+            }
+        }
+        None => "unknown".to_string(),
+    }
+}
+
+/// Format the build commit hash (version_control.git.commit_id)
+fn format_build_info_commit(info: &BuildInfo) -> String {
+    match info.version_control.as_ref().and_then(|vc| vc.git()) {
+        Some(git) => {
+            let hash = &git.commit_id;
+            if git.dirty {
+                format!("{}-dirty", hash)
+            } else {
+                hash.clone()
+            }
+        }
+        None => "unknown".to_string(),
+    }
+}
+
+/// Format the build commit date (version_control.git.commit_timestamp)
+fn format_build_info_commit_date(info: &BuildInfo) -> String {
+    match info.version_control.as_ref().and_then(|vc| vc.git()) {
+        // build-info has disabled the `chrono/alloc` feature, so we cannot use custom format
+        Some(git) => git.commit_timestamp.to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Format the compiler commit hash (compiler.commit_id)
+fn format_build_info_compiler_commit(info: &BuildInfo) -> String {
+    match info.compiler.commit_id.as_ref() {
+        Some(commit) => commit.clone(),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Format the compiler commit date (compiler.commit_date)
+fn format_build_info_compiler_commit_date(info: &BuildInfo) -> String {
+    match info.compiler.commit_date.as_ref() {
+        Some(date) => date.to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Format the CPU features (target.cpu.features)
+fn format_build_info_target_cpu_features(info: &BuildInfo) -> String {
+    info.target.cpu.features.join(", ")
+}


### PR DESCRIPTION
- Added a new `version` command to the Seahaven CLI that prints version information, including build metadata such as Git commit hash and build timestamp.
- Introduced a build script to generate runtime-accessible build information.
- Updated `Cargo.toml` to include `build-info` and `build-info-build` dependencies.
- Refactored command structure to incorporate the new `version` command.