### PR TITLE
docs: update command usage for system dependencies check

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Truman depends on the following tools:
 > Verify the system dependencies with:
 >
 > ```bash
-> truman system --check-deps
+> truman system check
 > ```
 
 #### Docker


### PR DESCRIPTION
- Changed the command from `truman system --check-deps` to `truman system check` to reflect the new subcommand structure introduced in the recent updates.

This change ensures that the documentation is aligned with the latest command organization.