### PR TITLE
feat(seahaven-compose-file): add 'npipe' option to compose-spec schema

### DIFF
--- a/seahaven-compose-file/schemas/compose-spec.json
+++ b/seahaven-compose-file/schemas/compose-spec.json
@@ -419,7 +419,7 @@
                 "required": ["type"],
                 "properties": {
                   "type": {"type": "string",
-                    "enum": ["bind", "volume", "tmpfs", "cluster", "image"]
+                    "enum": ["bind", "volume", "tmpfs", "cluster", "npipe", "image"]
                   },
                   "source": {"type": "string"},
                   "target": {"type": "string"},


### PR DESCRIPTION
- Updated the `compose-spec.json` schema to include 'npipe' in the enum for the 'type' property, expanding the options available for volume types.
- This change enhances the flexibility of the schema, allowing for more diverse configurations in Docker Compose setups.