### PR TITLE
feat(seahaven-docker): enhance version fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,6 +1566,7 @@ dependencies = [
 name = "seahaven-docker"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "indoc",
  "semver",
  "serde",
@@ -1574,6 +1575,7 @@ dependencies = [
  "test-with",
  "thiserror",
  "tokio",
+ "tracing",
  "which",
 ]
 

--- a/seahaven-docker/Cargo.toml
+++ b/seahaven-docker/Cargo.toml
@@ -8,13 +8,15 @@ repository.workspace = true
 edition.workspace = true
 
 [dependencies]
+anyhow = "1.0.98"
 indoc = "2.0.6"
 semver = { version = "1.0.26", features = ["serde"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 serde_with = "3.12.0"
 thiserror = "2.0.12"
-tokio = { version = "1.44", default-features = false, features = ["macros", "process"] }
+tokio = { version = "1.44", default-features = false, features = ["macros", "process", "time"] }
+tracing = { version = "0.1.41", default-features = false, features = ["std"] }
 which = "7.0.2"
 
 [dev-dependencies]

--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -14,6 +14,7 @@
 //!
 //! The following Docker commands are currently supported:
 //!
+//! - `docker --version`
 //! - `docker version`
 //! - `docker system (info | prune)`
 //! - `docker compose (pull | build | up | down)`
@@ -77,11 +78,13 @@
 mod common;
 pub mod compose;
 mod root;
+mod root_version;
 pub mod system;
 pub mod version;
 
 pub use common::IntoCommand;
 pub use root::DockerCmd;
+pub use root_version::DockerRootVersionCmd;
 
 #[cfg(test)]
 mod tests {

--- a/seahaven-docker/src/cmd/root.rs
+++ b/seahaven-docker/src/cmd/root.rs
@@ -1,8 +1,8 @@
 use std::borrow::Borrow;
 
 use super::{
-    common::IntoCommand, compose::DockerComposeCmd, system::DockerSystemCmd,
-    version::DockerVersionCmd,
+    common::IntoCommand, compose::DockerComposeCmd, root_version::DockerRootVersionCmd,
+    system::DockerSystemCmd, version::DockerVersionCmd,
 };
 use crate::exe::Executable;
 
@@ -19,6 +19,11 @@ impl DockerCmd {
 }
 
 impl DockerCmd {
+    /// Create a new `docker --version` command
+    pub fn get_version(self) -> DockerRootVersionCmd {
+        DockerRootVersionCmd::new(self)
+    }
+
     /// Create a new `docker version` command
     pub fn version(self) -> DockerVersionCmd {
         DockerVersionCmd::new(self)

--- a/seahaven-docker/src/cmd/root_version.rs
+++ b/seahaven-docker/src/cmd/root_version.rs
@@ -1,0 +1,21 @@
+use super::common::IntoCommand;
+
+pub struct DockerRootVersionCmd(tokio::process::Command);
+
+impl DockerRootVersionCmd {
+    /// Create a new `docker --version` command
+    pub(crate) fn new(cmd: impl IntoCommand) -> Self {
+        Self(cmd.into_command())
+    }
+}
+
+impl IntoCommand for DockerRootVersionCmd {
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.0;
+
+        // Add the `--version` flag
+        cmd.arg("--version");
+
+        cmd
+    }
+}

--- a/seahaven-docker/src/cmd/tests/it_root.rs
+++ b/seahaven-docker/src/cmd/tests/it_root.rs
@@ -17,3 +17,20 @@ async fn run_docker_root() {
 
     assert_eq!(args, ["<no-args>"]);
 }
+
+#[tokio::test]
+async fn run_docker_root_version() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe).get_version().into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker --version");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--version"]);
+}

--- a/seahaven-docker/src/tests/it_version.rs
+++ b/seahaven-docker/src/tests/it_version.rs
@@ -13,10 +13,15 @@ async fn resolve_docker_version() {
     let res = get_docker_version_versions(&exe).await;
 
     //* Then
-    // Assert the different versions are greater than `0.0.0`
     let versions = res.expect("An error occurred while getting the docker version");
+
+    // Assert the client version is greater than `0.0.0`
     assert!(versions.client > semver::Version::new(0, 0, 0));
-    assert!(versions.engine > semver::Version::new(0, 0, 0));
+
+    // Assert the engine version, if present, is greater than `0.0.0`
+    if let Some(engine_version) = versions.engine {
+        assert!(engine_version > semver::Version::new(0, 0, 0));
+    }
 }
 
 #[test_with::no_env(CI)]
@@ -29,12 +34,14 @@ async fn resolve_docker_plugin_versions() {
     let res = get_docker_system_info_versions(&exe).await;
 
     //* Then
-    // Assert the `compose` and `buildx` plugin versions are present and their versions are greater than `0.0.0`
     let versions = res.expect("An error occurred while getting the docker plugin versions");
 
+    // Assert the `compose` plugin version, if present, is greater than `0.0.0`
     if let Some(compose_version) = versions.plugin_compose {
         assert!(compose_version > semver::Version::new(0, 0, 0));
     }
+
+    // Assert the `buildx` plugin version, if present, is greater than `0.0.0`
     if let Some(buildx_version) = versions.plugin_buildx {
         assert!(buildx_version > semver::Version::new(0, 0, 0));
     }

--- a/seahaven-docker/src/version.rs
+++ b/seahaven-docker/src/version.rs
@@ -7,8 +7,9 @@
 //!
 //! This version information is essential for ensuring compatibility and for troubleshooting issues.
 
-use std::borrow::Borrow;
+use std::{borrow::Borrow, process::Stdio, time::Duration};
 
+pub use semver;
 use serde_with::{DisplayFromStr, serde_as};
 
 use crate::{
@@ -18,23 +19,43 @@ use crate::{
 
 /// The Docker version
 ///
-/// This struct contains the version information of the Docker client, engine, and plugins.
+/// This struct contains the version information of the different Docker components.
 ///
 /// See [`fetch`] for more information.
 #[derive(Debug, Clone)]
 pub struct Version {
-    /// The client version
-    pub client: semver::Version,
-    /// The engine version
-    pub engine: semver::Version,
-    /// The compose plugin version
+    /// The CLI version
     ///
-    /// If the plugin is not installed, this will be `None`.
-    pub plugin_compose: Option<semver::Version>,
+    /// The version reported by the `docker --version` command.
+    pub cli: semver::Version,
+
+    /// The client version
+    ///
+    /// The version reported by the `docker version` command.
+    ///
+    /// The `docker version` can fail if the Docker daemon is not running. In this case, the version will be `None`.
+    pub client: Option<semver::Version>,
+
+    /// The engine version
+    ///
+    /// The version reported by the `docker version` command.
+    ///
+    /// The `docker version` can fail if the Docker daemon is not running. In this case, the version will be `None`.
+    pub engine: Option<semver::Version>,
+
     /// The buildx plugin version
+    ///
+    /// The version reported by the `docker system info` command.
     ///
     /// If the plugin is not installed, this will be `None`.
     pub plugin_buildx: Option<semver::Version>,
+
+    /// The compose plugin version
+    ///
+    /// The version reported by the `docker system info` command.
+    ///
+    /// If the plugin is not installed, this will be `None`.
+    pub plugin_compose: Option<semver::Version>,
 }
 
 /// Errors that can occur when retrieving Docker version information
@@ -43,23 +64,23 @@ pub enum Error {
     /// Failed to execute the Docker command
     #[error("Failed to execute '{cmd}': {src}")]
     CommandExecution {
-        cmd: &'static str,
+        cmd: String,
         #[source]
-        src: std::io::Error,
+        src: Box<dyn std::error::Error + Send + Sync>,
     },
 
     /// Failed to parse the Docker version output
     #[error("Failed to parse '{cmd}' output: {src}")]
     OutputParsing {
-        cmd: &'static str,
+        cmd: String,
         #[source]
-        src: serde_json::Error,
+        src: Box<dyn std::error::Error + Send + Sync>,
     },
 
     /// Failed to parse a version string
     #[error("Failed to parse '{cmd}' version string: {src}")]
     VersionParsing {
-        cmd: &'static str,
+        cmd: String,
         #[source]
         src: semver::Error,
     },
@@ -76,26 +97,97 @@ pub async fn fetch<E>(bin: &E) -> Result<Version, Error>
 where
     E: Borrow<Executable>,
 {
-    let (version, system_info) = tokio::try_join!(
+    let (cli_version, version, system_info) = tokio::join!(
+        get_docker_cli_version(bin.borrow()),
         get_docker_version_versions(bin.borrow()),
         get_docker_system_info_versions(bin.borrow())
-    )?;
+    );
+
+    let (client_version, engine_version) = match version {
+        Ok(version) => (Some(version.client), version.engine),
+        Err(_) => (None, None),
+    };
+
+    let (plugin_compose, plugin_buildx) = match system_info {
+        Ok(system_info) => (system_info.plugin_compose, system_info.plugin_buildx),
+        Err(_) => (None, None),
+    };
 
     Ok(Version {
-        client: version.client,
-        engine: version.engine,
-        plugin_compose: system_info.plugin_compose,
-        plugin_buildx: system_info.plugin_buildx,
+        cli: cli_version?,
+        client: client_version,
+        engine: engine_version,
+        plugin_buildx,
+        plugin_compose,
     })
 }
 
+/// Get the versions from the `docker --version` command
+pub(crate) async fn get_docker_cli_version(bin: &Executable) -> Result<semver::Version, Error> {
+    let mut cmd = DockerCmd::with_executable(bin).get_version().into_command();
+    let cmd_str = format!("{:?}", cmd.as_std());
+
+    tracing::debug!("docker --version cmd: {}", cmd_str);
+
+    let child = cmd
+        .kill_on_drop(true)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|err| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: err.into(),
+        })?;
+
+    let output = tokio::time::timeout(Duration::from_secs(10), child.wait_with_output())
+        .await
+        .map_err(|_| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: anyhow::anyhow!("Command timed out").into(),
+        })?
+        .map_err(|err| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: err.into(),
+        })?;
+
+    tracing::debug!("docker --version rc: {}", output.status);
+
+    let output_str = String::from_utf8(output.stdout).map_err(|err| Error::OutputParsing {
+        cmd: cmd_str.clone(),
+        src: err.into(),
+    })?;
+
+    // Extract the version from the output, expected output is: `Docker version 28.0.4, build b8034c0ed7`. Note the `,` after the version.
+    let version_str = output_str
+        .strip_prefix("Docker version ")
+        .and_then(|s| s.split(",").next())
+        .ok_or(Error::OutputParsing {
+            cmd: cmd_str.clone(),
+            src: anyhow::anyhow!("Invalid output format: {}", output_str).into(),
+        })?;
+
+    let version = semver::Version::parse(version_str).map_err(|err| Error::VersionParsing {
+        cmd: cmd_str,
+        src: err,
+    })?;
+
+    Ok(version)
+}
+
 /// The versions retrieved from the `docker version` command
+#[serde_as]
 #[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct DockerVersionVersions {
     /// The client version
     pub client: semver::Version,
+
     /// The engine version
-    pub engine: semver::Version,
+    ///
+    /// If the engine is not available, this will be `None`.
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde(default)]
+    pub engine: Option<semver::Version>,
 }
 
 /// Get the versions from the `docker version` command
