### PR TITLE
feat(seahaven-package): allow only one service per package

### DIFF
--- a/seahaven-package/src/manifest.rs
+++ b/seahaven-package/src/manifest.rs
@@ -1,4 +1,9 @@
 //! # The Package Manifest
+//!
+//! The package `manifest.toml` file is used to describe reusable services and init targets
+//! in a Seahaven `setup.yaml` file.
+
+mod model;
 
 #[cfg(feature = "display")]
 pub mod ser;
@@ -6,78 +11,4 @@ pub mod ser;
 #[cfg(feature = "parse")]
 pub mod de;
 
-/// The manifest for a Seahaven package.
-#[derive(Debug)]
-#[cfg_attr(feature = "display", derive(serde::Serialize))]
-pub struct Manifest {
-    /// The package meta information
-    pub package: PackageMeta,
-
-    /// The services in the package
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Vec::is_empty"))]
-    pub services: Vec<Service>,
-
-    /// The init targets in the package
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Vec::is_empty"))]
-    pub init: Vec<InitContainer>,
-}
-
-/// The package meta information
-#[derive(Debug)]
-#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
-#[cfg_attr(feature = "display", derive(serde::Serialize))]
-pub struct PackageMeta {
-    /// The name of the package
-    ///
-    /// This is the name of the package as it will be referenced in the workspace.
-    pub name: String,
-
-    /// The version of the package
-    ///
-    /// This is an optional field.
-    #[cfg_attr(feature = "parse", serde(default))]
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
-    pub version: Option<String>,
-
-    /// The description of the package
-    ///
-    /// This is an optional field.
-    #[cfg_attr(feature = "parse", serde(default))]
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
-    pub description: Option<String>,
-
-    /// The readme file for the package
-    ///
-    /// This is an optional field.
-    #[cfg_attr(feature = "parse", serde(default))]
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
-    pub readme: Option<String>,
-}
-
-/// A service in the package
-#[derive(Debug)]
-#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
-#[cfg_attr(feature = "display", derive(serde::Serialize))]
-pub struct Service {
-    /// The name of the service
-    pub name: String,
-
-    /// The service defaults
-    #[cfg_attr(feature = "parse", serde(default))]
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
-    pub defaults: Option<toml::Value>,
-}
-
-/// An init container in the package
-#[derive(Debug)]
-#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
-#[cfg_attr(feature = "display", derive(serde::Serialize))]
-pub struct InitContainer {
-    /// The name of the init container
-    pub name: String,
-
-    /// The init container defaults
-    #[cfg_attr(feature = "parse", serde(default))]
-    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
-    pub defaults: Option<toml::Value>,
-}
+pub use model::*;

--- a/seahaven-package/src/manifest/de.rs
+++ b/seahaven-package/src/manifest/de.rs
@@ -2,7 +2,7 @@
 
 use serde::de::Error;
 
-use super::{InitContainer, Manifest, PackageMeta, Service};
+use super::model::{InitContainer, Manifest, PackageMeta, Service};
 
 /// Deserializes a string into a [Manifest].
 pub fn from_str(s: &str) -> Result<Manifest, DeserializationError> {
@@ -18,7 +18,7 @@ impl<'de> serde::de::Deserialize<'de> for Manifest {
         struct ManifestInternal {
             package: PackageMeta,
             #[serde(default)]
-            services: Vec<Service>,
+            service: Option<Service>,
             #[serde(default)]
             init: Vec<InitContainer>,
         }
@@ -36,13 +36,13 @@ impl<'de> serde::de::Deserialize<'de> for Manifest {
             )));
         }
 
