### PR TITLE
feat(seahaven-cli): integrate `deps` module for executable resolution

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/build.rs
+++ b/seahaven-cli/src/bin/truman/cmd/build.rs
@@ -4,6 +4,7 @@ use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
 use super::common::file_arg;
+use crate::deps::resolve_docker_executable;
 
 /// The `build` command name
 pub const CMD: &str = "build";
@@ -29,8 +30,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // - No min version for docker
     // - No min version for docker compose plugin (required)
     // - No min version for buildx plugin (required)
-    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
-        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+    let docker_exe = resolve_docker_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {}", err))?;
 
     tracing::debug!("docker executable: {}", docker_exe);
 

--- a/seahaven-cli/src/bin/truman/cmd/down.rs
+++ b/seahaven-cli/src/bin/truman/cmd/down.rs
@@ -4,6 +4,7 @@ use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
 use super::common::file_arg;
+use crate::deps::resolve_docker_executable;
 
 /// The `down` command name
 pub const CMD: &str = "down";
@@ -28,8 +29,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
     // - No min version for docker
     // - No min version for docker compose plugin (required)
-    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
-        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+    let docker_exe = resolve_docker_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {}", err))?;
 
     tracing::debug!("docker executable: {}", docker_exe);
 

--- a/seahaven-cli/src/bin/truman/cmd/pull.rs
+++ b/seahaven-cli/src/bin/truman/cmd/pull.rs
@@ -4,6 +4,7 @@ use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
 use super::common::file_arg;
+use crate::deps::resolve_docker_executable;
 
 /// The `pull` command name
 pub const CMD: &str = "pull";
@@ -25,8 +26,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
     // - No min version for docker
     // - No min version for docker compose plugin (required)
-    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
-        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+    let docker_exe = resolve_docker_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {}", err))?;
 
     tracing::debug!("docker executable: {}", docker_exe);
 

--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -4,6 +4,7 @@ use seahaven_cli::result::{Error, Result};
 use seahaven_just::cmd::{IntoCommand, JustCmd};
 
 use super::common::file_arg;
+use crate::deps::resolve_just_executable;
 
 /// The `run` command name
 pub const CMD: &str = "run";
@@ -34,8 +35,8 @@ pub fn cmd() -> clap::Command {
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
     // - No min version for just
-    let just_exe = seahaven_just::exe::resolve_cli_executable()
-        .map_err(|err| anyhow::anyhow!("Failed to resolve just executable: {err}"))?;
+    let just_exe = resolve_just_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve just executable: {}", err))?;
 
     tracing::debug!("just executable: {}", just_exe);
 

--- a/seahaven-cli/src/bin/truman/cmd/system/check.rs
+++ b/seahaven-cli/src/bin/truman/cmd/system/check.rs
@@ -1,5 +1,7 @@
 use seahaven_cli::result::Result;
 
+use crate::deps::{fetch_docker_version, fetch_just_version};
+
 /// The `check` command name
 pub const CMD: &str = "check";
 
@@ -68,44 +70,4 @@ async fn check_dependencies() -> Result<()> {
     }
 
     Ok(())
-}
-
-/// Resolves the Docker CLI executable path and fetches version information for Docker components.
-/// Returns None if Docker is not found or version check fails.
-async fn fetch_docker_version() -> Option<seahaven_docker::version::Version> {
-    let docker_exe = match seahaven_docker::exe::resolve_cli_executable() {
-        Ok(exe) => exe,
-        Err(err) => {
-            tracing::debug!("Failed to resolve docker executable: {}", err);
-            return None;
-        }
-    };
-
-    match seahaven_docker::version::fetch(&docker_exe).await {
-        Ok(version) => Some(version),
-        Err(err) => {
-            tracing::debug!("Failed to determine docker version: {}", err);
-            None
-        }
-    }
-}
-
-/// Resolves the Just CLI executable path and fetches version information for Just.
-/// Returns None if Just is not found or version check fails.
-async fn fetch_just_version() -> Option<seahaven_just::version::Version> {
-    let just_exe = match seahaven_just::exe::resolve_cli_executable() {
-        Ok(exe) => exe,
-        Err(err) => {
-            tracing::debug!("Failed to resolve just executable: {}", err);
-            return None;
-        }
-    };
-
-    match seahaven_just::version::fetch(&just_exe).await {
-        Ok(version) => Some(version),
-        Err(err) => {
-            tracing::debug!("Failed to determine just version: {}", err);
-            None
-        }
-    }
 }