@@ -106,27 +198,46 @@ pub(crate) async fn get_docker_version_versions(
     const DOCKER_VERSION_FMT: &str = indoc::indoc! {
         r#"{
           "client":"{{.Client.Version}}",
-          "client_api":"{{.Client.APIVersion}}",
+          "client_api":"{{.Client.APIVersion}}"{{if .Server}},
           "engine":"{{range .Server.Components}}{{if eq .Name "Engine"}}{{.Version}}{{end}}{{end}}",
-          "engine_api":"{{range .Server.Components}}{{if eq .Name "Engine"}}{{.Details.ApiVersion}}{{end}}{{end}}"
+          "engine_api":"{{range .Server.Components}}{{if eq .Name "Engine"}}{{.Details.ApiVersion}}{{end}}{{end}}"{{end}}
         }"#
     };
 
-    let output = DockerCmd::with_executable(bin)
+    let mut cmd = DockerCmd::with_executable(bin)
         .version()
         .with_custom_format(DOCKER_VERSION_FMT)
-        .into_command()
+        .into_command();
+    let cmd_str = format!("{:?}", cmd.as_std());
+
+    tracing::debug!("docker version cmd: {}", cmd_str);
+
+    let child = cmd
         .kill_on_drop(true)
-        .output()
-        .await
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .map_err(|err| Error::CommandExecution {
-            cmd: "docker version",
-            src: err,
+            cmd: cmd_str.clone(),
+            src: err.into(),
         })?;
 
