### PR TITLE
feat(seahaven-docker): introduce trait for command flag options

### DIFF
--- a/seahaven-docker/src/cmd/common.rs
+++ b/seahaven-docker/src/cmd/common.rs
@@ -23,3 +23,27 @@ pub(super) trait IntoCmdOptValue<T> {
     /// Returns `Some(value)` if the option is set, or `None` if the option is not set.
     fn into_value(self) -> Option<T>;
 }
+
+/// A trait that converts a command option struct into a boolean flag value.
+///
+/// This trait is used internally to convert command option structs into boolean flags.
+/// It provides a type-safe way to handle boolean command line arguments where the presence
+/// or absence of a value is encoded in the type system.
+///
+/// This trait is automatically implemented for any type that implements `IntoCmdOptValue<bool>`.
+pub(super) trait IntoCmdFlagValue: IntoCmdOptValue<bool> {
+    /// Convert the command option struct into a boolean flag value.
+    ///
+    /// Returns `true` if the option is set to `Some(true)`, or `false` otherwise.
+    fn into_flag_value(self) -> bool;
+}
+
+impl<T> IntoCmdFlagValue for T
+where
+    T: IntoCmdOptValue<bool>,
+{
+    #[inline]
+    fn into_flag_value(self) -> bool {
+        matches!(self.into_value(), Some(true))
+    }
+}

--- a/seahaven-docker/src/cmd/compose/build.rs
+++ b/seahaven-docker/src/cmd/compose/build.rs
@@ -1,4 +1,4 @@
-use super::{IntoCmdOptValue, IntoCommand};
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
 
 pub struct DockerComposeBuildCmd<
     D = DryRunNotSet,
@@ -39,7 +39,7 @@ where
         cmd.arg("build");
 
         // --dry-run
-        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+        if self.dry_run_opt.into_flag_value() {
             cmd.arg("--dry-run");
         }
 

