### PR TITLE
fix(seahaven-cli): disabled clap version flag

### DIFF
--- a/seahaven-cli/src/cmd/eject.rs
+++ b/seahaven-cli/src/cmd/eject.rs
@@ -2,6 +2,7 @@ use std::{fs::File, io::BufReader, path::PathBuf};
 
 use super::common::file_arg;
 use crate::result::Result;
+
 /// The `eject` command name
 pub const CMD: &str = "eject";
 

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,9 +1,12 @@
 use super::{build, down, eject, init, pull, run, setup, up, version};
 use crate::result::Result;
 
+/// The name of the CLI
+pub const CMD: &str = "truman";
+
 /// Create and execute the DIPs CLI command line interface
 pub async fn cmd_run() -> Result<()> {
-    let matches = clap::command!()
+    let matches = clap::command!(CMD)
         .subcommands([
             build::cmd(),
             down::cmd(),
@@ -17,6 +20,7 @@ pub async fn cmd_run() -> Result<()> {
         ])
         .infer_long_args(true)
         .infer_subcommands(true)
+        .disable_version_flag(true)
         .get_matches();
 
     match matches.subcommand() {


### PR DESCRIPTION
- Updated the `root.rs` file to define the CLI command name as "truman" and adjusted the command initialization to use this constant, enhancing clarity and maintainability.
- Disabled the version flag in the command structure to streamline user experience.