### PR TITLE
fix(seahaven-cli): remove default value for `--env-file` argument

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/common.rs
+++ b/seahaven-cli/src/bin/truman/cmd/common.rs
@@ -12,7 +12,6 @@ pub fn file_arg() -> clap::Arg {
 /// The `-e`/`--env-file` argument
 pub fn env_file_arg() -> clap::Arg {
     clap::arg!(-e --"env-file" <ENV_FILE> "Specify an alternate environment file (can be specified multiple times)")
-        .default_value(".env")
         .action(clap::ArgAction::Append)
         .value_parser(clap::value_parser!(PathBuf))
 }


### PR DESCRIPTION
- Removed the default value for the `--env-file` argument in the CLI, allowing users to specify environment files without a preset fallback.
- This change enhances flexibility by ensuring that the absence of a specified environment file does not default to `.env`, promoting explicit configuration.

This update improves the clarity and control of environment file handling in the CLI.