--- a/seahaven-docker/src/cmd/compose/down.rs
+++ b/seahaven-docker/src/cmd/compose/down.rs
@@ -1,4 +1,4 @@
-use super::{IntoCmdOptValue, IntoCommand};
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
 
 pub struct DockerComposeDownCmd<V = VolumesNotSet, DR = DryRunNotSet, S = ServicesNotSet> {
     cmd: tokio::process::Command,
@@ -31,12 +31,12 @@ where
         cmd.arg("down");
 
         // --volumes
-        if matches!(self.volumes_opt.into_value(), Some(true)) {
+        if self.volumes_opt.into_flag_value() {
             cmd.arg("--volumes");
         }
 
         // --dry-run
-        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+        if self.dry_run_opt.into_flag_value() {
             cmd.arg("--dry-run");
         }
 

--- a/seahaven-docker/src/cmd/compose/pull.rs
+++ b/seahaven-docker/src/cmd/compose/pull.rs
@@ -1,4 +1,4 @@
-use super::{IntoCmdOptValue, IntoCommand};
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
 
 pub struct DockerComposePullCmd<DR = DryRunNotSet, S = ServicesNotSet> {
     cmd: tokio::process::Command,
@@ -28,7 +28,7 @@ where
         cmd.arg("pull");
 
         // --dry-run
-        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+        if self.dry_run_opt.into_flag_value() {
             cmd.arg("--dry-run");
         }
 

--- a/seahaven-docker/src/cmd/compose/up.rs
+++ b/seahaven-docker/src/cmd/compose/up.rs
@@ -1,4 +1,4 @@
-use super::{IntoCmdOptValue, IntoCommand};
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
 
 pub struct DockerComposeUpCmd<
     D = DetachNotSet,
@@ -39,17 +39,17 @@ where
         cmd.arg("up");
 
         // --build
-        if matches!(self.build_opt.into_value(), Some(true)) {
+        if self.build_opt.into_flag_value() {
             cmd.arg("--build");
         }
 
         // --detach
-        if matches!(self.detach_opt.into_value(), Some(true)) {
+        if self.detach_opt.into_flag_value() {
             cmd.arg("--detach");
         }
 
         // --dry-run
-        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+        if self.dry_run_opt.into_flag_value() {
             cmd.arg("--dry-run");
         }
 

--- a/seahaven-docker/src/cmd/system.rs
+++ b/seahaven-docker/src/cmd/system.rs
@@ -2,7 +2,7 @@ pub mod info;
 pub mod prune;
 
 use self::{info::DockerSystemInfoCmd, prune::DockerSystemPruneCmd};
-use super::common::{IntoCmdOptValue, IntoCommand};
+use super::common::IntoCommand;
 
 pub struct DockerSystemCmd(tokio::process::Command);
 

--- a/seahaven-docker/src/cmd/system/info.rs
+++ b/seahaven-docker/src/cmd/system/info.rs
@@ -1,4 +1,4 @@
-use super::{IntoCmdOptValue, IntoCommand};
+use crate::cmd::common::{IntoCmdOptValue, IntoCommand};
 
 pub struct DockerSystemInfoCmd<F = FormatNotSet> {
     cmd: tokio::process::Command,

--- a/seahaven-docker/src/cmd/system/prune.rs
+++ b/seahaven-docker/src/cmd/system/prune.rs
@@ -1,4 +1,4 @@
-use super::{IntoCmdOptValue, IntoCommand};
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
 
 pub struct DockerSystemPruneCmd<V = VolumesNotSet, A = AllNotSet, F = ForceNotSet> {
     cmd: tokio::process::Command,
@@ -31,17 +31,17 @@ where
         cmd.arg("prune");
 
         // --volumes
-        if matches!(self.volumes_opt.into_value(), Some(true)) {
+        if self.volumes_opt.into_flag_value() {
             cmd.arg("--volumes");
         }
 
         // --all
-        if matches!(self.all_opt.into_value(), Some(true)) {
+        if self.all_opt.into_flag_value() {
             cmd.arg("--all");
         }
 
         // --force
-        if matches!(self.force_opt.into_value(), Some(true)) {
+        if self.force_opt.into_flag_value() {
             cmd.arg("--force");
         }
 

--- a/seahaven-just/src/cmd/common.rs
+++ b/seahaven-just/src/cmd/common.rs
@@ -19,3 +19,27 @@ pub trait IntoCmdOptValue<T> {
     /// Convert the option into its value.
     fn into_value(self) -> Option<T>;
 }
+
+/// A trait that converts a command option struct into a boolean flag value.
+///
+/// This trait is used internally to convert command option structs into boolean flags.
+/// It provides a type-safe way to handle boolean command line arguments where the presence
+/// or absence of a value is encoded in the type system.
+///
+/// This trait is automatically implemented for any type that implements `IntoCmdOptValue<bool>`.
+pub(super) trait IntoCmdFlagValue: IntoCmdOptValue<bool> {
+    /// Convert the command option struct into a boolean flag value.
+    ///
+    /// Returns `true` if the option is set to `Some(true)`, or `false` otherwise.
+    fn into_flag_value(self) -> bool;
+}
+
+impl<T> IntoCmdFlagValue for T
+where
+    T: IntoCmdOptValue<bool>,
+{
+    #[inline]
+    fn into_flag_value(self) -> bool {
+        matches!(self.into_value(), Some(true))
+    }
+}

--- a/seahaven-just/src/cmd/root.rs
+++ b/seahaven-just/src/cmd/root.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use super::{
-    common::{IntoCmdOptValue, IntoCommand},
+    common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand},
     dump::JustDumpCmd,
     list::JustListCmd,
     summary::JustSummaryCmd,
@@ -94,7 +94,7 @@ where
         }
 
         // --dry-run
-        if matches!(self.dry_run_opt.into_value(), Some(true)) {
+        if self.dry_run_opt.into_flag_value() {
             cmd.arg("--dry-run");
         }
 


### PR DESCRIPTION
- Added the `IntoCmdFlagValue` trait to convert command option structs into boolean flag values, enhancing type safety for command line arguments.
- Updated multiple command implementations (`build`, `down`, `pull`, `up`, `prune`, `info`) to utilize the new trait for handling boolean options, simplifying the code, and improving readability.

This enhancement streamlines the management of boolean flags in the CLI, providing a more consistent approach across commands.