### PR TITLE
feat(seahaven-cli): introduce `eject` command

### DIFF
--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -1,5 +1,6 @@
 mod build;
 mod down;
+mod eject;
 mod init;
 mod pull;
 mod root;

--- a/seahaven-cli/src/cmd/eject.rs
+++ b/seahaven-cli/src/cmd/eject.rs
@@ -1,0 +1,100 @@
+use std::{fs::File, io::BufReader, path::PathBuf};
+
+use crate::result::Result;
+
+/// The `eject` command name
+pub const CMD: &str = "eject";
+
+/// Create the `eject` command
+pub fn cmd() -> clap::Command {
+    clap::command!(CMD)
+        .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
+        .args([clap::arg!(-o --"output-dir" <DIR> "The output directory")
+            .default_value(".")
+            .value_parser(clap::value_parser!(PathBuf))])
+}
+
+/// The `eject` command implementation
+///
+/// This function ejects the setup.yaml file to get the docker-compose.yaml and .env files.
+/// This is a one-way operation. Once ejected, you will need to manage the configuration manually.
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Display warning message about the one-way nature of the operation
+    indoc::eprintdoc! {r#"
+        \x1b[33m\x1b[1mWARNING\x1b[0m: This is a one-way operation. Once ejected, you will need to manage the configuration manually.
+        \x1b[33m\x1b[1mWARNING\x1b[0m: The ejected files will be created in the specified output directory.
+        \x1b[33m\x1b[1mWARNING\x1b[0m: You can always regenerate the setup.yaml file from the ejected files if needed.
+        \x1b[33m\x1b[1mWARNING\x1b[0m: Are you sure you want to continue? [y/N] "#
+    }
+
+    // Get user confirmation
+    let mut input = String::new();
+    std::io::stdin()
+        .read_line(&mut input)
+        .map_err(|err| anyhow::anyhow!("Failed to read user input: {err}"))?;
+    if !input.trim().to_lowercase().starts_with('y') {
+        eprintln!("Operation cancelled.");
+        return Ok(());
+    }
+
+    // Get the setup file path from the command line (required)
+    let setup_file_path = matches
+        .get_one::<PathBuf>("file")
+        .expect("Failed to get setup file path");
+    if !setup_file_path.is_file() {
+        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
+    }
+
+    // Get the output directory from the command line (required)
+    let output_dir = matches
+        .get_one::<PathBuf>("output-dir")
+        .expect("Failed to get output directory");
+    if !output_dir.is_dir() {
+        return Err(anyhow::anyhow!("Invalid output directory: {}", output_dir.display()).into());
+    }
+
+    // Read and parse the setup file
+    let file = File::open(setup_file_path)
+        .map(BufReader::new)
+        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
+    let (env, content) = seahaven_file::from_reader(file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
+        .unpack();
+
+    // Transform the content into a compose file
+    let compose_file = seahaven_file::try_into_compose_file(content)
+        .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
+
+    // Serialize the compose file to a string
+    let compose_content = seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
+        .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
+
+    // Write the docker-compose.yaml file
+    let output_compose_file_path = output_dir.join("docker-compose.yaml");
+    std::fs::write(&output_compose_file_path, compose_content)
+        .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml: {}", err))?;
+    println!(
+        "Created docker-compose.yaml file at {}",
+        output_compose_file_path.display()
+    );
+
+    // If environment section is present, write the .env file
+    if let Some(env) = env {
+        // Serialize the environment variables to a string
+        let env_content = seahaven_file::serde_envfile::to_string(&env)
+            .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
+
+        // Write the .env file
+        let output_env_file_path = output_dir.join(".env");
+        std::fs::write(&output_env_file_path, env_content)
+            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {}", err))?;
+        println!("Created .env file at {}", output_env_file_path.display());
+    } else {
+        println!("No environment variables found in the setup file, skipping .env file creation");
+    }
+
+    println!("Setup ejected successfully!");
+    println!("You can now manage your configuration manually.");
+
+    Ok(())
+}

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::{build, down, init, pull, run, setup, up, version};
+use super::{build, down, eject, init, pull, run, setup, up, version};
 use crate::result::Result;
 
 /// Create and execute the DIPs CLI command line interface
@@ -9,6 +9,7 @@ pub async fn cmd_run() -> Result<()> {
         .subcommands([
             build::cmd(),
             down::cmd(),
+            eject::cmd(),
             init::cmd(),
             pull::cmd(),
             run::cmd(),
@@ -29,6 +30,7 @@ pub async fn cmd_run() -> Result<()> {
     match matches.subcommand() {
         Some((build::CMD, matches)) => build::run(matches).await,
         Some((down::CMD, matches)) => down::run(matches).await,
+        Some((eject::CMD, matches)) => eject::run(matches).await,
         Some((init::CMD, matches)) => init::run(matches).await,
         Some((pull::CMD, matches)) => pull::run(matches).await,
         Some((run::CMD, matches)) => run::run(matches).await,

--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -9,7 +9,7 @@ pub const CMD: &str = "setup";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Manage local development environment setup")
-        .subcommands([env::cmd(), compose::cmd(), eject::cmd()])
+        .subcommands([env::cmd(), compose::cmd()])
 }
 
 /// The `setup` command implementation
@@ -17,7 +17,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     match matches.subcommand() {
         Some((env::CMD, matches)) => env::run(matches).await,
         Some((compose::CMD, matches)) => compose::run(matches).await,
-        Some((eject::CMD, matches)) => eject::run(matches).await,
         _ => Err(anyhow::anyhow!("No setup command specified").into()),
     }
 }
@@ -117,116 +116,6 @@ mod compose {
                 .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
 
         println!("{}", compose_content);
-
-        Ok(())
-    }
-}
-
-mod eject {
-    use super::*;
-
-    /// The `setup eject` command name
-    pub const CMD: &str = "eject";
-
-    /// Create the `setup eject` sub-command
-    pub fn cmd() -> clap::Command {
-        clap::command!(CMD)
-            .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
-            .args([clap::arg!(-o --"output-dir" <DIR> "The output directory")
-                .default_value(".")
-                .value_parser(clap::value_parser!(PathBuf))])
-    }
-
-    /// The `setup eject` command
-    ///
-    /// This function ejects the setup.yaml file to get the docker-compose.yaml and .env files.
-    /// This is a one-way operation. Once ejected, you will need to manage the configuration manually.
-    pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
-        // Display warning message about the one-way nature of the operation
-        indoc::eprintdoc! {r#"
-            \x1b[33m\x1b[1mWARNING\x1b[0m: This is a one-way operation. Once ejected, you will need to manage the configuration manually.
-            \x1b[33m\x1b[1mWARNING\x1b[0m: The ejected files will be created in the specified output directory.
-            \x1b[33m\x1b[1mWARNING\x1b[0m: You can always regenerate the setup.yaml file from the ejected files if needed.
-            \x1b[33m\x1b[1mWARNING\x1b[0m: Are you sure you want to continue? [y/N] "#
-        }
-
-        // Get user confirmation
-        let mut input = String::new();
-        std::io::stdin()
-            .read_line(&mut input)
-            .map_err(|err| anyhow::anyhow!("Failed to read user input: {err}"))?;
-        if !input.trim().to_lowercase().starts_with('y') {
-            eprintln!("Operation cancelled.");
-            return Ok(());
-        }
-
-        // Get the setup file path from the command line (required)
-        let setup_file_path = matches
-            .get_one::<PathBuf>("file")
-            .expect("Failed to get setup file path");
-        if !setup_file_path.is_file() {
-            return Err(
-                anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into(),
-            );
-        }
-
-        // Get the output directory from the command line (required)
-        let output_dir = matches
-            .get_one::<PathBuf>("output-dir")
-            .expect("Failed to get output directory");
-        if !output_dir.is_dir() {
-            return Err(
-                anyhow::anyhow!("Invalid output directory: {}", output_dir.display()).into(),
-            );
-        }
-
-        // Read and parse the setup file
-        let file = File::open(setup_file_path)
-            .map(BufReader::new)
-            .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-        let (env, content) = seahaven_file::from_reader(file)
-            .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
-            .unpack();
-
-        // Transform the content into a compose file
-        let compose_file = seahaven_file::try_into_compose_file(content).map_err(|err| {
-            anyhow::anyhow!("Failed to convert setup file to compose file: {}", err)
-        })?;
-
-        // Serialize the compose file to a string
-        let compose_content =
-            seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)
-                .map_err(|err| anyhow::anyhow!("Failed to serialize compose file: {}", err))?;
-
-        // Write the docker-compose.yaml file
-        let output_compose_file_path = output_dir.join("docker-compose.yaml");
-        std::fs::write(&output_compose_file_path, compose_content)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml: {}", err))?;
-        println!(
-            "Created docker-compose.yaml file at {}",
-            output_compose_file_path.display()
-        );
-
-        // If environment section is present, write the .env file
-        if let Some(env) = env {
-            // Serialize the environment variables to a string
-            let env_content = seahaven_file::serde_envfile::to_string(&env).map_err(|err| {
-                anyhow::anyhow!("Failed to serialize environment variables: {}", err)
-            })?;
-
-            // Write the .env file
-            let output_env_file_path = output_dir.join(".env");
-            std::fs::write(&output_env_file_path, env_content)
-                .map_err(|err| anyhow::anyhow!("Failed to write .env file: {}", err))?;
-            println!("Created .env file at {}", output_env_file_path.display());
-        } else {
-            println!(
-                "No environment variables found in the setup file, skipping .env file creation"
-            );
-        }
-
-        println!("Ejection completed successfully!");
-        println!("You can now manage your configuration manually.");
 
         Ok(())
     }


### PR DESCRIPTION
- Introduced a new `eject` command that allows users to extract the `setup.yaml` file into `docker-compose.yaml` and `.env` files.
- Implemented user confirmation for the one-way operation, ensuring users are aware of the implications of ejecting the setup.
- Updated command structure to include the new `eject` command in the CLI.