### PR TITLE
feat(seahaven-package): introduce seahaven-package crate with manifes handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +508,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foreign-types"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,6 +665,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1384,6 +1401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "regress"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ef7fa9ed0256d64a688a3747d0fef7a88851c18a5e1d57f115f38ec2e09366"
+dependencies = [
+ "hashbrown 0.15.2",
+ "memchr",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1615,6 +1642,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "seahaven-package"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "regress",
+ "seahaven-package-testdata",
+ "semver",
+ "serde",
+ "thiserror",
+ "toml",
+ "tracing",
+]
+
+[[package]]
+name = "seahaven-package-testdata"
+version = "0.0.0"
+dependencies = [
+ "indoc",
+ "minijinja",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1737,15 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
  "serde",
 ]
 
@@ -2021,6 +2079,40 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -2545,6 +2637,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "seahaven-file",
     "seahaven-file/testdata",
     "seahaven-just",
+    "seahaven-package",
+    "seahaven-package/testdata",
 ]
 
 [workspace.package]

--- a/seahaven-package/Cargo.toml
+++ b/seahaven-package/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "seahaven-package"
+description = "The Seahaven package manifest"
+version = "0.1.0"
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[features]
+parse = ["dep:serde", "semver/serde", "toml/parse", "dep:regress"]
+display = ["dep:serde", "semver/serde", "toml/display"]
+
+[dependencies]
+anyhow = "1.0"
+regress = { version = "0.10.3", optional = true }
+semver = "1.0"
+serde = { version = "1.0", optional = true, features = ["derive"] }
+thiserror = "2.0"
+toml = "0.8.20"
+tracing = "0.1.41"
+
+[dev-dependencies]
+seahaven-package-testdata = { path = "testdata" }

--- a/seahaven-package/src/lib.rs
+++ b/seahaven-package/src/lib.rs
@@ -1,0 +1,3 @@
+//! # Seahaven Package
+
+pub mod manifest;

--- a/seahaven-package/src/manifest.rs
+++ b/seahaven-package/src/manifest.rs
@@ -1,0 +1,83 @@
+//! # The Package Manifest
+
+#[cfg(feature = "display")]
+pub mod ser;
+
+#[cfg(feature = "parse")]
+pub mod de;
+
+/// The manifest for a Seahaven package.
+#[derive(Debug)]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct Manifest {
+    /// The package meta information
+    pub package: PackageMeta,
+
+    /// The services in the package
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Vec::is_empty"))]
+    pub services: Vec<Service>,
+
+    /// The init targets in the package
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Vec::is_empty"))]
+    pub init: Vec<InitContainer>,
+}
+
+/// The package meta information
+#[derive(Debug)]
+#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct PackageMeta {
+    /// The name of the package
+    ///
+    /// This is the name of the package as it will be referenced in the workspace.
+    pub name: String,
+
+    /// The version of the package
+    ///
+    /// This is an optional field.
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub version: Option<String>,
+
+    /// The description of the package
+    ///
+    /// This is an optional field.
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub description: Option<String>,
+
+    /// The readme file for the package
+    ///
+    /// This is an optional field.
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub readme: Option<String>,
+}
+
+/// A service in the package
+#[derive(Debug)]
+#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct Service {
+    /// The name of the service
+    pub name: String,
+
+    /// The service defaults
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub defaults: Option<toml::Value>,
+}
+
+/// An init container in the package
+#[derive(Debug)]
+#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct InitContainer {
+    /// The name of the init container
+    pub name: String,
+
+    /// The init container defaults
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub defaults: Option<toml::Value>,
+}

