### PR TITLE
feat(seahaven-cli): add support for `--env-file` option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,6 +1538,7 @@ dependencies = [
  "build-info",
  "build-info-build",
  "clap",
+ "dotenvy",
  "indoc",
  "seahaven-docker",
  "seahaven-file",

--- a/docs/notes/setup.yaml.md
+++ b/docs/notes/setup.yaml.md
@@ -1,6 +1,6 @@
 # TODO
 
-- [ ] #v0_2 Support `.env` files in the project root. See [[#Front-matter env + `.env` file support]]
+- [x] #v0_2 Support `.env` files in the project root. See [[#Front-matter env + `.env` file support]]
 # Notes
 - Equivalent to `docker-compose.yaml` file with the `.env` section (constants section).
 - There are two type of containers: 

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/bin/truman/main.rs"
 anyhow = "1.0.97"
 build-info = "0.0.40"
 clap = { version = "4.5", features = ["cargo", "derive"] }
+dotenvy = "0.15.7"
 indoc = "2.0.6"
 seahaven-docker = { version = "0.1.0", path = "../seahaven-docker" }
 seahaven-file = { version = "0.1.0", path = "../seahaven-file" }

--- a/seahaven-cli/src/bin/truman/cmd/build.rs
+++ b/seahaven-cli/src/bin/truman/cmd/build.rs
@@ -1,10 +1,13 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{fs::File, path::PathBuf};
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
-use super::common::file_arg;
-use crate::deps::resolve_docker_executable;
+use super::common::{env_file_arg, file_arg};
+use crate::{
+    deps::resolve_docker_executable,
+    files::{load_env_files, load_setup_file},
+};
 
 /// The `build` command name
 pub const CMD: &str = "build";
@@ -13,7 +16,7 @@ pub const CMD: &str = "build";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Build the development environment images using docker compose")
-        .arg(file_arg())
+        .args([file_arg(), env_file_arg()])
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
@@ -62,16 +65,26 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let setup_file = File::open(setup_file)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
-    let (env, content) = seahaven_file::from_reader(setup_file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?
-        .unpack();
+    let (front_matter_env, content) = load_setup_file(setup_file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
 
     // Transform the content into a compose file
     let compose = seahaven_file::try_into_compose_file(content)
         .map_err(|err| anyhow::anyhow!("Invalid setup file: {err}"))?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/common.rs
+++ b/seahaven-cli/src/bin/truman/cmd/common.rs
@@ -8,3 +8,11 @@ pub fn file_arg() -> clap::Arg {
         .default_value("setup.yaml")
         .value_parser(clap::value_parser!(PathBuf))
 }
+
+/// The `-e`/`--env-file` argument
+pub fn env_file_arg() -> clap::Arg {
+    clap::arg!(-e --"env-file" <ENV_FILE> "Specify an alternate environment file (can be specified multiple times)")
+        .default_value(".env")
+        .action(clap::ArgAction::Append)
+        .value_parser(clap::value_parser!(PathBuf))
+}

--- a/seahaven-cli/src/bin/truman/cmd/down.rs
+++ b/seahaven-cli/src/bin/truman/cmd/down.rs
@@ -1,10 +1,13 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{fs::File, path::PathBuf};
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
-use super::common::file_arg;
-use crate::deps::resolve_docker_executable;
+use super::common::{env_file_arg, file_arg};
+use crate::{
+    deps::resolve_docker_executable,
+    files::{load_env_files, load_setup_file},
+};
 
 /// The `down` command name
 pub const CMD: &str = "down";
@@ -13,7 +16,7 @@ pub const CMD: &str = "down";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Stop and remove containers, networks, images, and volumes")
-        .arg(file_arg())
+        .args([file_arg(), env_file_arg()])
         .args([
             clap::arg!(-v --volumes "Remove named volumes declared in the volumes section of the Compose file")
                 .action(clap::ArgAction::SetTrue),
@@ -55,16 +58,26 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let setup_file = File::open(setup_file)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
-    let (env, content) = seahaven_file::from_reader(setup_file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?
-        .unpack();
+    let (front_matter_env, content) = load_setup_file(setup_file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
 
     // Transform the content into a compose file
     let compose = seahaven_file::try_into_compose_file(content)
         .map_err(|err| anyhow::anyhow!("Invalid setup file: {err}"))?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/dump_config.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config.rs
@@ -1,6 +1,6 @@
 use seahaven_cli::result::Result;
 
-use super::common::file_arg;
+use super::common::{env_file_arg, file_arg};
 
 mod compose_file;
 mod env_file;
@@ -44,7 +44,7 @@ pub fn cmd() -> clap::Command {
               docker compose --file <(truman dump-config compose-file) --env-file <(truman dump-config env-file) up
         "#})
         .subcommands([env_file::cmd(), compose_file::cmd()])
-        .arg(file_arg().global(true))
+        .args([file_arg().global(true), env_file_arg().global(true)])
         .arg_required_else_help(true)
         .infer_long_args(true)
         .infer_subcommands(true)

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/compose_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/compose_file.rs
@@ -1,6 +1,8 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
+
+use crate::files::load_setup_file;
 
 /// The `dump-config compose-file` command name
 pub const CMD: &str = "compose-file";
@@ -49,13 +51,9 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Read and parse the setup file
-    let file = File::open(setup_file_path)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let (_env, content) = seahaven_file::from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
-        .unpack();
+    // Load the setup file and environment files
+    let (_front_matter_env, content) = load_setup_file(setup_file_path)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     // Transform the content into a compose file
     let compose_file = seahaven_file::try_into_compose_file(content)

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
@@ -1,6 +1,8 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
+
+use crate::files::{load_env_files, load_setup_file};
 
 /// The `dump-config env-file` command name
 pub const CMD: &str = "env-file";
@@ -49,12 +51,23 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Read and parse the setup file
-    let file = File::open(setup_file_path)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let env = seahaven_file::fileenv_from_reader(file)
+    // Load the setup file and environment files
+    let (front_matter_env, _content) = load_setup_file(setup_file_path)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // If no environment is present, print a warning and return
     let env = match env {

--- a/seahaven-cli/src/bin/truman/cmd/eject.rs
+++ b/seahaven-cli/src/bin/truman/cmd/eject.rs
@@ -1,8 +1,9 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
 
-use super::common::file_arg;
+use super::common::{env_file_arg, file_arg};
+use crate::files::{load_env_files, load_setup_file};
 
 /// The `eject` command name
 pub const CMD: &str = "eject";
@@ -11,7 +12,7 @@ pub const CMD: &str = "eject";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
-        .arg(file_arg())
+        .args([file_arg(), env_file_arg()])
         .args([clap::arg!(-o --"output-dir" <DIR> "The output directory")
             .default_value(".")
             .value_parser(clap::value_parser!(PathBuf))])
@@ -56,17 +57,27 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Invalid output directory: {}", output_dir.display()).into());
     }
 
-    // Read and parse the setup file
-    let file = File::open(setup_file_path)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {}", err))?;
-    let (env, content) = seahaven_file::from_reader(file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?
-        .unpack();
+    // Load the setup file and environment files
+    let (front_matter_env, content) = load_setup_file(setup_file_path)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
 
     // Transform the content into a compose file
     let compose_file = seahaven_file::try_into_compose_file(content)
         .map_err(|err| anyhow::anyhow!("Failed to convert setup file to compose file: {}", err))?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // Serialize the compose file to a string
     let compose_content = seahaven_file::seahaven_compose_file::ser::to_string(&compose_file)

--- a/seahaven-cli/src/bin/truman/cmd/pull.rs
+++ b/seahaven-cli/src/bin/truman/cmd/pull.rs
@@ -1,10 +1,13 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{fs::File, path::PathBuf};
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
-use super::common::file_arg;
-use crate::deps::resolve_docker_executable;
+use super::common::{env_file_arg, file_arg};
+use crate::{
+    deps::resolve_docker_executable,
+    files::{load_env_files, load_setup_file},
+};
 
 /// The `pull` command name
 pub const CMD: &str = "pull";
@@ -13,7 +16,7 @@ pub const CMD: &str = "pull";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Pull the images for the development environment")
-        .arg(file_arg())
+        .args([file_arg(), env_file_arg()])
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
@@ -52,16 +55,26 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let setup_file = File::open(setup_file)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
-    let (env, content) = seahaven_file::from_reader(setup_file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?
-        .unpack();
+    let (front_matter_env, content) = load_setup_file(setup_file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
 
     // Transform the content into a compose file
     let compose = seahaven_file::try_into_compose_file(content)
         .map_err(|err| anyhow::anyhow!("Invalid setup file: {err}"))?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -1,10 +1,13 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{fs::File, path::PathBuf};
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_just::cmd::{IntoCommand, JustCmd};
 
-use super::common::file_arg;
-use crate::deps::resolve_just_executable;
+use super::common::{env_file_arg, file_arg};
+use crate::{
+    deps::resolve_just_executable,
+    files::{load_env_files, load_setup_file},
+};
 
 /// The `run` command name
 pub const CMD: &str = "run";
@@ -13,7 +16,7 @@ pub const CMD: &str = "run";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("run the development environment images using docker compose")
-        .arg(file_arg())
+        .args([file_arg(), env_file_arg()])
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
@@ -54,12 +57,22 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let setup_file = File::open(setup_file)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
-    let (env, _) = seahaven_file::from_reader(setup_file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?
-        .unpack();
+    let (front_matter_env, _content) = load_setup_file(setup_file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/up.rs
+++ b/seahaven-cli/src/bin/truman/cmd/up.rs
@@ -1,10 +1,13 @@
-use std::{fs::File, io::BufReader, path::PathBuf};
+use std::{fs::File, path::PathBuf};
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 
-use super::common::file_arg;
-use crate::deps::resolve_docker_executable;
+use super::common::{env_file_arg, file_arg};
+use crate::{
+    deps::resolve_docker_executable,
+    files::{load_env_files, load_setup_file},
+};
 
 /// The `up` command name
 pub const CMD: &str = "up";
@@ -13,7 +16,7 @@ pub const CMD: &str = "up";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Start the development environment using docker compose")
-        .arg(file_arg().global(true))
+        .args([file_arg(), env_file_arg()])
         .args([
             clap::arg!(-d --detach "Detached mode: Run containers in the background")
                 .action(clap::ArgAction::SetTrue),
@@ -56,16 +59,26 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let setup_file = File::open(setup_file)
-        .map(BufReader::new)
-        .map_err(|err| anyhow::anyhow!("Failed to open setup file: {err}"))?;
-    let (env, content) = seahaven_file::from_reader(setup_file)
-        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?
-        .unpack();
+    let (front_matter_env, content) = load_setup_file(setup_file)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
 
     // Transform the content into a compose file
     let compose = seahaven_file::try_into_compose_file(content)
         .map_err(|err| anyhow::anyhow!("Invalid setup file: {err}"))?;
+
+    // Merge the env files and front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -1,0 +1,82 @@
+//! # Seahaven file processing
+
+use std::{fs::File, io::BufReader, path::Path};
+
+use seahaven_cli::result::Result;
+use seahaven_file::{Content, Env};
+
+/// Loads a single file and returns its environment variables and content.
+///
+/// Returns an error if the file cannot be opened or parsed.
+pub fn load_setup_file<P>(path: P) -> Result<(Option<Env>, Content)>
+where
+    P: AsRef<Path>,
+{
+    let file = File::open(&path).map(BufReader::new).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to open setup file '{}': {}",
+            path.as_ref().display(),
+            err
+        )
+    })?;
+
+    let res = seahaven_file::from_reader(file)
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "Failed to parse setup file '{}': {}",
+                path.as_ref().display(),
+                err
+            )
+        })?
+        .unpack();
+
+    Ok(res)
+}
+
+/// Loads all variables found in the files into the environment,
+/// overriding any existing environment variables of the same name.
+///
+/// If a variable is specified multiple times in different files,
+/// then the last occurrence is applied.
+///
+/// Files are loaded in order, with later values overriding earlier ones.
+/// If a file is invalid or unreadable, an error is returned.
+pub fn load_env_files<P>(files: impl IntoIterator<Item = P>) -> Result<Option<Env>>
+where
+    P: AsRef<Path>,
+{
+    let mut env = Env::new();
+
+    // Load all files into the environment
+    for path in files {
+        let reader = File::open(&path).map(BufReader::new).map_err(|err| {
+            anyhow::anyhow!(
+                "Failed to open env file '{}': {}",
+                path.as_ref().display(),
+                err,
+            )
+        })?;
+
+        for pair in dotenvy::Iter::new(reader) {
+            match pair {
+                Ok((key, value)) => {
+                    env.insert(key, value);
+                }
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to parse env file '{}': {}",
+                        path.as_ref().display(),
+                        err
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+
+    if env.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(env))
+}

--- a/seahaven-cli/src/bin/truman/main.rs
+++ b/seahaven-cli/src/bin/truman/main.rs
@@ -1,5 +1,6 @@
 mod cmd;
 mod deps;
+mod files;
 
 #[tokio::main(flavor = "current_thread")]
 pub async fn main() {


### PR DESCRIPTION
- Introduced a new `env-file` argument across multiple commands (`build`, `down`, `eject`, `pull`, `run`, `up`, and `dump-config`) to allow users to specify alternate environment files.
- Updated command implementations to load and merge environment variables from the specified files with front matter from the setup file, improving flexibility in environment configuration.
- Refactored file handling logic to utilize a new `files` module for loading setup and environment files, enhancing code organization and maintainability.

This enhancement improves the CLI's usability by providing users with more control over their environment configurations.