+    let output = tokio::time::timeout(Duration::from_secs(10), child.wait_with_output())
+        .await
+        .map_err(|_| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: anyhow::anyhow!("Command timed out").into(),
+        })?
+        .map_err(|err| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: err.into(),
+        })?;
+
+    tracing::debug!("docker version rc: {}", output.status);
     serde_json::from_slice(&output.stdout).map_err(|err| Error::OutputParsing {
-        cmd: "docker version",
-        src: err,
+        cmd: cmd_str,
+        src: err.into(),
     })
 }
 
@@ -160,21 +271,40 @@ pub(crate) async fn get_docker_system_info_versions(
         }"#
     };
 
-    let output = DockerCmd::with_executable(bin)
+    let mut cmd = DockerCmd::with_executable(bin)
         .system()
         .info()
         .with_custom_format(DOCKER_SYSTEM_INFO_FMT)
-        .into_command()
+        .into_command();
+    let cmd_str = format!("{:?}", cmd.as_std());
+
+    tracing::debug!("docker system info cmd: {}", cmd_str);
+
+    let child = cmd
         .kill_on_drop(true)
-        .output()
-        .await
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
         .map_err(|err| Error::CommandExecution {
-            cmd: "docker system info",
-            src: err,
+            cmd: cmd_str.clone(),
+            src: err.into(),
         })?;
 