--- a/seahaven-package/src/manifest/de.rs
+++ b/seahaven-package/src/manifest/de.rs
@@ -1,0 +1,75 @@
+//! Deserializing TOML into a [Manifest] struct.
+
+use serde::de::Error;
+
+use super::{InitContainer, Manifest, PackageMeta, Service};
+
+/// Deserializes a string into a [Manifest].
+pub fn from_str(s: &str) -> Result<Manifest, DeserializationError> {
+    toml::from_str(s).map_err(DeserializationError)
+}
+
+impl<'de> serde::de::Deserialize<'de> for Manifest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(serde::Deserialize)]
+        struct ManifestInternal {
+            package: PackageMeta,
+            #[serde(default)]
+            services: Vec<Service>,
+            #[serde(default)]
+            init: Vec<InitContainer>,
+        }
+
+        let manifest = ManifestInternal::deserialize(deserializer)?;
+
+        // Validate the manifest
+        let name_regex = regress::Regex::new(r#"^[a-zA-Z0-9._-]+$"#).expect("Invalid name regex");
+
+        // Check that the package name is valid
+        if name_regex.find(&manifest.package.name).is_none() {
+            return Err(D::Error::custom(format!(
+                "invalid package name: '{}'",
+                manifest.package.name
+            )));
+        }
+
+        // Check that there are either services or init containers defined
+        if manifest.services.is_empty() && manifest.init.is_empty() {
+            return Err(D::Error::custom("no services or init containers defined"));
+        }
+
+        // Check that all service names are valid
+        for service in &manifest.services {
+            if name_regex.find(&service.name).is_none() {
+                return Err(D::Error::custom(format!(
+                    "invalid service name: '{}'",
+                    service.name
+                )));
+            }
+        }
+
+        // Check that all init container names are valid
+        for init in &manifest.init {
+            if name_regex.find(&init.name).is_none() {
+                return Err(D::Error::custom(format!(
+                    "invalid init container name: '{}'",
+                    init.name
+                )));
+            }
+        }
+
+        Ok(Manifest {
+            package: manifest.package,
+            services: manifest.services,
+            init: manifest.init,
+        })
+    }
+}
+
+/// The error that occurs when deserializing a string into a [Manifest].
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct DeserializationError(toml::de::Error);

--- a/seahaven-package/src/manifest/ser.rs
+++ b/seahaven-package/src/manifest/ser.rs
@@ -1,0 +1,18 @@
+//! Serializing a [Manifest] into TOML.
+
+use super::Manifest;
+
+/// Serializes a [Manifest] as a String of TOML.
+pub fn to_string(manifest: &Manifest) -> Result<String, SerializationError> {
+    toml::to_string(manifest).map_err(SerializationError)
+}
+
+/// Serializes a [Manifest] as a "pretty" String of TOML.
+pub fn to_pretty_string(manifest: &Manifest) -> Result<String, SerializationError> {
+    toml::to_string_pretty(manifest).map_err(SerializationError)
+}
+
+/// The error that occurs when serializing a [Manifest] as a String of TOML.
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct SerializationError(toml::ser::Error);

--- a/seahaven-package/testdata/Cargo.toml
+++ b/seahaven-package/testdata/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "seahaven-package-testdata"
+version = "0.0.0"
+edition.workspace = true
+publish = false
+
+[features]
+codegen = []
+
+[dependencies]
+indoc = "2"
+
+[build-dependencies]
+minijinja = { version = "2", features = ["builtins"] }

--- a/seahaven-package/testdata/README.md
+++ b/seahaven-package/testdata/README.md
@@ -1,0 +1,19 @@
+seahaven-package-testdata
+-------------------------
+
+This crate contains test vectors for the Seahaven package manifest.
+
+The test vectors are stored in the `data` directory. 
+The templates for the test vectors are stored in the `templates` directory.
+
+## Code generation
+
+The `build.rs` file contains the code that generates the test vectors from the templates and the data files.
+
+To re-generate the test vectors, run the following command:
+
+```sh
+cargo build -p seahaven-package-testdata --features=codegen
+```
+
+This will generate the test vector files in the `src` directory.

