### PR TITLE
feat(seahaven-cli): add `truman run --list` and `truman run --summary` commands

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -18,8 +18,15 @@ pub fn cmd() -> clap::Command {
                 .action(clap::ArgAction::SetTrue),
             clap::arg!(--justfile <FILE> "Path to the justfile to use")
                 .value_parser(clap::value_parser!(PathBuf)),
+            clap::arg!(--list "List available recipes")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with("summary"),
+            clap::arg!(--summary "Show summary of available recipes")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with("list"),
             clap::arg!([ARGUMENTS] ... "Overrides and recipe(s) to run, defaulting to the first recipe in the justfile")
-                .action(clap::ArgAction::Append),
+                .action(clap::ArgAction::Append)
+                .conflicts_with_all(["list", "summary"]),
         ])
 }
 
@@ -73,12 +80,18 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     // Create and run the just command
-    let mut command = JustCmd::with_executable(just_exe)
-        .with_justfile::<&PathBuf>(matches.get_one::<PathBuf>("justfile"))
-        .with_env_file(env_file_path)
-        .with_dry_run(matches.get_flag("dry-run"))
-        .with_args(matches.get_many::<String>("ARGUMENTS").unwrap_or_default())
-        .into_command();
+    let mut command = if matches.get_flag("list") {
+        JustCmd::with_executable(just_exe).list().into_command()
+    } else if matches.get_flag("summary") {
+        JustCmd::with_executable(just_exe).summary().into_command()
+    } else {
+        JustCmd::with_executable(just_exe)
+            .with_justfile::<&PathBuf>(matches.get_one::<PathBuf>("justfile"))
+            .with_env_file(env_file_path)
+            .with_dry_run(matches.get_flag("dry-run"))
+            .with_args(matches.get_many::<String>("ARGUMENTS").unwrap_or_default())
+            .into_command()
+    };
 
     tracing::debug!("command: {:?}", command.as_std());
 

--- a/seahaven-just/src/cmd.rs
+++ b/seahaven-just/src/cmd.rs
@@ -16,6 +16,8 @@
 //!
 //! - `just --version`
 //! - `just --dump`
+//! - `just --list`
+//! - `just --summary`
 //! - `just` with the following options:
 //!   - `--justfile <path>` - Specify an alternate justfile
 //!   - `--dotenv-path <path>` - Specify an alternate environment file
@@ -25,7 +27,9 @@
 
 mod common;
 pub mod dump;
+pub mod list;
 mod root;
+pub mod summary;
 pub mod version;
 
 pub use common::IntoCommand;
@@ -37,6 +41,8 @@ pub use root::{
 mod tests {
     mod common;
     mod it_dump;
+    mod it_list;
     mod it_root;
+    mod it_summary;
     mod it_version;
 }

--- a/seahaven-just/src/cmd/list.rs
+++ b/seahaven-just/src/cmd/list.rs
@@ -1,20 +1,20 @@
 use super::common::IntoCommand;
 
-pub struct JustVersionCmd(tokio::process::Command);
+pub struct JustListCmd(tokio::process::Command);
 
-impl JustVersionCmd {
-    /// Create a new `just --version` command
+impl JustListCmd {
+    /// Create a new `just --list` command
     pub(crate) fn new(cmd: impl IntoCommand) -> Self {
         Self(cmd.into_command())
     }
 }
 
-impl IntoCommand for JustVersionCmd {
+impl IntoCommand for JustListCmd {
     fn into_command(self) -> tokio::process::Command {
         let mut cmd = self.0;
 
-        // Add the `version` subcommand
-        cmd.arg("--version");
+        // Add the `list` subcommand
+        cmd.arg("--list");
 
         cmd
     }

--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -7,6 +7,8 @@ use std::{
 use super::{
     common::{IntoCmdOptValue, IntoCommand},
     dump::JustDumpCmd,
+    list::JustListCmd,
+    summary::JustSummaryCmd,
     version::JustVersionCmd,
 };
 use crate::exe::Executable;
@@ -52,6 +54,16 @@ impl JustCmd {
     /// Create a new `just --dump` command
     pub fn dump(self) -> JustDumpCmd {
         JustDumpCmd::new(self)
+    }
+
+    /// Create a new `just --list` command
+    pub fn list(self) -> JustListCmd {
+        JustListCmd::new(self)
+    }
+
+    /// Create a new `just --summary` command
+    pub fn summary(self) -> JustSummaryCmd {
+        JustSummaryCmd::new(self)
     }
 }
 

--- a/seahaven-just/src/cmd/summary.rs
+++ b/seahaven-just/src/cmd/summary.rs
@@ -1,20 +1,20 @@
 use super::common::IntoCommand;
 
-pub struct JustVersionCmd(tokio::process::Command);
+pub struct JustSummaryCmd(tokio::process::Command);
 
-impl JustVersionCmd {
-    /// Create a new `just --version` command
+impl JustSummaryCmd {
+    /// Create a new `just --summary` command
     pub(crate) fn new(cmd: impl IntoCommand) -> Self {
         Self(cmd.into_command())
     }
 }
 
-impl IntoCommand for JustVersionCmd {
+impl IntoCommand for JustSummaryCmd {
     fn into_command(self) -> tokio::process::Command {
         let mut cmd = self.0;
 
-        // Add the `version` subcommand
-        cmd.arg("--version");
+        // Add the `summary` subcommand
+        cmd.arg("--summary");
 
         cmd
     }

--- a/seahaven-just/src/cmd/tests/it_list.rs
+++ b/seahaven-just/src/cmd/tests/it_list.rs
@@ -1,0 +1,19 @@
+use super::common::{fixture_exe, parse_fixture_exe_output};
+use crate::cmd::{IntoCommand, JustCmd};
+
+#[tokio::test]
+async fn run_just_list() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = JustCmd::with_executable(exe).list().into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just list");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--list"]);
+}

--- a/seahaven-just/src/cmd/tests/it_summary.rs
+++ b/seahaven-just/src/cmd/tests/it_summary.rs
@@ -1,0 +1,19 @@
+use super::common::{fixture_exe, parse_fixture_exe_output};
+use crate::cmd::{IntoCommand, JustCmd};
+
+#[tokio::test]
+async fn run_just_summary() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = JustCmd::with_executable(exe).summary().into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run just summary");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["--summary"]);
+}


### PR DESCRIPTION
- Introduced `--list` and `--summary` options to the `just` command for listing available recipes and showing a summary of recipes, respectively.
- Updated the command structure to handle these new options, ensuring they conflict with each other for clarity.
- Added corresponding implementations in the command module and created tests to verify functionality.

This enhancement improves the usability of the CLI by providing users with quick access to recipe information.