--- a/seahaven-cli/src/bin/truman/cmd/up.rs
+++ b/seahaven-cli/src/bin/truman/cmd/up.rs
@@ -4,6 +4,7 @@ use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
 use super::common::file_arg;
+use crate::deps::resolve_docker_executable;
 
 /// The `up` command name
 pub const CMD: &str = "up";
@@ -29,8 +30,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Check for requirements
     // - No min version for docker
     // - No min version for docker compose plugin (required)
-    let docker_exe = seahaven_docker::exe::resolve_cli_executable()
-        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {err}"))?;
+    let docker_exe = resolve_docker_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {}", err))?;
 
     tracing::debug!("docker executable: {}", docker_exe);
 

--- a/seahaven-cli/src/bin/truman/cmd/version.rs
+++ b/seahaven-cli/src/bin/truman/cmd/version.rs
@@ -1,6 +1,8 @@
 use build_info::BuildInfo;
 use seahaven_cli::result::Result;
 
+use crate::deps::{fetch_docker_version, fetch_just_version};
+
 // Generate the build info function.
 build_info::build_info!(fn get_build_info);
 
@@ -118,44 +120,6 @@ enum Format {
     Full,
     /// Print version information in JSON format.
     Json,
-}
-
-/// Fetch the docker version
-async fn fetch_docker_version() -> Option<seahaven_docker::version::Version> {
-    let docker_exe = match seahaven_docker::exe::resolve_cli_executable() {
-        Ok(exe) => exe,
-        Err(err) => {
-            tracing::debug!("Failed to resolve docker executable: {}", err);
-            return None;
-        }
-    };
-
-    match seahaven_docker::version::fetch(&docker_exe).await {
-        Ok(version) => Some(version),
-        Err(err) => {
-            tracing::debug!("Failed to determine docker version: {}", err);
-            None
-        }
-    }
-}
-
-/// Fetch the just version
-async fn fetch_just_version() -> Option<seahaven_just::version::Version> {
-    let just_exe = match seahaven_just::exe::resolve_cli_executable() {
-        Ok(exe) => exe,
-        Err(err) => {
-            tracing::debug!("Failed to resolve just executable: {}", err);
-            return None;
-        }
-    };
-
-    match seahaven_just::version::fetch(&just_exe).await {
-        Ok(version) => Some(version),
-        Err(err) => {
-            tracing::debug!("Failed to determine just version: {}", err);
-            None
-        }
-    }
 }
 
 mod info {

--- a/seahaven-cli/src/bin/truman/deps.rs
+++ b/seahaven-cli/src/bin/truman/deps.rs
@@ -1,0 +1,138 @@
+//! # Truman CLI Dependencies
+//!
+//! This module provides functionality for resolving and managing external dependencies
+//! required by the Truman CLI, specifically Docker and Just executables.
+//!
+//! It handles:
+//! - Resolution of executable paths through environment variables or system PATH
+//! - Version information retrieval for both Docker and Just
+//! - Error handling for missing or inaccessible executables
+
+use seahaven_docker::exe::{Executable as DockerExecutable, NotFoundError as DockerNotFoundError};
+use seahaven_just::exe::{Executable as JustExecutable, NotFoundError as JustNotFoundError};
+
+/// Environment variable name for specifying a custom Docker executable path
+const DOCKER_EXE_ENV_VAR: &str = "SEAHAVEN_DOCKER_EXE";
+
+/// Default name of the Docker executable when not specified via environment variable
+const DEFAULT_DOCKER_EXE: &str = "docker";
+
+/// Environment variable name for specifying a custom Just executable path
+const JUST_EXE_ENV_VAR: &str = "SEAHAVEN_JUST_EXE";
+
+/// Default name of the Just executable when not specified via environment variable
+const DEFAULT_JUST_EXE: &str = "just";
+
+/// Resolves the path to the Docker CLI executable.
+///
+/// The resolution process follows this order:
+/// 1. Checks for the [`DOCKER_EXE_ENV_VAR`] environment variable
+/// 2. Falls back to the default executable name if no environment variable is set
+/// 3. Searches for the executable in the system PATH
+///
+/// # Returns
+///
+/// - `Ok(DockerExecutable)` containing the resolved executable path
+/// - `Err(DockerNotFoundError)` if the executable cannot be found or accessed
+///
+/// # Errors
+///
+/// Returns a [`DockerNotFoundError`] if:
+/// - The specified path in the environment variable does not exist
+/// - The default executable cannot be found in the system PATH
+/// - The executable exists but is not accessible
+pub fn resolve_docker_executable() -> Result<DockerExecutable, DockerNotFoundError> {
+    let path = std::env::var_os(DOCKER_EXE_ENV_VAR).unwrap_or(DEFAULT_DOCKER_EXE.into());
+    seahaven_docker::exe::resolve(path)
+}
+
+/// Resolves the path to the Just CLI executable.
+///
+/// The resolution process follows this order:
+/// 1. Checks for the [`JUST_EXE_ENV_VAR`] environment variable
+/// 2. Falls back to the default executable name if no environment variable is set
+/// 3. Searches for the executable in the system PATH
+///
+/// # Returns
+///
+/// - `Ok(JustExecutable)` containing the resolved executable path
+/// - `Err(JustNotFoundError)` if the executable cannot be found or accessed
+///
+/// # Errors
+///
+/// Returns a [`JustNotFoundError`] if:
+/// - The specified path in the environment variable does not exist
+/// - The default executable cannot be found in the system PATH
+/// - The executable exists but is not accessible
+pub fn resolve_just_executable() -> Result<JustExecutable, JustNotFoundError> {
+    let path = std::env::var_os(JUST_EXE_ENV_VAR).unwrap_or(DEFAULT_JUST_EXE.into());
+    seahaven_just::exe::resolve(path)
+}
+
+/// Retrieves version information for the Docker installation.
+///
+/// This function:
+/// 1. Resolves the Docker executable path
+/// 2. Executes the Docker CLI to fetch version information
+/// 3. Parses and returns the version details
+///
+/// # Returns
+///
+/// - `Some(Version)` containing the Docker version information if successful
+/// - `None` if:
+///   - The Docker executable cannot be found
+///   - Version information cannot be retrieved
+///   - The version check fails
+///
+/// Failures are logged at the debug level and do not propagate errors.
+pub async fn fetch_docker_version() -> Option<seahaven_docker::version::Version> {
+    let docker_exe = match resolve_docker_executable() {
+        Ok(exe) => exe,
+        Err(err) => {
+            tracing::debug!("Failed to resolve docker executable: {}", err);
+            return None;
+        }
+    };
+
+    match seahaven_docker::version::fetch(&docker_exe).await {
+        Ok(version) => Some(version),
+        Err(err) => {
+            tracing::debug!("Failed to determine docker version: {}", err);
+            None
+        }
+    }
+}
+
+/// Retrieves version information for the Just installation.
+///
+/// This function:
+/// 1. Resolves the Just executable path
+/// 2. Executes the Just CLI to fetch version information
+/// 3. Parses and returns the version details
+///
+/// # Returns
+///
+/// - `Some(Version)` containing the Just version information if successful
+/// - `None` if:
+///   - The Just executable cannot be found
+///   - Version information cannot be retrieved
+///   - The version check fails
+///
+/// Failures are logged at the debug level and do not propagate errors.
+pub async fn fetch_just_version() -> Option<seahaven_just::version::Version> {
+    let just_exe = match resolve_just_executable() {
+        Ok(exe) => exe,
+        Err(err) => {
+            tracing::debug!("Failed to resolve just executable: {}", err);
+            return None;
+        }
+    };
+
+    match seahaven_just::version::fetch(&just_exe).await {
+        Ok(version) => Some(version),
+        Err(err) => {
+            tracing::debug!("Failed to determine just version: {}", err);
+            None
+        }
+    }
+}

--- a/seahaven-cli/src/bin/truman/main.rs
+++ b/seahaven-cli/src/bin/truman/main.rs
@@ -1,4 +1,5 @@
 mod cmd;
+mod deps;
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() {

--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -26,12 +26,12 @@
 //! ```rust
 //! use seahaven_docker::{
 //!     cmd::{DockerCmd, IntoCommand},
-//!     exe::resolve_cli_executable,
+//!     exe::resolve,
 //! };
 //!
 //! // Get Docker version information
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let exe = resolve_cli_executable()?;
+//! let exe = resolve("docker")?;
 //! let version_cmd = DockerCmd::with_executable(exe).version();
 //! let mut command = version_cmd.into_command();
 //!
@@ -46,12 +46,12 @@
 //! ```rust
 //! use seahaven_docker::{
 //!     cmd::{DockerCmd, IntoCommand},
-//!     exe::resolve_cli_executable,
+//!     exe::resolve,
 //! };
 //!
 //! // Configure and start services with Docker Compose
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let exe = resolve_cli_executable()?;
+//! let exe = resolve("docker")?;
 //! let mut compose_cmd = DockerCmd::with_executable(exe)
 //!     .compose()
 //!     .up()

--- a/seahaven-docker/src/cmd/tests/common.rs
+++ b/seahaven-docker/src/cmd/tests/common.rs
@@ -1,6 +1,6 @@
 //! Common utilities for tests
 
-use crate::exe::Executable;
+use crate::exe::{Executable, resolve};
 
 /// The path to the `mocker.sh` fixture file
 const MOCKER_SH_PATH: &str = {
@@ -14,7 +14,7 @@ const MOCKER_SH_PATH: &str = {
 ///
 /// The executable is the `mocker.sh` fixture script, which is used to mock the Docker CLI.
 pub fn fixture_exe() -> Executable {
-    Executable::resolve(MOCKER_SH_PATH).expect("Failed to resolve the test fixture executable")
+    resolve(MOCKER_SH_PATH).expect("Failed to resolve the test fixture executable")
 }
 
 /// Parses the output of the fixture executable into a [`Vec`] of string slices

--- a/seahaven-docker/src/exe.rs
+++ b/seahaven-docker/src/exe.rs
@@ -2,45 +2,27 @@
 //!
 //! This module provides functionality to resolve the Docker CLI executable path
 //! and a type-safe wrapper for the executable path.
-//!
-//! ## Executable resolution
-//!
-//! The Docker CLI executable is resolved in the following order:
-//!
-//!  1. If the `SEAHAVEN_DOCKER_CLI` environment variable is set, its value is used as the
-//!     executable path.
-//!  2. Otherwise, the system's `docker` command is located in the `$PATH` environment variable.
-//!
-//! In both cases, the resolved path is validated to ensure it exists and is executable.
-//! If the path is invalid or the executable cannot be found, an error is returned.
 
 use std::{ffi::OsStr, path::Path};
 
-/// The environment variable that contains the path to the docker CLI binary
-const DOCKER_CLI_EXECUTABLE_ENVVAR: &str = "SEAHAVEN_DOCKER_CLI";
-
-/// The default docker CLI executable name
-const DEFAULT_DOCKER_CLI_EXECUTABLE: &str = "docker";
-
-/// Errors that can occur when resolving the Docker CLI executable
-#[derive(Debug, thiserror::Error)]
-#[error("Docker CLI executable not found: {0}")]
-pub struct NotFoundError(#[from] which::Error);
-
-/// Resolve the docker CLI executable path
+/// Resolves and validates a Docker executable path
 ///
-/// If the [`DOCKER_CLI_PATH_ENVVAR`] environment variable is set, it will be used.
-/// Otherwise, the function will try to find the `docker` CLI executable in the "$PATH" environment variable.
-/// If the `docker` CLI executable is not found, an error is returned.
-///
-/// Returns the path to the docker CLI executable.
-pub fn resolve_cli_executable() -> Result<Executable, NotFoundError> {
-    let path = std::env::var_os(DOCKER_CLI_EXECUTABLE_ENVVAR)
-        .unwrap_or_else(|| DEFAULT_DOCKER_CLI_EXECUTABLE.into());
+/// Takes a path-like value and attempts to locate the corresponding executable.
+/// Returns an [`Executable`] if the path exists and is executable, or a [`NotFoundError`]
+/// if the executable cannot be found or is not executable.
+pub fn resolve<P>(path: P) -> Result<Executable, NotFoundError>
+where
+    P: AsRef<OsStr>,
+{
     which::which(path)
         .map(|path| Executable(path.into_boxed_path()))
-        .map_err(Into::into)
+        .map_err(NotFoundError)
 }
+
+/// An error that can occur when resolving the Docker executable
+#[derive(Debug, thiserror::Error)]
+#[error("Executable not found: {0}")]
+pub struct NotFoundError(which::Error);
 
 /// The path to the Docker CLI executable
 ///
@@ -49,21 +31,6 @@ pub fn resolve_cli_executable() -> Result<Executable, NotFoundError> {
 /// This type is used to ensure that the Docker CLI executable path is always valid.
 #[derive(Clone)]
 pub struct Executable(Box<Path>);
-
-impl Executable {
-    /// Create a new [`Executable`] from a path
-    ///
-    /// The path is resolved and validated to ensure it exists and is executable.
-    /// If the path is not found, or is not executable, an error is returned.
-    pub fn resolve<P>(path: P) -> Result<Self, NotFoundError>
-    where
-        P: AsRef<OsStr>,
-    {
-        which::which(path)
-            .map(|path| Executable(path.into_boxed_path()))
-            .map_err(Into::into)
-    }
-}
 
 impl AsRef<OsStr> for Executable {
     fn as_ref(&self) -> &OsStr {

--- a/seahaven-docker/src/tests/it_version.rs
+++ b/seahaven-docker/src/tests/it_version.rs
@@ -1,5 +1,5 @@
 use crate::{
-    exe::resolve_cli_executable,
+    exe::resolve,
     version::{get_docker_system_info_versions, get_docker_version_versions},
 };
 
@@ -7,7 +7,7 @@ use crate::{
 #[tokio::test]
 async fn resolve_docker_version() {
     //* Given
-    let exe = resolve_cli_executable().expect("docker binary not found");
+    let exe = resolve("docker").expect("docker binary not found");
 
     //* When
     let res = get_docker_version_versions(&exe).await;
@@ -28,7 +28,7 @@ async fn resolve_docker_version() {
 #[tokio::test]
 async fn resolve_docker_plugin_versions() {
     //* Given
-    let exe = resolve_cli_executable().expect("docker binary not found");
+    let exe = resolve("docker").expect("docker binary not found");
 
     //* When
     let res = get_docker_system_info_versions(&exe).await;

--- a/seahaven-docker/tests/it_exe.rs
+++ b/seahaven-docker/tests/it_exe.rs
@@ -1,4 +1,4 @@
-use seahaven_docker::exe::{Executable, resolve_cli_executable};
+use seahaven_docker::exe::resolve;
 
 #[test_with::no_env(CI)]
 #[test]
@@ -7,7 +7,7 @@ fn resolve_invalid_executable() {
     let invalid_exe_name = "non_existent_docker_binary";
 
     //* When
-    let invalid_result = Executable::resolve(invalid_exe_name);
+    let invalid_result = resolve(invalid_exe_name);
 
     //* Then
     assert!(
@@ -20,7 +20,7 @@ fn resolve_invalid_executable() {
 #[test]
 fn executable_display_and_debug() {
     //* Given
-    let exe = resolve_cli_executable().expect("docker binary not found");
+    let exe = resolve("docker").expect("docker binary not found");
 
     //* When
     let display_str = format!("{}", exe);

--- a/seahaven-docker/tests/it_version.rs
+++ b/seahaven-docker/tests/it_version.rs
@@ -1,10 +1,10 @@
-use seahaven_docker::{exe::resolve_cli_executable, version};
+use seahaven_docker::{exe::resolve, version};
 
 #[test_with::no_env(CI)]
 #[tokio::test]
 async fn resolve_docker_version() {
     //* Given
-    let exe = resolve_cli_executable().expect("docker binary not found");
+    let exe = resolve("docker").expect("docker binary not found");
 
     //* When
     let res = version::fetch(&exe).await;

--- a/seahaven-just/src/cmd/tests/common.rs
+++ b/seahaven-just/src/cmd/tests/common.rs
@@ -1,6 +1,6 @@
 //! Common utilities for tests
 
-use crate::exe::Executable;
+use crate::exe::{Executable, resolve};
 
 /// The path to the `mocker.sh` fixture file
 const MOCKER_SH_PATH: &str = {
@@ -14,7 +14,7 @@ const MOCKER_SH_PATH: &str = {
 ///
 /// The executable is the `mocker.sh` fixture script, which is used to mock the Just CLI.
 pub fn fixture_exe() -> Executable {
-    Executable::resolve(MOCKER_SH_PATH).expect("Failed to resolve the test fixture executable")
+    resolve(MOCKER_SH_PATH).expect("Failed to resolve the test fixture executable")
 }
 
 /// Parses the output of the fixture executable into a [`Vec`] of string slices

--- a/seahaven-just/src/exe.rs
+++ b/seahaven-just/src/exe.rs
@@ -2,68 +2,35 @@
 //!
 //! This module provides functionality to resolve the Just CLI executable path
 //! and a type-safe wrapper for the executable path.
-//!
-//! ## Executable resolution
-//!
-//! The Just CLI executable is resolved in the following order:
-//!
-//!  1. If the `SEAHAVEN_JUST_CLI` environment variable is set, its value is used as the
-//!     executable path.
-//!  2. Otherwise, the system's `just` command is located in the `$PATH` environment variable.
-//!
-//! In both cases, the resolved path is validated to ensure it exists and is executable.
-//! If the path is invalid or the executable cannot be found, an error is returned.
 
 use std::{ffi::OsStr, path::Path};
 
-/// The environment variable that contains the path to the just CLI binary
-const JUST_CLI_EXECUTABLE_ENVVAR: &str = "SEAHAVEN_JUST_CLI";
-
-/// The default just CLI executable name
-const DEFAULT_JUST_CLI_EXECUTABLE: &str = "just";
-
-/// Errors that can occur when resolving the Just CLI executable
-#[derive(Debug, thiserror::Error)]
-#[error("Just CLI executable not found: {0}")]
-pub struct NotFoundError(#[from] which::Error);
-
-/// Resolve the just CLI executable path
+/// Resolves and validates a Just executable path
 ///
-/// If the [`JUST_CLI_PATH_ENVVAR`] environment variable is set, it will be used.
-/// Otherwise, the function will try to find the `just` CLI executable in the "$PATH" environment variable.
-/// If the `just` CLI executable is not found, an error is returned.
-///
-/// Returns the path to the just CLI executable.
-pub fn resolve_cli_executable() -> Result<Executable, NotFoundError> {
-    let path = std::env::var_os(JUST_CLI_EXECUTABLE_ENVVAR)
-        .unwrap_or_else(|| DEFAULT_JUST_CLI_EXECUTABLE.into());
+/// Takes a path-like value and attempts to locate the corresponding executable.
+/// Returns an [`Executable`] if the path exists and is executable, or a [`NotFoundError`]
+/// if the executable cannot be found or is not executable.
+pub fn resolve<P>(path: P) -> Result<Executable, NotFoundError>
+where
+    P: AsRef<OsStr>,
+{
     which::which(path)
         .map(|path| Executable(path.into_boxed_path()))
-        .map_err(Into::into)
+        .map_err(NotFoundError)
 }
+
+/// An error that can occur when resolving the Just executable
+#[derive(Debug, thiserror::Error)]
+#[error("Executable not found: {0}")]
+pub struct NotFoundError(which::Error);
 
 /// The path to the Just CLI executable
 ///
 /// A type-safe wrapper around a [`Path`] that represents the path to the executable.
 ///
-/// This type is used to ensure that the Just CLI executable path is always valid.
+/// This type is used to ensure that the Just executable path is always valid.
 #[derive(Clone)]
 pub struct Executable(Box<Path>);
-
-impl Executable {
-    /// Create a new [`Executable`] from a path
-    ///
-    /// The path is resolved and validated to ensure it exists and is executable.
-    /// If the path is not found, or is not executable, an error is returned.
-    pub fn resolve<P>(path: P) -> Result<Self, NotFoundError>
-    where
-        P: AsRef<OsStr>,
-    {
-        which::which(path)
-            .map(|path| Executable(path.into_boxed_path()))
-            .map_err(Into::into)
-    }
-}
 
 impl AsRef<OsStr> for Executable {
     fn as_ref(&self) -> &OsStr {

--- a/seahaven-just/tests/it_exe.rs
+++ b/seahaven-just/tests/it_exe.rs
@@ -1,4 +1,4 @@
-use seahaven_just::exe::{Executable, resolve_cli_executable};
+use seahaven_just::exe::resolve;
 
 #[test_with::no_env(CI)]
 #[test]
@@ -7,7 +7,7 @@ fn resolve_invalid_executable() {
     let invalid_exe_name = "non_existent_just_binary";
 
     //* When
-    let invalid_result = Executable::resolve(invalid_exe_name);
+    let invalid_result = resolve(invalid_exe_name);
 
     //* Then
     assert!(
@@ -20,7 +20,7 @@ fn resolve_invalid_executable() {
 #[test]
 fn executable_display_and_debug() {
     //* Given
-    let exe = resolve_cli_executable().expect("just binary not found");
+    let exe = resolve("just").expect("just binary not found");
 
     //* When
     let display_str = format!("{}", exe);

--- a/seahaven-just/tests/it_version.rs
+++ b/seahaven-just/tests/it_version.rs
@@ -1,10 +1,10 @@
-use seahaven_just::{exe::resolve_cli_executable, version};
+use seahaven_just::{exe::resolve, version};
 
 #[test_with::no_env(CI)]
 #[tokio::test]
 async fn resolve_just_version() {
     //* Given
-    let exe = resolve_cli_executable().expect("just binary not found");
+    let exe = resolve("just").expect("just binary not found");
 
     //* When
     let res = version::fetch(&exe).await;


### PR DESCRIPTION
- Added a new `deps` module to handle the resolution of Docker and Just CLI executables, improving code organization and maintainability.
- Updated command implementations in `build`, `down`, `pull`, `run`, and `up` to utilize the new resolution functions, enhancing error handling for executable resolution.
- Removed redundant executable resolution logic from the `version` and `check` commands, streamlining the codebase.

This enhancement improves the overall structure and reliability of the CLI by centralizing executable resolution logic.