### PR TITLE
feat(seahaven-cli): check for required commands

### DIFF
--- a/seahaven-cli/src/cmd/build.rs
+++ b/seahaven-cli/src/cmd/build.rs
@@ -23,6 +23,12 @@ pub fn cmd() -> clap::Command {
 
 /// The `build` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    // TODO: Check for the docker compose and buildx plugins
+    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");
@@ -30,7 +36,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    // Load the setup file
     let setup_file = File::open(setup_file)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
@@ -85,7 +90,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         );
 
     // Create and run the docker command
-    let mut command = DockerCmd::new()
+    let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
         .with_file(content_file_path)
         .with_env_file(env_file_path)

--- a/seahaven-cli/src/cmd/down.rs
+++ b/seahaven-cli/src/cmd/down.rs
@@ -23,6 +23,12 @@ pub fn cmd() -> clap::Command {
 
 /// The `down` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    // TODO: Check for the docker compose plugin
+    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");
@@ -30,7 +36,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    // Load the setup file
     let setup_file = File::open(setup_file)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
@@ -72,7 +77,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
 
-    let mut command = DockerCmd::new()
+    let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
         .with_file(content_file_path)
         .with_env_file(env_file_path)

--- a/seahaven-cli/src/cmd/pull.rs
+++ b/seahaven-cli/src/cmd/pull.rs
@@ -20,6 +20,12 @@ pub fn cmd() -> clap::Command {
 
 /// The `pull` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    // TODO: Check for the docker compose plugin
+    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");
@@ -27,7 +33,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    // Load the setup file
     let setup_file = File::open(setup_file)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
@@ -70,7 +75,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     // Create and run the docker command
-    let mut command = DockerCmd::new()
+    let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
         .with_file(content_file_path)
         .with_env_file(env_file_path)

--- a/seahaven-cli/src/cmd/run.rs
+++ b/seahaven-cli/src/cmd/run.rs
@@ -23,6 +23,11 @@ pub fn cmd() -> clap::Command {
 
 /// The `run` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    let just_exe = seahaven_just::exe::resolve_cli_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve just executable: {err}"))?;
+
+    // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");
@@ -30,7 +35,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    // Load the setup file
     let setup_file = File::open(setup_file)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
@@ -58,7 +62,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     // Create and run the just command
-    let mut command = JustCmd::new()
+    let mut command = JustCmd::with_executable(just_exe)
         .with_justfile::<&PathBuf>(matches.get_one::<PathBuf>("justfile"))
         .with_env_file(env_file_path)
         .with_dry_run(matches.get_flag("dry-run"))

--- a/seahaven-cli/src/cmd/up.rs
+++ b/seahaven-cli/src/cmd/up.rs
@@ -24,6 +24,12 @@ pub fn cmd() -> clap::Command {
 
 /// The `up` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    // TODO: Check for the docker compose plugin
+    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
         .expect("Failed to get setup file");
@@ -31,7 +37,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    // Load the setup file
     let setup_file = File::open(setup_file)
         .map(BufReader::new)
         .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
@@ -73,7 +78,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
 
-    let mut command = DockerCmd::new()
+    let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
         .with_file(content_file_path)
         .with_env_file(env_file_path)

--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -23,11 +23,15 @@
 //! ### Basic Docker Command
 //!
 //! ```rust
-//! use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+//! use seahaven_docker::{
+//!     cmd::{DockerCmd, IntoCommand},
+//!     exe::resolve_cli_executable,
+//! };
 //!
 //! // Get Docker version information
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let version_cmd = DockerCmd::new().version();
+//! let exe = resolve_cli_executable()?;
+//! let version_cmd = DockerCmd::with_executable(exe).version();
 //! let mut command = version_cmd.into_command();
 //!
 //! // Execute the command
@@ -39,17 +43,24 @@
 //! ### Docker Compose Command with Options
 //!
 //! ```rust
-//! use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+//! use seahaven_docker::{
+//!     cmd::{DockerCmd, IntoCommand},
+//!     exe::resolve_cli_executable,
+//! };
 //!
 //! // Configure and start services with Docker Compose
-//! let mut compose_cmd = DockerCmd::new()
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let exe = resolve_cli_executable()?;
+//! let mut compose_cmd = DockerCmd::with_executable(exe)
 //!     .compose()
 //!     .up()
 //!     .with_detach(true)
 //!     .with_service("my-service");
-//!
 //! let command = compose_cmd.into_command();
+//! # Ok(())
+//! # }
 //! ```
+//!
 //! Note that the order of method calls matters - `with_progress_json` must be called before `up`.
 //! The reverse order would not compile:
 //!

--- a/seahaven-docker/src/cmd/root.rs
+++ b/seahaven-docker/src/cmd/root.rs
@@ -4,34 +4,11 @@ use super::{
     common::IntoCommand, compose::DockerComposeCmd, system::DockerSystemCmd,
     version::DockerVersionCmd,
 };
-use crate::exe::{Executable, resolve_cli_executable};
+use crate::exe::Executable;
 
 pub struct DockerCmd(tokio::process::Command);
 
-impl Default for DockerCmd {
-    /// Create a new docker command
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if the docker CLI binary is not found.
-    fn default() -> Self {
-        let exe = resolve_cli_executable().expect("Docker CLI binary not found");
-        Self::with_executable(exe)
-    }
-}
-
 impl DockerCmd {
-    /// Create a new `docker` command
-    ///
-    /// This is equivalent to calling [`DockerCmd::default()`].
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if the docker CLI binary is not found.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Create a new `docker` command with a custom executable
     pub fn with_executable<B>(exe: B) -> Self
     where

--- a/seahaven-docker/tests/it_exe.rs
+++ b/seahaven-docker/tests/it_exe.rs
@@ -1,7 +1,4 @@
-use seahaven_docker::{
-    cmd::{DockerCmd, IntoCommand},
-    exe::{Executable, resolve_cli_executable},
-};
+use seahaven_docker::exe::{Executable, resolve_cli_executable};
 
 #[test_with::no_env(CI)]
 #[test]
@@ -32,31 +29,4 @@ fn executable_display_and_debug() {
     //* Then
     assert!(display_str.contains("docker"));
     assert!(debug_str.contains("docker"));
-}
-
-#[test_with::no_env(CI)]
-#[test]
-fn docker_cmd_default() {
-    //* Given
-    // Resolve the docker executable
-    let expected_exe = resolve_cli_executable().expect("docker CLI executable not found");
-
-    //* When
-    let command = DockerCmd::default().into_command();
-
-    // Get the program path
-    let prog_path = command.as_std().get_program();
-
-    //* Then
-    // Assert that the program path is a valid utf-8 string
-    let prog_path_str = prog_path
-        .to_str()
-        .expect("Program path should be a valid utf-8 string");
-    assert!(
-        prog_path_str.contains("docker"),
-        "Program path should contain 'docker'"
-    );
-
-    // Assert that the program path is the same as the resolved executable
-    assert_eq!(prog_path, expected_exe.as_ref());
 }

--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -9,7 +9,7 @@ use super::{
     dump::JustDumpCmd,
     version::JustVersionCmd,
 };
-use crate::exe::{Executable, resolve_cli_executable};
+use crate::exe::Executable;
 
 pub struct JustCmd<
     F = JustfileNotSet,
@@ -26,30 +26,7 @@ pub struct JustCmd<
     args_opt: A,
 }
 
-impl Default for JustCmd {
-    /// Create a new just command
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if the just CLI binary is not found.
-    fn default() -> Self {
-        let exe = resolve_cli_executable().expect("Just CLI binary not found");
-        Self::with_executable(exe)
-    }
-}
-
 impl JustCmd {
-    /// Create a new `just` command
-    ///
-    /// This is equivalent to calling [`JustCmd::default()`].
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if the just CLI binary is not found.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     /// Create a new `just` command with a custom executable
     pub fn with_executable<B>(exe: B) -> Self
     where

--- a/seahaven-just/tests/it_exe.rs
+++ b/seahaven-just/tests/it_exe.rs
@@ -1,7 +1,4 @@
-use seahaven_just::{
-    cmd::{IntoCommand, JustCmd},
-    exe::{Executable, resolve_cli_executable},
-};
+use seahaven_just::exe::{Executable, resolve_cli_executable};
 
 #[test_with::no_env(CI)]
 #[test]
@@ -32,31 +29,4 @@ fn executable_display_and_debug() {
     //* Then
     assert!(display_str.contains("just"));
     assert!(debug_str.contains("just"));
-}
-
-#[test_with::no_env(CI)]
-#[test]
-fn just_cmd_default() {
-    //* Given
-    // Resolve the just executable
-    let expected_exe = resolve_cli_executable().expect("just CLI executable not found");
-
-    //* When
-    let command = JustCmd::default().into_command();
-
-    // Get the program path
-    let prog_path = command.as_std().get_program();
-
-    //* Then
-    // Assert that the program path is a valid utf-8 string
-    let prog_path_str = prog_path
-        .to_str()
-        .expect("Program path should be a valid utf-8 string");
-    assert!(
-        prog_path_str.contains("just"),
-        "Program path should contain 'just'"
-    );
-
-    // Assert that the program path is the same as the resolved executable
-    assert_eq!(prog_path, expected_exe.as_ref());
 }


### PR DESCRIPTION
- Updated the `run`, `build`, `down`, `pull`, and `up` commands to resolve the Docker and Just CLI executables before execution, enhancing reliability.
- Removed default constructors for `DockerCmd` and `JustCmd`, replacing them with methods that accept custom executable paths.
- Cleaned up related tests to reflect the removal of default command constructors.