-        // Check that there are either services or init containers defined
-        if manifest.services.is_empty() && manifest.init.is_empty() {
-            return Err(D::Error::custom("no services or init containers defined"));
+        // Check that there are either a service or init containers defined
+        if manifest.service.is_none() && manifest.init.is_empty() {
+            return Err(D::Error::custom("no service or init containers defined"));
         }
 
-        // Check that all service names are valid
-        for service in &manifest.services {
+        // Check that the service name is valid
+        if let Some(service) = &manifest.service {
             if name_regex.find(&service.name).is_none() {
                 return Err(D::Error::custom(format!(
                     "invalid service name: '{}'",
@@ -63,7 +63,7 @@ impl<'de> serde::de::Deserialize<'de> for Manifest {
 
         Ok(Manifest {
             package: manifest.package,
-            services: manifest.services,
+            service: manifest.service,
             init: manifest.init,
         })
     }

--- a/seahaven-package/src/manifest/model.rs
+++ b/seahaven-package/src/manifest/model.rs
@@ -1,0 +1,75 @@
+/// The manifest for a Seahaven package.
+#[derive(Debug)]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct Manifest {
+    /// The package meta information
+    pub package: PackageMeta,
+
+    /// The service in the package
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub service: Option<Service>,
+
+    /// The init targets in the package
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Vec::is_empty"))]
+    pub init: Vec<InitContainer>,
+}
+
+/// The package meta information
+#[derive(Debug)]
+#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct PackageMeta {
+    /// The name of the package
+    ///
+    /// This is the name of the package as it will be referenced in the workspace.
+    pub name: String,
+
+    /// The version of the package
+    ///
+    /// This is an optional field.
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub version: Option<String>,
+
+    /// The description of the package
+    ///
+    /// This is an optional field.
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub description: Option<String>,
+
+    /// The readme file for the package
+    ///
+    /// This is an optional field.
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub readme: Option<String>,
+}
+
+/// A service in the package
+#[derive(Debug)]
+#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct Service {
+    /// The name of the service
+    pub name: String,
+
+    /// The service defaults
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub defaults: Option<toml::Value>,
+}
+
+/// An init container in the package
+#[derive(Debug)]
+#[cfg_attr(feature = "parse", derive(serde::Deserialize))]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+pub struct InitContainer {
+    /// The name of the init container
+    pub name: String,
+
+    /// The init container defaults
+    #[cfg_attr(feature = "parse", serde(default))]
+    #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
+    pub defaults: Option<toml::Value>,
+}

--- a/seahaven-package/src/manifest/ser.rs
+++ b/seahaven-package/src/manifest/ser.rs
@@ -1,6 +1,6 @@
 //! Serializing a [Manifest] into TOML.
 
-use super::Manifest;
+use super::model::Manifest;
 
 /// Serializes a [Manifest] as a String of TOML.
 pub fn to_string(manifest: &Manifest) -> Result<String, SerializationError> {

--- a/seahaven-package/testdata/data/kitchen_sink.toml
+++ b/seahaven-package/testdata/data/kitchen_sink.toml
@@ -9,12 +9,12 @@ description = "A package that does way too much"
 readme = "README.md"
 
 
-# Service target settings. Zero or more are allowed per package.
-[[service]]
+# Service target settings. Zero or one are allowed per package.
+[service]
 name = "chain"
 image = "ghcr.io/foundry-rs/foundry:latest"
 
-[[service.defaults]]
+[service.defaults]
 command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
 ports = [ "${CHAIN_RPC}:8545" ]
 healthcheck = { interval = "1s", retries = 10, test = "cast block" }

--- a/seahaven-package/testdata/data/name_empty.toml
+++ b/seahaven-package/testdata/data/name_empty.toml
@@ -3,11 +3,11 @@ name = ""
 description = "A package with an empty name"
 
 # Service target settings
-[[service]]
+[service]
 name = "chain"
 image = "ghcr.io/foundry-rs/foundry:latest"
 
-[[service.defaults]]
+[service.defaults]
 command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
 ports = [ "${CHAIN_RPC}:8545" ]
 healthcheck = { interval = "1s", retries = 10, test = "cast block" }

--- a/seahaven-package/testdata/data/name_invalid.toml
+++ b/seahaven-package/testdata/data/name_invalid.toml
@@ -3,10 +3,10 @@ name = "invalid/name"
 description = "A package with an invalid name"
 
 # Service target settings
-[[service]]
+[service]
 name = "chain"
 image = "ghcr.io/foundry-rs/foundry:latest"
 
-[[service.defaults]]
+[service.defaults]
 command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
 ports = [ "${CHAIN_RPC}:8545" ]

--- a/seahaven-package/testdata/src/kitchen_sink.rs
+++ b/seahaven-package/testdata/src/kitchen_sink.rs
@@ -12,12 +12,12 @@
 #[doc = r##"readme = "README.md""##]
 #[doc = r##""##]
 #[doc = r##""##]
-#[doc = r##"# Service target settings. Zero or more are allowed per package."##]
-#[doc = r##"[[service]]"##]
+#[doc = r##"# Service target settings. Zero or one are allowed per package."##]
+#[doc = r##"[service]"##]
 #[doc = r##"name = "chain""##]
 #[doc = r##"image = "ghcr.io/foundry-rs/foundry:latest""##]
 #[doc = r##""##]
-#[doc = r##"[[service.defaults]]"##]
+#[doc = r##"[service.defaults]"##]
 #[doc = r##"command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0""##]
 #[doc = r##"ports = [ "${CHAIN_RPC}:8545" ]"##]
 #[doc = r##"healthcheck = { interval = "1s", retries = 10, test = "cast block" }"##]
@@ -67,12 +67,12 @@ pub const KITCHEN_SINK: &str = indoc::indoc! { r###"
   readme = "README.md"
 
 
-  # Service target settings. Zero or more are allowed per package.
-  [[service]]
+  # Service target settings. Zero or one are allowed per package.
+  [service]
   name = "chain"
   image = "ghcr.io/foundry-rs/foundry:latest"
 
-  [[service.defaults]]
+  [service.defaults]
   command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
   ports = [ "${CHAIN_RPC}:8545" ]
   healthcheck = { interval = "1s", retries = 10, test = "cast block" }

--- a/seahaven-package/testdata/src/name_empty.rs
+++ b/seahaven-package/testdata/src/name_empty.rs
@@ -6,11 +6,11 @@
 #[doc = r##"description = "A package with an empty name""##]
 #[doc = r##""##]
 #[doc = r##"# Service target settings"##]
-#[doc = r##"[[service]]"##]
+#[doc = r##"[service]"##]
 #[doc = r##"name = "chain""##]
 #[doc = r##"image = "ghcr.io/foundry-rs/foundry:latest""##]
 #[doc = r##""##]
-#[doc = r##"[[service.defaults]]"##]
+#[doc = r##"[service.defaults]"##]
 #[doc = r##"command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0""##]
 #[doc = r##"ports = [ "${CHAIN_RPC}:8545" ]"##]
 #[doc = r##"healthcheck = { interval = "1s", retries = 10, test = "cast block" }"##]
@@ -23,11 +23,11 @@ pub const NAME_EMPTY: &str = indoc::indoc! { r###"
   description = "A package with an empty name"
 
   # Service target settings
-  [[service]]
+  [service]
   name = "chain"
   image = "ghcr.io/foundry-rs/foundry:latest"
 
-  [[service.defaults]]
+  [service.defaults]
   command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
   ports = [ "${CHAIN_RPC}:8545" ]
   healthcheck = { interval = "1s", retries = 10, test = "cast block" }"### };

--- a/seahaven-package/testdata/src/name_invalid.rs
+++ b/seahaven-package/testdata/src/name_invalid.rs
@@ -6,11 +6,11 @@
 #[doc = r##"description = "A package with an invalid name""##]
 #[doc = r##""##]
 #[doc = r##"# Service target settings"##]
-#[doc = r##"[[service]]"##]
+#[doc = r##"[service]"##]
 #[doc = r##"name = "chain""##]
 #[doc = r##"image = "ghcr.io/foundry-rs/foundry:latest""##]
 #[doc = r##""##]
-#[doc = r##"[[service.defaults]]"##]
+#[doc = r##"[service.defaults]"##]
 #[doc = r##"command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0""##]
 #[doc = r##"ports = [ "${CHAIN_RPC}:8545" ]"##]
 #[doc = "```"]
@@ -22,10 +22,10 @@ pub const NAME_INVALID: &str = indoc::indoc! { r###"
   description = "A package with an invalid name"
 
   # Service target settings
-  [[service]]
+  [service]
   name = "chain"
   image = "ghcr.io/foundry-rs/foundry:latest"
 
-  [[service.defaults]]
+  [service.defaults]
   command = "anvil --host=0.0.0.0 --chain-id=${CHAIN_ID} --base-fee=0"
   ports = [ "${CHAIN_RPC}:8545" ]"### };

--- a/seahaven-package/tests/it_manifest_serde.rs
+++ b/seahaven-package/tests/it_manifest_serde.rs
@@ -28,7 +28,7 @@ fn parse_no_targets_toml() {
     //* Then
     assert!(
         err.to_string()
-            .contains("no services or init containers defined")
+            .contains("no service or init containers defined")
     );
 }
 


### PR DESCRIPTION
- Moved the `Manifest`, `PackageMeta`, `Service`, and `InitContainer` structs to a new `model.rs` file for better organization.
- Updated the `Manifest` struct to allow only one service instead of multiple, changing the corresponding serialization and deserialization logic.
- Adjusted TOML test data to reflect the new service structure, ensuring compatibility with the updated manifest format.
- Enhanced error messages for clarity when no service or init containers are defined.

This refactor improves the clarity and maintainability of the manifest handling in the Seahaven package.