+    let output = tokio::time::timeout(Duration::from_secs(10), child.wait_with_output())
+        .await
+        .map_err(|_| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: anyhow::anyhow!("Command timed out").into(),
+        })?
+        .map_err(|err| Error::CommandExecution {
+            cmd: cmd_str.clone(),
+            src: err.into(),
+        })?;
+
+    tracing::debug!("docker system info rc: {}", output.status);
     serde_json::from_slice(&output.stdout).map_err(|err| Error::OutputParsing {
-        cmd: "docker system info",
-        src: err,
+        cmd: cmd_str,
+        src: err.into(),
     })
 }

--- a/seahaven-docker/tests/it_version.rs
+++ b/seahaven-docker/tests/it_version.rs
@@ -12,9 +12,16 @@ async fn resolve_docker_version() {
     //* Then
     let version = res.expect("An error occurred while getting the docker version");
 
+    // Assert the CLI version is greater than `0.0.0`
+    assert!(version.cli > semver::Version::new(0, 0, 0));
+
     // Assert the client and engine versions are greater than `0.0.0`
-    assert!(version.client > semver::Version::new(0, 0, 0));
-    assert!(version.engine > semver::Version::new(0, 0, 0));
+    if let Some(client_version) = version.client {
+        assert!(client_version > semver::Version::new(0, 0, 0));
+    }
+    if let Some(engine_version) = version.engine {
+        assert!(engine_version > semver::Version::new(0, 0, 0));
+    }
 
     // Assert the compose plugin version, if present, is greater than `0.0.0`
     if let Some(version) = version.plugin_compose {


### PR DESCRIPTION
- Added support for retrieving the Docker CLI version using the new `DockerRootVersionCmd`.
- Updated the `Version` struct to include the CLI version and adjusted error handling for command execution.
- Enhanced the `get_docker_version_versions` and `get_docker_system_info_versions` functions to improve version retrieval.
- Updated `Cargo.toml` to include `anyhow` and `tracing` dependencies, and modified `tokio` features.
- Added tests for the new version command functionality.