### PR TITLE
feat(seahaven-cli): validate Docker and Just CLI plugin versions

### DIFF
--- a/seahaven-cli/src/cmd/build.rs
+++ b/seahaven-cli/src/cmd/build.rs
@@ -24,9 +24,32 @@ pub fn cmd() -> clap::Command {
 /// The `build` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
-    // TODO: Check for the docker compose and buildx plugins
+    // - No min version for docker
+    // - No min version for docker compose plugin (required)
+    // - No min version for buildx plugin (required)
     let docker_exe = seahaven_docker::exe::resolve_cli_executable()
         .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    tracing::debug!("docker executable: {}", docker_exe);
+
+    let docker_version = seahaven_docker::version::fetch(&docker_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine docker version: {err}"))?;
+
+    tracing::debug!("docker version: {:?}", docker_version);
+
+    if docker_version.plugin_compose.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the docker compose plugin version. Is the docker compose plugin installed?"
+        )
+        .into());
+    }
+    if docker_version.plugin_buildx.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the buildx plugin version. Is the buildx plugin installed?"
+        )
+        .into());
+    }
 
     // Load the setup file
     let setup_file = matches

--- a/seahaven-cli/src/cmd/down.rs
+++ b/seahaven-cli/src/cmd/down.rs
@@ -24,9 +24,25 @@ pub fn cmd() -> clap::Command {
 /// The `down` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
-    // TODO: Check for the docker compose plugin
+    // - No min version for docker
+    // - No min version for docker compose plugin (required)
     let docker_exe = seahaven_docker::exe::resolve_cli_executable()
         .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    tracing::debug!("docker executable: {}", docker_exe);
+
+    let docker_version = seahaven_docker::version::fetch(&docker_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine docker version: {err}"))?;
+
+    tracing::debug!("docker version: {:?}", docker_version);
+
+    if docker_version.plugin_compose.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the docker compose plugin version. Is the docker compose plugin installed?"
+        )
+        .into());
+    }
 
     // Load the setup file
     let setup_file = matches

--- a/seahaven-cli/src/cmd/pull.rs
+++ b/seahaven-cli/src/cmd/pull.rs
@@ -21,9 +21,25 @@ pub fn cmd() -> clap::Command {
 /// The `pull` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
-    // TODO: Check for the docker compose plugin
+    // - No min version for docker
+    // - No min version for docker compose plugin (required)
     let docker_exe = seahaven_docker::exe::resolve_cli_executable()
         .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    tracing::debug!("docker executable: {}", docker_exe);
+
+    let docker_version = seahaven_docker::version::fetch(&docker_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine docker version: {err}"))?;
+
+    tracing::debug!("docker version: {:?}", docker_version);
+
+    if docker_version.plugin_compose.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the docker compose plugin version. Is the docker compose plugin installed?"
+        )
+        .into());
+    }
 
     // Load the setup file
     let setup_file = matches

--- a/seahaven-cli/src/cmd/run.rs
+++ b/seahaven-cli/src/cmd/run.rs
@@ -24,8 +24,17 @@ pub fn cmd() -> clap::Command {
 /// The `run` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
+    // - No min version for just
     let just_exe = seahaven_just::exe::resolve_cli_executable()
         .map_err(|err| anyhow::anyhow!("Failed to resolve just executable: {err}"))?;
+
+    tracing::debug!("just executable: {}", just_exe);
+
+    let just_version = seahaven_just::version::fetch(&just_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine just version: {err}"))?;
+
+    tracing::debug!("just version: {}", just_version);
 
     // Load the setup file
     let setup_file = matches

--- a/seahaven-cli/src/cmd/up.rs
+++ b/seahaven-cli/src/cmd/up.rs
@@ -25,9 +25,25 @@ pub fn cmd() -> clap::Command {
 /// The `up` command implementation
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
-    // TODO: Check for the docker compose plugin
+    // - No min version for docker
+    // - No min version for docker compose plugin (required)
     let docker_exe = seahaven_docker::exe::resolve_cli_executable()
         .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+
+    tracing::debug!("docker executable: {}", docker_exe);
+
+    let docker_version = seahaven_docker::version::fetch(&docker_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine docker version: {err}"))?;
+
+    tracing::debug!("docker version: {:?}", docker_version);
+
+    if docker_version.plugin_compose.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the docker compose plugin version. Is the docker compose plugin installed?"
+        )
+        .into());
+    }
 
     // Load the setup file
     let setup_file = matches


### PR DESCRIPTION
- Enhanced the `run`, `build`, `down`, `pull`, and `up` commands to check for the presence of required Docker plugins (compose and buildx) and Just CLI version before execution.
- Added debug logging for the resolved executable paths and their respective versions.
- Improved error handling to provide clear messages if required plugins are not installed.