### PR TITLE
feat(seahaven-package): add name validation and improve deserialization error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ name = "seahaven-package"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "once_cell",
  "regress",
  "seahaven-package-testdata",
  "semver",

--- a/seahaven-package/Cargo.toml
+++ b/seahaven-package/Cargo.toml
@@ -13,6 +13,7 @@ display = ["dep:serde", "semver/serde", "toml/display"]
 
 [dependencies]
 anyhow = "1.0"
+once_cell = "1.21.3"
 regress = { version = "0.10.3", optional = true }
 semver = "1.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/seahaven-package/src/manifest/de.rs
+++ b/seahaven-package/src/manifest/de.rs
@@ -2,12 +2,17 @@
 
 use serde::de::Error;
 
-use super::model::{InitContainer, Manifest, PackageMeta, Service};
+use super::model::{InitContainer, Manifest, Name, PackageMeta, Service};
 
 /// Deserializes a string into a [Manifest].
 pub fn from_str(s: &str) -> Result<Manifest, DeserializationError> {
     toml::from_str(s).map_err(DeserializationError)
 }
+
+/// The error that occurs when deserializing a string into a [Manifest].
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct DeserializationError(toml::de::Error);
 
 impl<'de> serde::de::Deserialize<'de> for Manifest {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -26,39 +31,9 @@ impl<'de> serde::de::Deserialize<'de> for Manifest {
         let manifest = ManifestInternal::deserialize(deserializer)?;
 
         // Validate the manifest
-        let name_regex = regress::Regex::new(r#"^[a-zA-Z0-9._-]+$"#).expect("Invalid name regex");
-
-        // Check that the package name is valid
-        if name_regex.find(&manifest.package.name).is_none() {
-            return Err(D::Error::custom(format!(
-                "invalid package name: '{}'",
-                manifest.package.name
-            )));
-        }
-
         // Check that there are either a service or init containers defined
         if manifest.service.is_none() && manifest.init.is_empty() {
             return Err(D::Error::custom("no service or init containers defined"));
-        }
-
-        // Check that the service name is valid
-        if let Some(service) = &manifest.service {
-            if name_regex.find(&service.name).is_none() {
-                return Err(D::Error::custom(format!(
-                    "invalid service name: '{}'",
-                    service.name
-                )));
-            }
-        }
-
-        // Check that all init container names are valid
-        for init in &manifest.init {
-            if name_regex.find(&init.name).is_none() {
-                return Err(D::Error::custom(format!(
-                    "invalid init container name: '{}'",
-                    init.name
-                )));
-            }
         }
 
         Ok(Manifest {
@@ -69,7 +44,29 @@ impl<'de> serde::de::Deserialize<'de> for Manifest {
     }
 }
 
-/// The error that occurs when deserializing a string into a [Manifest].
-#[derive(Debug, thiserror::Error)]
-#[error(transparent)]
-pub struct DeserializationError(toml::de::Error);
+impl<'de> serde::Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        if !validate::is_valid_name(&name) {
+            return Err(D::Error::custom(format!("invalid name: '{}'", name)));
+        }
+        Ok(Name::new_unchecked(name))
+    }
+}
+
+mod validate {
+    use once_cell::sync::Lazy;
+
+    /// Validates that a name is valid.
+    ///
+    /// A name is valid if it matches the `^[a-zA-Z0-9._-]+$` regex.
+    pub fn is_valid_name(name: &str) -> bool {
+        static NAME_REGEX: Lazy<regress::Regex> =
+            Lazy::new(|| regress::Regex::new(r#"^[a-zA-Z0-9._-]+$"#).expect("Invalid regex"));
+
+        NAME_REGEX.find(name).is_some()
+    }
+}

--- a/seahaven-package/src/manifest/model.rs
+++ b/seahaven-package/src/manifest/model.rs
@@ -1,5 +1,5 @@
 /// The manifest for a Seahaven package.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "display", derive(serde::Serialize))]
 pub struct Manifest {
     /// The package meta information
@@ -15,14 +15,14 @@ pub struct Manifest {
 }
 
 /// The package meta information
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "parse", derive(serde::Deserialize))]
 #[cfg_attr(feature = "display", derive(serde::Serialize))]
 pub struct PackageMeta {
     /// The name of the package
     ///
     /// This is the name of the package as it will be referenced in the workspace.
-    pub name: String,
+    pub name: Name,
 
     /// The version of the package
     ///
@@ -47,12 +47,12 @@ pub struct PackageMeta {
 }
 
 /// A service in the package
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "parse", derive(serde::Deserialize))]
 #[cfg_attr(feature = "display", derive(serde::Serialize))]
 pub struct Service {
     /// The name of the service
-    pub name: String,
+    pub name: Name,
 
     /// The service defaults
     #[cfg_attr(feature = "parse", serde(default))]
@@ -61,15 +61,59 @@ pub struct Service {
 }
 
 /// An init container in the package
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "parse", derive(serde::Deserialize))]
 #[cfg_attr(feature = "display", derive(serde::Serialize))]
 pub struct InitContainer {
     /// The name of the init container
-    pub name: String,
+    pub name: Name,
 
     /// The init container defaults
     #[cfg_attr(feature = "parse", serde(default))]
     #[cfg_attr(feature = "display", serde(skip_serializing_if = "Option::is_none"))]
     pub defaults: Option<toml::Value>,
+}
+
+/// A name that is validated against the `^[a-zA-Z0-9._-]+$` regex.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "display", derive(serde::Serialize))]
+#[cfg_attr(any(feature = "parse", feature = "display"), serde(transparent))]
+pub struct Name(String);
+
+impl Name {
+    /// Creates a new name from a [`String`].
+    ///
+    /// This is an internal function that does not validate the name.
+    #[cfg(feature = "parse")]
+    pub(super) fn new_unchecked(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Consumes the [`Name`] and returns the inner [`String`].
+    ///
+    /// The returned [`String`] is guaranteed to be valid.
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl AsRef<str> for Name {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl<T> std::cmp::PartialEq<T> for Name
+where
+    T: ?Sized + std::convert::AsRef<str>,
+{
+    fn eq(&self, other: &T) -> bool {
+        self.0.as_str() == other.as_ref()
+    }
+}
+
+impl std::fmt::Display for Name {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }

--- a/seahaven-package/tests/it_manifest_serde.rs
+++ b/seahaven-package/tests/it_manifest_serde.rs
@@ -42,7 +42,7 @@ fn parse_name_empty_toml() {
         .expect_err("Failed to deserialize manifest");
 
     //* Then
-    assert!(err.to_string().contains("invalid package name"));
+    assert!(err.to_string().contains("invalid name"));
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn parse_name_invalid_toml() {
         .expect_err("Failed to deserialize manifest");
 
     //* Then
-    assert!(err.to_string().contains("invalid package name"));
+    assert!(err.to_string().contains("invalid name"));
 }
 
 #[test]


### PR DESCRIPTION
- Introduced a new `Name` struct to encapsulate package and service names, ensuring they adhere to a specific regex pattern for validation.
- Updated the `Manifest` struct to use the new `Name` type for package and service names, enhancing type safety.
- Refactored deserialization logic to provide clearer error messages when names are invalid.
- Added validation logic for names in the `de.rs` module, improving the robustness of the manifest handling.

This change enhances the integrity of package and service names within the Seahaven package, ensuring they meet defined criteria.