### PR TITLE
feat(seahaven-cli): add common `--file` argument to commands

### DIFF
--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -1,4 +1,5 @@
 mod build;
+mod common;
 mod down;
 mod eject;
 mod init;

--- a/seahaven-cli/src/cmd/build.rs
+++ b/seahaven-cli/src/cmd/build.rs
@@ -2,6 +2,7 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
+use super::common::file_arg;
 use crate::result::{Error, Result};
 
 /// The `build` command name
@@ -11,6 +12,7 @@ pub const CMD: &str = "build";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Build the development environment images using docker compose")
+        .arg(file_arg())
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),

--- a/seahaven-cli/src/cmd/common.rs
+++ b/seahaven-cli/src/cmd/common.rs
@@ -1,0 +1,10 @@
+//! Common options for all commands
+
+use std::path::PathBuf;
+
+/// The `-f`/`--file` argument
+pub fn file_arg() -> clap::Arg {
+    clap::arg!(-f --file <FILE> "The seahaven setup file")
+        .default_value("setup.yaml")
+        .value_parser(clap::value_parser!(PathBuf))
+}

--- a/seahaven-cli/src/cmd/down.rs
+++ b/seahaven-cli/src/cmd/down.rs
@@ -2,6 +2,7 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
+use super::common::file_arg;
 use crate::result::{Error, Result};
 
 /// The `down` command name
@@ -11,6 +12,7 @@ pub const CMD: &str = "down";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Stop and remove containers, networks, images, and volumes")
+        .arg(file_arg())
         .args([
             clap::arg!(-v --volumes "Remove named volumes declared in the volumes section of the Compose file")
                 .action(clap::ArgAction::SetTrue),

--- a/seahaven-cli/src/cmd/eject.rs
+++ b/seahaven-cli/src/cmd/eject.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::BufReader, path::PathBuf};
 
+use super::common::file_arg;
 use crate::result::Result;
-
 /// The `eject` command name
 pub const CMD: &str = "eject";
 
@@ -9,6 +9,7 @@ pub const CMD: &str = "eject";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
+        .arg(file_arg())
         .args([clap::arg!(-o --"output-dir" <DIR> "The output directory")
             .default_value(".")
             .value_parser(clap::value_parser!(PathBuf))])

--- a/seahaven-cli/src/cmd/pull.rs
+++ b/seahaven-cli/src/cmd/pull.rs
@@ -2,6 +2,7 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
+use super::common::file_arg;
 use crate::result::{Error, Result};
 
 /// The `pull` command name
@@ -11,6 +12,7 @@ pub const CMD: &str = "pull";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Pull the images for the development environment")
+        .arg(file_arg())
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use super::{build, down, eject, init, pull, run, setup, up, version};
 use crate::result::Result;
 
@@ -17,12 +15,6 @@ pub async fn cmd_run() -> Result<()> {
             up::cmd(),
             version::cmd(),
         ])
-        .arg(
-            clap::arg!(-f --file <FILE> "The seahaven setup file")
-                .default_value("setup.yaml")
-                .value_parser(clap::value_parser!(PathBuf))
-                .global(true),
-        )
         .infer_long_args(true)
         .infer_subcommands(true)
         .get_matches();

--- a/seahaven-cli/src/cmd/run.rs
+++ b/seahaven-cli/src/cmd/run.rs
@@ -2,8 +2,8 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use seahaven_just::cmd::{IntoCommand, JustCmd};
 
+use super::common::file_arg;
 use crate::result::{Error, Result};
-
 /// The `run` command name
 pub const CMD: &str = "run";
 
@@ -11,6 +11,7 @@ pub const CMD: &str = "run";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("run the development environment images using docker compose")
+        .arg(file_arg())
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),

--- a/seahaven-cli/src/cmd/setup.rs
+++ b/seahaven-cli/src/cmd/setup.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, io::BufReader, path::PathBuf};
 
+use super::common::file_arg;
 use crate::result::Result;
-
 /// The `setup` command name
 pub const CMD: &str = "setup";
 
@@ -10,6 +10,7 @@ pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Manage local development environment setup")
         .subcommands([env::cmd(), compose::cmd()])
+        .arg(file_arg().global(true))
 }
 
 /// The `setup` command implementation

--- a/seahaven-cli/src/cmd/up.rs
+++ b/seahaven-cli/src/cmd/up.rs
@@ -2,8 +2,8 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
+use super::common::file_arg;
 use crate::result::{Error, Result};
-
 /// The `up` command name
 pub const CMD: &str = "up";
 
@@ -11,6 +11,7 @@ pub const CMD: &str = "up";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Start the development environment using docker compose")
+        .arg(file_arg().global(true))
         .args([
             clap::arg!(-d --detach "Detached mode: Run containers in the background")
                 .action(clap::ArgAction::SetTrue),


### PR DESCRIPTION
- Introduced a new `common.rs` module to define a shared `-f/--file` argument for all commands, allowing users to specify the Seahaven setup file.
- Updated the `build`, `down`, `eject`, `pull`, `run`, `setup`, and `up` commands to include the new file argument, enhancing consistency across the CLI.
- Removed the global file argument from the root command to streamline command structure.