### PR TITLE
fix(seahaven-cli): enforce subcommand requirement in dump_config command

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/dump_config.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config.rs
@@ -47,6 +47,7 @@ pub fn cmd() -> clap::Command {
         .subcommands([env_file::cmd(), compose_file::cmd()])
         .args([file_arg().global(true), env_file_arg().global(true)])
         .arg_required_else_help(true)
+        .subcommand_required(true)
         .infer_long_args(true)
         .infer_subcommands(true)
 }


### PR DESCRIPTION
- Updated the `cmd` function in `dump_config.rs` to require a subcommand, enhancing command structure and user guidance.
- This change ensures that users must specify a subcommand, improving the clarity of command usage.