### PR TITLE
chore(deps): update serde-envfile dependency revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "serde-envfile"
 version = "0.2.0"
-source = "git+https://github.com/LNSD/serde-envfile.git?rev=ad00e40#ad00e4029930d238cb1b1465b46e5647a87ded6e"
+source = "git+https://github.com/LNSD/serde-envfile.git?rev=7d02f71#7d02f716d8bc06623a8d03075486298cdcdec1f2"
 dependencies = [
  "cfg-if",
  "dotenvy",

--- a/seahaven-file/Cargo.toml
+++ b/seahaven-file/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 anyhow = "1.0"
 seahaven-compose-file = { version = "0.1.0", path = "../seahaven-compose-file", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "ad00e40" }
+serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "7d02f71" }
 serde_yaml = "0.9"
 thiserror = "2.0"
 


### PR DESCRIPTION
- Updated the `serde-envfile` dependency in both `Cargo.toml` and `Cargo.lock` to use the latest commit revision `7d02f71` for improved stability and features.

This change ensures that the project is using the most recent version of the dependency.