### PR TITLE
feat(seahaven-cli): add `system` command

### DIFF
--- a/seahaven-cli/src/cmd.rs
+++ b/seahaven-cli/src/cmd.rs
@@ -7,6 +7,7 @@ mod pull;
 mod root;
 mod run;
 mod setup;
+mod system;
 mod up;
 mod version;
 

--- a/seahaven-cli/src/cmd/root.rs
+++ b/seahaven-cli/src/cmd/root.rs
@@ -1,4 +1,4 @@
-use super::{build, down, eject, init, pull, run, setup, up, version};
+use super::{build, down, eject, init, pull, run, setup, system, up, version};
 use crate::result::Result;
 
 /// The name of the CLI
@@ -15,6 +15,7 @@ pub async fn cmd_run() -> Result<()> {
             pull::cmd(),
             run::cmd(),
             setup::cmd(),
+            system::cmd(),
             up::cmd(),
             version::cmd(),
         ])
@@ -31,6 +32,7 @@ pub async fn cmd_run() -> Result<()> {
         Some((pull::CMD, matches)) => pull::run(matches).await,
         Some((run::CMD, matches)) => run::run(matches).await,
         Some((setup::CMD, matches)) => setup::run(matches).await,
+        Some((system::CMD, matches)) => system::run(matches).await,
         Some((up::CMD, matches)) => up::run(matches).await,
         Some((version::CMD, matches)) => version::run(matches).await,
         _ => Err(anyhow::anyhow!("No command specified").into()),

--- a/seahaven-cli/src/cmd/system.rs
+++ b/seahaven-cli/src/cmd/system.rs
@@ -1,0 +1,106 @@
+use crate::result::Result;
+
+/// The `system` command name
+pub const CMD: &str = "system";
+
+/// Create the `system` command
+pub fn cmd() -> clap::Command {
+    clap::command!(CMD)
+        .about("Manage seahaven system")
+        .args([clap::arg!(--"check-deps" "Check for dependency versions")
+            .action(clap::ArgAction::SetTrue)])
+        .group(clap::ArgGroup::new("check").args(["check-deps"]))
+}
+
+/// The `system` command implementation
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    if matches.get_flag("check-deps") {
+        return check_dependencies().await;
+    }
+
+    Err(anyhow::anyhow!("Invalid command").into())
+}
+
+/// Verifies the presence of required system dependencies including Docker components (client,
+/// engine, compose plugin, buildx plugin) and Just CLI.
+///
+/// Returns an error with a list of missing dependencies if any are not found.
+async fn check_dependencies() -> Result<()> {
+    let docker_version = fetch_docker_version().await;
+    let just_version = fetch_just_version().await;
+
+    let mut missing_deps = Vec::new();
+
+    // Check docker dependencies
+    if let Some(docker) = docker_version {
+        if docker.client.is_none() {
+            missing_deps.push("docker-client");
+        }
+        if docker.engine.is_none() {
+            missing_deps.push("docker-engine");
+        }
+        if docker.plugin_compose.is_none() {
+            missing_deps.push("docker-compose");
+        }
+        if docker.plugin_buildx.is_none() {
+            missing_deps.push("docker-buildx");
+        }
+    } else {
+        missing_deps.push("docker-cli");
+    }
+
+    // Check just CLI dependency
+    if just_version.is_none() {
+        missing_deps.push("just-cli");
+    }
+
+    if !missing_deps.is_empty() {
+        return Err(anyhow::anyhow!(
+            "The following dependencies are missing: {}",
+            missing_deps.join(", ")
+        )
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Resolves the Docker CLI executable path and fetches version information for Docker components.
+/// Returns None if Docker is not found or version check fails.
+async fn fetch_docker_version() -> Option<seahaven_docker::version::Version> {
+    let docker_exe = match seahaven_docker::exe::resolve_cli_executable() {
+        Ok(exe) => exe,
+        Err(err) => {
+            tracing::debug!("Failed to resolve docker executable: {}", err);
+            return None;
+        }
+    };
+
+    match seahaven_docker::version::fetch(&docker_exe).await {
+        Ok(version) => Some(version),
+        Err(err) => {
+            tracing::debug!("Failed to determine docker version: {}", err);
+            None
+        }
+    }
+}
+
+/// Resolves the Just CLI executable path and fetches version information for Just.
+/// Returns None if Just is not found or version check fails.
+async fn fetch_just_version() -> Option<seahaven_just::version::Version> {
+    let just_exe = match seahaven_just::exe::resolve_cli_executable() {
+        Ok(exe) => exe,
+        Err(err) => {
+            tracing::debug!("Failed to resolve just executable: {}", err);
+            return None;
+        }
+    };
+
+    match seahaven_just::version::fetch(&just_exe).await {
+        Ok(version) => Some(version),
+        Err(err) => {
+            tracing::debug!("Failed to determine just version: {}", err);
+            None
+        }
+    }
+}

--- a/seahaven-cli/src/cmd/version.rs
+++ b/seahaven-cli/src/cmd/version.rs
@@ -17,9 +17,8 @@ pub fn cmd() -> clap::Command {
                 .action(clap::ArgAction::SetTrue),
             clap::arg!(--full "Print version information in full format")
                 .action(clap::ArgAction::SetTrue),
-            clap::arg!(--check "Check for dependency versions").action(clap::ArgAction::SetTrue),
         ])
-        .group(clap::ArgGroup::new("format").args(["short", "full", "json", "check"]))
+        .group(clap::ArgGroup::new("format").args(["short", "full", "json"]))
 }
 
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
@@ -31,11 +30,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
 
         info::into_version_info(build_info, docker_version, just_version)
     };
-
-    // Check if dependencies are present
-    if matches.get_flag("check") {
-        return check_dependencies(&info);
-    }
 
     let format = if matches.get_flag("short") {
         Format::Short
@@ -315,40 +309,4 @@ mod info {
     fn format_build_info_target_cpu_features(info: &BuildInfo) -> String {
         info.target.cpu.features.join(", ")
     }
-}
-
-/// Check if all required dependencies are present
-fn check_dependencies(info: &info::VersionInfo) -> Result<()> {
-    let mut missing_deps = Vec::new();
-
-    if let Some(docker) = info.dependencies.docker.as_ref() {
-        if docker.client.is_none() {
-            missing_deps.push("docker-client");
-        }
-        if docker.engine.is_none() {
-            missing_deps.push("docker-engine");
-        }
-        if docker.compose.is_none() {
-            missing_deps.push("docker-compose");
-        }
-        if docker.buildx.is_none() {
-            missing_deps.push("docker-buildx");
-        }
-    } else {
-        missing_deps.push("docker-cli");
-    }
-
-    if info.dependencies.just.is_none() {
-        missing_deps.push("just-cli");
-    }
-
-    if !missing_deps.is_empty() {
-        return Err(anyhow::anyhow!(
-            "The following dependencies are missing: {}",
-            missing_deps.join(", ")
-        )
-        .into());
-    }
-
-    Ok(())
 }


### PR DESCRIPTION
- Introduced a new `system` command to the CLI, allowing users to check for required system dependencies, including Docker and Just CLI.
- Updated the `root.rs` file to include the `system` command in the command initialization.
- Removed the dependency checking functionality from the `version` command to streamline its purpose.