--- a/seahaven-package/testdata/build.rs
+++ b/seahaven-package/testdata/build.rs
@@ -183,7 +183,7 @@ fn main() {
             // Render the content and write to the generated file
             let rendered_content = codegen::engine().render_test_vector(
                 test_vector_name,
-                "seahaven-file/testdata/data",
+                "seahaven-package/testdata/data",
                 content,
             );
             let gen_file = dest_dir.join(&gen_file_name);

--- a/seahaven-package/testdata/data/kitchen_sink.toml
+++ b/seahaven-package/testdata/data/kitchen_sink.toml
@@ -1,0 +1,51 @@
+[package]
+# The name of the package (Required)
+name = "kitchen-sink"
+# The version of the package (Optional)
+version = "0.1.0"
+# The description of the package (Optional)
+description = "A package that does way too much"
+# The readme file for the package (Optional)
+readme = "README.md"
+
+
+# Service target settings. Zero or more are allowed per package.
+[[service]]
+name = "chain"
+image = "ghcr.io/foundry-rs/foundry:latest"
+
+[[service.defaults]]
+command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
+ports = [ "${CHAIN_RPC}:8545" ]
+healthcheck = { interval = "1s", retries = 10, test = "cast block" }
+
+
+# Init target settings. Zero or more are allowed per package.
+[[init]]
+# The name of the init target (Required)
+name = "deploy-core-contracts"
+# Clone the repo and checkout the branch
+source = { git = "https://github.com/LNSD/seahaven-project.git", rev = "d3af235" }
+# The build context for the Dockerfile
+context = "testlib/testdata/app-contracts"
+# The name of the Dockerfile to use within the context
+dockerfile = "Dockerfile"
+
+# The service defaults for the 'deploy-core-contracts' init target
+[[init.defaults]]
+command = "cast deploy"
+
+[[init]]
+name = "deploy-app-contracts"
+# The source for the init target, relative to the package root
+source = "./app-contracts"
+# The name of the Dockerfile to use within the source
+dockerfile = "Dockerfile"
+# The build args for the Dockerfile
+build_args = { CHAIN_ID = 1337 }
+# The build target for the Dockerfile
+target = "debug"
+
+# The service defaults for the 'deploy-app-contracts' init target
+[[init.defaults]]
+command = "cast deploy"

--- a/seahaven-package/testdata/data/name_empty.toml
+++ b/seahaven-package/testdata/data/name_empty.toml
@@ -1,0 +1,13 @@
+[package]
+name = ""
+description = "A package with an empty name"
+
+# Service target settings
+[[service]]
+name = "chain"
+image = "ghcr.io/foundry-rs/foundry:latest"
+
+[[service.defaults]]
+command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
+ports = [ "${CHAIN_RPC}:8545" ]
+healthcheck = { interval = "1s", retries = 10, test = "cast block" }

--- a/seahaven-package/testdata/data/name_invalid.toml
+++ b/seahaven-package/testdata/data/name_invalid.toml
@@ -1,0 +1,12 @@
+[package]
+name = "invalid/name"
+description = "A package with an invalid name"
+
+# Service target settings
+[[service]]
+name = "chain"
+image = "ghcr.io/foundry-rs/foundry:latest"
+
+[[service.defaults]]
+command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
+ports = [ "${CHAIN_RPC}:8545" ]

--- a/seahaven-package/testdata/data/no_targets.toml
+++ b/seahaven-package/testdata/data/no_targets.toml
@@ -1,0 +1,5 @@
+[package]
+name = "no-targets"
+description = "A package that does nothing"
+
+# No targets are defined

--- a/seahaven-package/testdata/src/kitchen_sink.rs
+++ b/seahaven-package/testdata/src/kitchen_sink.rs
@@ -1,0 +1,109 @@
+#[doc = "Test vector: `seahaven-package/testdata/data/kitchen_sink`"]
+#[doc = ""]
+#[doc = "```toml"]
+#[doc = r##"[package]"##]
+#[doc = r##"# The name of the package (Required)"##]
+#[doc = r##"name = "kitchen-sink""##]
+#[doc = r##"# The version of the package (Optional)"##]
+#[doc = r##"version = "0.1.0""##]
+#[doc = r##"# The description of the package (Optional)"##]
+#[doc = r##"description = "A package that does way too much""##]
+#[doc = r##"# The readme file for the package (Optional)"##]
+#[doc = r##"readme = "README.md""##]
+#[doc = r##""##]
+#[doc = r##""##]
+#[doc = r##"# Service target settings. Zero or more are allowed per package."##]
+#[doc = r##"[[service]]"##]
+#[doc = r##"name = "chain""##]
+#[doc = r##"image = "ghcr.io/foundry-rs/foundry:latest""##]
+#[doc = r##""##]
+#[doc = r##"[[service.defaults]]"##]
+#[doc = r##"command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0""##]
+#[doc = r##"ports = [ "${CHAIN_RPC}:8545" ]"##]
+#[doc = r##"healthcheck = { interval = "1s", retries = 10, test = "cast block" }"##]
+#[doc = r##""##]
+#[doc = r##""##]
+#[doc = r##"# Init target settings. Zero or more are allowed per package."##]
+#[doc = r##"[[init]]"##]
+#[doc = r##"# The name of the init target (Required)"##]
+#[doc = r##"name = "deploy-core-contracts""##]
+#[doc = r##"# Clone the repo and checkout the branch"##]
+#[doc = r##"source = { git = "https://github.com/LNSD/seahaven-project.git", rev = "d3af235" }"##]
+#[doc = r##"# The build context for the Dockerfile"##]
+#[doc = r##"context = "testlib/testdata/app-contracts""##]
+#[doc = r##"# The name of the Dockerfile to use within the context"##]
+#[doc = r##"dockerfile = "Dockerfile""##]
+#[doc = r##""##]
+#[doc = r##"# The service defaults for the 'deploy-core-contracts' init target"##]
+#[doc = r##"[[init.defaults]]"##]
+#[doc = r##"command = "cast deploy""##]
+#[doc = r##""##]
+#[doc = r##"[[init]]"##]
+#[doc = r##"name = "deploy-app-contracts""##]
+#[doc = r##"# The source for the init target, relative to the package root"##]
+#[doc = r##"source = "./app-contracts""##]
+#[doc = r##"# The name of the Dockerfile to use within the source"##]
+#[doc = r##"dockerfile = "Dockerfile""##]
+#[doc = r##"# The build args for the Dockerfile"##]
+#[doc = r##"build_args = { CHAIN_ID = 1337 }"##]
+#[doc = r##"# The build target for the Dockerfile"##]
+#[doc = r##"target = "debug""##]
+#[doc = r##""##]
+#[doc = r##"# The service defaults for the 'deploy-app-contracts' init target"##]
+#[doc = r##"[[init.defaults]]"##]
+#[doc = r##"command = "cast deploy""##]
+#[doc = "```"]
+#[doc = ""]
+#[doc = "See file: `seahaven-package/testdata/data/kitchen_sink.toml`"]
+pub const KITCHEN_SINK: &str = indoc::indoc! { r###"
+  [package]
+  # The name of the package (Required)
+  name = "kitchen-sink"
+  # The version of the package (Optional)
+  version = "0.1.0"
+  # The description of the package (Optional)
+  description = "A package that does way too much"
+  # The readme file for the package (Optional)
+  readme = "README.md"
+
+
+  # Service target settings. Zero or more are allowed per package.
+  [[service]]
+  name = "chain"
+  image = "ghcr.io/foundry-rs/foundry:latest"
+
+  [[service.defaults]]
+  command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
+  ports = [ "${CHAIN_RPC}:8545" ]
+  healthcheck = { interval = "1s", retries = 10, test = "cast block" }
+
+
+  # Init target settings. Zero or more are allowed per package.
+  [[init]]
+  # The name of the init target (Required)
+  name = "deploy-core-contracts"
+  # Clone the repo and checkout the branch
+  source = { git = "https://github.com/LNSD/seahaven-project.git", rev = "d3af235" }
+  # The build context for the Dockerfile
+  context = "testlib/testdata/app-contracts"
+  # The name of the Dockerfile to use within the context
+  dockerfile = "Dockerfile"
+
+  # The service defaults for the 'deploy-core-contracts' init target
+  [[init.defaults]]
+  command = "cast deploy"
+
+  [[init]]
+  name = "deploy-app-contracts"
+  # The source for the init target, relative to the package root
+  source = "./app-contracts"
+  # The name of the Dockerfile to use within the source
+  dockerfile = "Dockerfile"
+  # The build args for the Dockerfile
+  build_args = { CHAIN_ID = 1337 }
+  # The build target for the Dockerfile
+  target = "debug"
+
+  # The service defaults for the 'deploy-app-contracts' init target
+  [[init.defaults]]
+  command = "cast deploy""### };

--- a/seahaven-package/testdata/src/lib.rs
+++ b/seahaven-package/testdata/src/lib.rs
@@ -1,0 +1,4 @@
+include!("kitchen_sink.rs");
+include!("name_empty.rs");
+include!("name_invalid.rs");
+include!("no_targets.rs");

--- a/seahaven-package/testdata/src/name_empty.rs
+++ b/seahaven-package/testdata/src/name_empty.rs
@@ -1,0 +1,33 @@
+#[doc = "Test vector: `seahaven-package/testdata/data/name_empty`"]
+#[doc = ""]
+#[doc = "```toml"]
+#[doc = r##"[package]"##]
+#[doc = r##"name = """##]
+#[doc = r##"description = "A package with an empty name""##]
+#[doc = r##""##]
+#[doc = r##"# Service target settings"##]
+#[doc = r##"[[service]]"##]
+#[doc = r##"name = "chain""##]
+#[doc = r##"image = "ghcr.io/foundry-rs/foundry:latest""##]
+#[doc = r##""##]
+#[doc = r##"[[service.defaults]]"##]
+#[doc = r##"command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0""##]
+#[doc = r##"ports = [ "${CHAIN_RPC}:8545" ]"##]
+#[doc = r##"healthcheck = { interval = "1s", retries = 10, test = "cast block" }"##]
+#[doc = "```"]
+#[doc = ""]
+#[doc = "See file: `seahaven-package/testdata/data/name_empty.toml`"]
+pub const NAME_EMPTY: &str = indoc::indoc! { r###"
+  [package]
+  name = ""
+  description = "A package with an empty name"
+
+  # Service target settings
+  [[service]]
+  name = "chain"
+  image = "ghcr.io/foundry-rs/foundry:latest"
+
+  [[service.defaults]]
+  command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
+  ports = [ "${CHAIN_RPC}:8545" ]
+  healthcheck = { interval = "1s", retries = 10, test = "cast block" }"### };

--- a/seahaven-package/testdata/src/name_invalid.rs
+++ b/seahaven-package/testdata/src/name_invalid.rs
@@ -1,0 +1,31 @@
+#[doc = "Test vector: `seahaven-package/testdata/data/name_invalid`"]
+#[doc = ""]
+#[doc = "```toml"]
+#[doc = r##"[package]"##]
+#[doc = r##"name = "invalid/name""##]
+#[doc = r##"description = "A package with an invalid name""##]
+#[doc = r##""##]
+#[doc = r##"# Service target settings"##]
+#[doc = r##"[[service]]"##]
+#[doc = r##"name = "chain""##]
+#[doc = r##"image = "ghcr.io/foundry-rs/foundry:latest""##]
+#[doc = r##""##]
+#[doc = r##"[[service.defaults]]"##]
+#[doc = r##"command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0""##]
+#[doc = r##"ports = [ "${CHAIN_RPC}:8545" ]"##]
+#[doc = "```"]
+#[doc = ""]
+#[doc = "See file: `seahaven-package/testdata/data/name_invalid.toml`"]
+pub const NAME_INVALID: &str = indoc::indoc! { r###"
+  [package]
+  name = "invalid/name"
+  description = "A package with an invalid name"
+
+  # Service target settings
+  [[service]]
+  name = "chain"
+  image = "ghcr.io/foundry-rs/foundry:latest"
+
+  [[service.defaults]]
+  command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
+  ports = [ "${CHAIN_RPC}:8545" ]"### };

--- a/seahaven-package/testdata/src/no_targets.rs
+++ b/seahaven-package/testdata/src/no_targets.rs
@@ -1,0 +1,17 @@
+#[doc = "Test vector: `seahaven-package/testdata/data/no_targets`"]
+#[doc = ""]
+#[doc = "```toml"]
+#[doc = r##"[package]"##]
+#[doc = r##"name = "no-targets""##]
+#[doc = r##"description = "A package that does nothing""##]
+#[doc = r##""##]
+#[doc = r##"# No targets are defined"##]
+#[doc = "```"]
+#[doc = ""]
+#[doc = "See file: `seahaven-package/testdata/data/no_targets.toml`"]
+pub const NO_TARGETS: &str = indoc::indoc! { r###"
+  [package]
+  name = "no-targets"
+  description = "A package that does nothing"
+
+  # No targets are defined"### };

--- a/seahaven-package/testdata/templates/lib.rs.jinja
+++ b/seahaven-package/testdata/templates/lib.rs.jinja
@@ -1,0 +1,1 @@
+include!("{{ path }}");

--- a/seahaven-package/testdata/templates/vector.rs.jinja
+++ b/seahaven-package/testdata/templates/vector.rs.jinja
@@ -1,0 +1,13 @@
+#[doc = "Test vector: `{{ data_set }}/{{ name }}`"]
+#[doc = ""]
+#[doc = "```toml"]
+{% for line in content -%}
+#[doc = r##"{{ line }}"##]
+{% endfor -%}
+#[doc = "```"]
+#[doc = ""]
+#[doc = "See file: `{{ data_set }}/{{ name }}.toml`"]
+pub const {{ name | upper | replace("/","_") }}: &str = indoc::indoc! { r###"
+{% for line in content -%}
+{{ line |  indent(2, true) }} {%- if loop.last %}"### };{% endif %}
+{% endfor -%}

--- a/seahaven-package/tests/it_manifest_serde.rs
+++ b/seahaven-package/tests/it_manifest_serde.rs
@@ -1,0 +1,89 @@
+#![cfg(all(feature = "parse", feature = "display"))]
+
+use seahaven_package_testdata::{KITCHEN_SINK, NAME_EMPTY, NAME_INVALID, NO_TARGETS};
+
+#[test]
+fn parse_kitchen_sink_toml() {
+    //* Given
+    let toml_str = KITCHEN_SINK;
+
+    //* When
+    let manifest =
+        seahaven_package::manifest::de::from_str(toml_str).expect("Failed to deserialize manifest");
+
+    //* Then
+    assert_eq!(manifest.package.name, "kitchen-sink");
+}
+
+#[test]
+fn parse_no_targets_toml() {
+    //* Given
+    // Invalid manifest, no services or init containers defined
+    let toml_str = NO_TARGETS;
+
+    //* When
+    let err = seahaven_package::manifest::de::from_str(toml_str)
+        .expect_err("Failed to deserialize manifest");
+
+    //* Then
+    assert!(
+        err.to_string()
+            .contains("no services or init containers defined")
+    );
+}
+
+#[test]
+fn parse_name_empty_toml() {
+    //* Given
+    let toml_str = NAME_EMPTY;
+
+    //* When
+    let err = seahaven_package::manifest::de::from_str(toml_str)
+        .expect_err("Failed to deserialize manifest");
+
+    //* Then
+    assert!(err.to_string().contains("invalid package name"));
+}
+
+#[test]
+fn parse_name_invalid_toml() {
+    //* Given
+    let toml_str = NAME_INVALID;
+
+    //* When
+    let err = seahaven_package::manifest::de::from_str(toml_str)
+        .expect_err("Failed to deserialize manifest");
+
+    //* Then
+    assert!(err.to_string().contains("invalid package name"));
+}
+
+#[test]
+fn display_kitchen_sink_toml() {
+    //* Given
+    let toml_str = KITCHEN_SINK;
+    let manifest =
+        seahaven_package::manifest::de::from_str(toml_str).expect("Failed to deserialize manifest");
+
+    //* When
+    let serialized = seahaven_package::manifest::ser::to_string(&manifest)
+        .expect("Failed to serialize manifest");
+
+    //* Then
+    assert!(!serialized.is_empty());
+}
+
+#[test]
+fn display_pretty_kitchen_sink_toml() {
+    //* Given
+    let toml_str = KITCHEN_SINK;
+    let manifest =
+        seahaven_package::manifest::de::from_str(toml_str).expect("Failed to deserialize manifest");
+
+    //* When
+    let serialized = seahaven_package::manifest::ser::to_pretty_string(&manifest)
+        .expect("Failed to serialize manifest");
+
+    //* Then
+    assert!(!serialized.is_empty());
+}


### PR DESCRIPTION
- Added a new crate `seahaven-package` to manage package manifests, including serialization and deserialization of TOML files.
- Implemented the `Manifest` struct and its associated methods for handling package metadata, services, and init containers.
- Created test vectors for various manifest scenarios, enhancing test coverage and validation.
- Introduced build scripts for generating test vectors from templates and data files, improving the testing framework.

This addition enhances the Seahaven ecosystem by providing a structured way to manage package manifests and their associated data.