### PR TITLE
feat(seahaven-file): add service and init-container parts

### DIFF
--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -84,13 +84,43 @@ where
 
 /// Convert a [`Content`] into a [`ComposeFile`].
 pub fn into_compose_file(file: Content) -> ComposeFile {
-    let mut compose_file = ComposeFile {
+    // Convert the services into a serde_yaml::Mapping
+    let mut services = file
+        .services
+        .into_iter()
+        .map(|(name, service)| {
+            (
+                serde_yaml::Value::String(name.into_inner()),
+                serde_yaml::Value::Mapping(
+                    service
+                        ._rest
+                        .into_iter()
+                        .map(|(k, v)| (serde_yaml::Value::String(k), v))
+                        .collect(),
+                ),
+            )
+        })
+        .collect::<serde_yaml::Mapping>();
+
+    // Merge the init-containers into the services map
+    if let Some(init) = file.init {
+        services.extend(init.into_iter().map(|(name, service)| {
+            (
+                serde_yaml::Value::String(name.into_inner()),
+                serde_yaml::Value::Mapping(
+                    service
+                        ._rest
+                        .into_iter()
+                        .map(|(k, v)| (serde_yaml::Value::String(k), v))
+                        .collect(),
+                ),
+            )
+        }));
+    }
+
+    ComposeFile {
         name: file.name.map(|name| name.into_inner()),
-        services: file
-            .services
-            .into_iter()
-            .map(|(name, service)| (serde_yaml::Value::String(name.into_inner()), service))
-            .collect(),
+        services,
         networks: file
             ._rest
             .get("networks")
@@ -111,15 +141,5 @@ pub fn into_compose_file(file: Content) -> ComposeFile {
             .get("secrets")
             .and_then(|secrets| secrets.as_mapping())
             .cloned(),
-    };
-
-    // Merge the init-containers into the services map
-    if let Some(init) = file.init {
-        compose_file.services.extend(
-            init.into_iter()
-                .map(|(name, service)| (serde_yaml::Value::String(name.into_inner()), service)),
-        );
     }
-
-    compose_file
 }

--- a/seahaven-file/src/model/parts.rs
+++ b/seahaven-file/src/model/parts.rs
@@ -1,5 +1,7 @@
 mod name;
 mod root;
+mod services;
 
 pub use name::Name;
 pub use root::{DeserializedRoot, ValidatedRoot};
+pub use services::{InitContainer, Service};

--- a/seahaven-file/src/model/parts/root.rs
+++ b/seahaven-file/src/model/parts/root.rs
@@ -6,7 +6,10 @@
 
 use indexmap::IndexMap as Map;
 
-use super::name::Name;
+use super::{
+    name::Name,
+    services::{InitContainer, Service},
+};
 
 /// Represents the content of a setup file after parsing, and before validation.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -16,11 +19,11 @@ pub struct DeserializedRoot {
     pub name: Option<Name>,
 
     /// Services top-level element
-    pub services: Map<Name, serde_yaml::Value>,
+    pub services: Map<Name, Service>,
 
     /// Init containers top-level element
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub init: Option<Map<Name, serde_yaml::Value>>,
+    pub init: Option<Map<Name, InitContainer>>,
 
     /// Rest of the file content
     #[serde(flatten, skip_serializing_if = "Map::is_empty")]
@@ -35,11 +38,11 @@ pub struct ValidatedRoot {
     pub name: Option<Name>,
 
     /// Services top-level element
-    pub services: Map<Name, serde_yaml::Value>,
+    pub services: Map<Name, Service>,
 
     /// Init containers top-level element
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub init: Option<Map<Name, serde_yaml::Value>>,
+    pub init: Option<Map<Name, InitContainer>>,
 
     /// Rest of the file content
     #[serde(flatten, skip_serializing_if = "Map::is_empty")]

--- a/seahaven-file/src/model/parts/services.rs
+++ b/seahaven-file/src/model/parts/services.rs
@@ -1,0 +1,17 @@
+use indexmap::IndexMap as Map;
+
+/// Represents a service in the setup file
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Service {
+    /// The rest of the service content
+    #[serde(flatten)]
+    pub _rest: Map<String, serde_yaml::Value>,
+}
+
+/// Represents a init-container service in the setup file
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct InitContainer {
+    /// The rest of the init-container content
+    #[serde(flatten)]
+    pub _rest: Map<String, serde_yaml::Value>,
+}


### PR DESCRIPTION
- Updated the `into_compose_file` function to streamline the conversion of `Content` into `ComposeFile`, integrating init-containers directly into the services map.
- Refactored the `DeserializedRoot` and `ValidatedRoot` structs to use specific `Service` and `InitContainer` types, improving type safety and clarity.
- Introduced a new `services.rs` module to define the `Service` and `InitContainer` structs, enhancing the organization of the model.

This update improves the handling of services and init-containers, leading to a more robust file model in Seahaven.