### PR TITLE
feat(seahaven-file): add package `use` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1623,6 +1623,7 @@ dependencies = [
  "seahaven-file-testdata",
  "serde",
  "serde-envfile",
+ "serde_with",
  "serde_yaml",
  "thiserror",
 ]

--- a/justfile
+++ b/justfile
@@ -11,6 +11,8 @@ default:
 # Run project tests
 test *suites='all':
     #!/usr/bin/env sh
+    set -e # Exit on error
+
     if [ "{{suites}}" = "all" ]; then
         cargo nextest run --all-features
         cargo test --all-features --doc

--- a/seahaven-file/Cargo.toml
+++ b/seahaven-file/Cargo.toml
@@ -20,6 +20,7 @@ once_cell = { version = "1.21.3", optional = true }
 regress = { version = "0.10.3", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "7d02f71" }
+serde_with = "3.12.0"
 serde_yaml = "0.9"
 thiserror = "2.0"
 

--- a/seahaven-file/src/model/parts.rs
+++ b/seahaven-file/src/model/parts.rs
@@ -1,7 +1,12 @@
+mod common;
 mod name;
+mod package_use;
+mod path;
 mod root;
 mod services;
 
 pub use name::Name;
+pub use package_use::PackageUse;
+pub use path::Path;
 pub use root::{DeserializedRoot, ValidatedRoot};
 pub use services::{InitContainer, Service};

--- a/seahaven-file/src/model/parts/common.rs
+++ b/seahaven-file/src/model/parts/common.rs
@@ -1,0 +1,62 @@
+use std::marker::PhantomData;
+
+/// A helper struct that deserializes a package use from a string or a struct.
+pub struct FromStructOrString;
+
+impl<'de, T> serde_with::DeserializeAs<'de, T> for FromStructOrString
+where
+    T: serde::Deserialize<'de> + std::str::FromStr,
+    <T as std::str::FromStr>::Err: std::fmt::Display,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // This is a Visitor that forwards string types to T's `FromStr` impl and
+        // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+        // keep the compiler from complaining about T being an unused generic type
+        // parameter. We need T in order to know the Value type for the Visitor
+        // impl.
+        struct StringOrStruct<T>(PhantomData<fn() -> T>);
+
+        impl<'de, T> serde::de::Visitor<'de> for StringOrStruct<T>
+        where
+            T: serde::Deserialize<'de> + std::str::FromStr,
+            <T as std::str::FromStr>::Err: std::fmt::Display,
+        {
+            type Value = T;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("string or map")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<T, E>
+            where
+                E: serde::de::Error,
+            {
+                std::str::FromStr::from_str(value).map_err(E::custom)
+            }
+
+            fn visit_map<M>(self, map: M) -> Result<T, M::Error>
+            where
+                M: serde::de::MapAccess<'de>,
+            {
+                T::deserialize(serde::de::value::MapAccessDeserializer::new(map))
+            }
+        }
+
+        deserializer.deserialize_any(StringOrStruct(PhantomData))
+    }
+}
+
+impl<T> serde_with::SerializeAs<T> for FromStructOrString
+where
+    T: serde::Serialize,
+{
+    fn serialize_as<S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        value.serialize(serializer)
+    }
+}

--- a/seahaven-file/src/model/parts/name.rs
+++ b/seahaven-file/src/model/parts/name.rs
@@ -37,14 +37,22 @@ where
 impl std::cmp::Eq for Name {}
 
 impl std::str::FromStr for Name {
-    type Err = anyhow::Error;
+    type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if !parse::is_valid_name(s) {
-            return Err(anyhow::anyhow!("invalid name: '{}'", s));
+        let name = s.to_string();
+        if !parse::is_valid_name(&name) {
+            return Err(Error { name });
         }
-        Ok(Name(s.to_string()))
+        Ok(Name(name))
     }
+}
+
+/// An error that occurs when a name is invalid.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid name: '{name}'")]
+pub struct Error {
+    pub name: String,
 }
 
 // TODO: #[cfg(feature = "parse")]
@@ -52,7 +60,7 @@ mod parse {
     use once_cell::sync::Lazy;
     use serde::de::Error as _;
 
-    use super::Name;
+    use super::{Error, Name};
 
     impl Name {
         /// Creates a new name from a [`String`].
@@ -70,7 +78,7 @@ mod parse {
         {
             let name = String::deserialize(deserializer)?;
             if !is_valid_name(&name) {
-                return Err(D::Error::custom(format!("invalid name: '{}'", name)));
+                return Err(D::Error::custom(Error { name }));
             }
             Ok(Name::new_unchecked(name))
         }

--- a/seahaven-file/src/model/parts/package_use.rs
+++ b/seahaven-file/src/model/parts/package_use.rs
@@ -1,0 +1,250 @@
+use super::{
+    name::{Error as NameError, Name},
+    path::{Error as PathError, Path},
+};
+
+/// A package `use` entry.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub struct PackageUse {
+    /// The path to the package
+    pub path: Path,
+
+    /// The target to use
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<Name>,
+}
+
+impl std::str::FromStr for PackageUse {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Split the use string into path and target
+        let (path, target) = match s.split_once('#') {
+            Some((path, target)) => (path, Some(target)),
+            None => (s, None),
+        };
+
+        // Parse the path
+        let path = path.parse::<Path>()?;
+
+        // Parse the target, and return an error if it's an invalid name
+        let target = target.map(|target| target.parse::<Name>()).transpose()?;
+
+        Ok(PackageUse { path, target })
+    }
+}
+
+/// An error that occurs when a package `use` is invalid.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum Error {
+    #[error("invalid package path '{path}': {reason}")]
+    InvalidPath { reason: String, path: String },
+
+    #[error("invalid package target: '{name}'")]
+    InvalidTarget { name: String },
+}
+
+impl From<NameError> for Error {
+    fn from(NameError { name }: NameError) -> Self {
+        Error::InvalidTarget { name }
+    }
+}
+
+impl From<PathError> for Error {
+    fn from(PathError { reason, path }: PathError) -> Self {
+        Error::InvalidPath { reason, path }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PackageUse;
+    use crate::model::parts::common::FromStructOrString;
+
+    /// A test struct that deserializes a package use from a string or a struct.
+    #[serde_with::serde_as]
+    #[derive(Debug, serde::Deserialize, serde::Serialize)]
+    struct TestStruct {
+        #[serde(rename = "use", default, skip_serializing_if = "Option::is_none")]
+        #[serde_as(as = "Option<FromStructOrString>")]
+        pub package_use: Option<PackageUse>,
+    }
+
+    #[test]
+    fn deserialize_from_string() {
+        //* Given
+        let input = r#"use: path/to/package#target"#;
+
+        //* When
+        let result = serde_yaml::from_str::<TestStruct>(input).expect("deserialization failed");
+
+        //* Then
+        let TestStruct { package_use } = result;
+
+        let package_use = package_use.expect("package use should be Some");
+
+        let path = package_use
+            .path
+            .to_str()
+            .expect("failed to convert path to string");
+        assert_eq!(path, "path/to/package");
+
+        let target = package_use.target.expect("target is not set");
+        assert_eq!(target, "target");
+    }
+
+    #[test]
+    fn deserialize_from_string_no_target() {
+        //* Given
+        let input = r#"use: path/to/package"#;
+
+        //* When
+        let result = serde_yaml::from_str::<TestStruct>(input).expect("deserialization failed");
+
+        //* Then
+        let TestStruct { package_use } = result;
+
+        let package_use = package_use.expect("package use should be Some");
+
+        let path = package_use
+            .path
+            .to_str()
+            .expect("failed to convert path to string");
+        assert_eq!(path, "path/to/package");
+        assert!(package_use.target.is_none());
+    }
+
+    #[test]
+    fn deserialize_from_yaml_mapping() {
+        //* Given
+        let input = indoc::indoc! {r#"
+            use:
+              path: path/to/package
+              target: target
+        "#};
+
+        //* When
+        let result = serde_yaml::from_str::<TestStruct>(input).expect("deserialization failed");
+
+        //* Then
+        let TestStruct { package_use } = result;
+
+        let package_use = package_use.expect("package use should be Some");
+
+        let path = package_use
+            .path
+            .to_str()
+            .expect("failed to convert path to string");
+        assert_eq!(path, "path/to/package");
+
+        let target = package_use.target.expect("target is not set");
+        assert_eq!(target, "target");
+    }
+
+    #[test]
+    fn deserialize_from_yaml_mapping_no_target() {
+        //* Given
+        let input = indoc::indoc! {r#"
+            use:
+              path: path/to/package
+        "#};
+
+        //* When
+        let result = serde_yaml::from_str::<TestStruct>(input).expect("deserialization failed");
+
+        //* Then
+        let TestStruct { package_use } = result;
+
+        let package_use = package_use.expect("package use should be Some");
+
+        let path = package_use
+            .path
+            .to_str()
+            .expect("failed to convert path to string");
+        assert_eq!(path, "path/to/package");
+        assert!(package_use.target.is_none());
+    }
+
+    #[test]
+    fn deserialize_from_empty_string() {
+        //* Given
+        let input = r#"use: """#;
+
+        //* When
+        let result =
+            serde_yaml::from_str::<TestStruct>(input).expect_err("deserialization should fail");
+
+        //* Then
+        assert!(result.to_string().contains("invalid package path"));
+        assert!(result.to_string().contains("empty path"));
+    }
+
+    #[test]
+    fn deserialize_from_number() {
+        //* Given
+        let input = r#"use: 123"#;
+
+        //* When
+        let result =
+            serde_yaml::from_str::<TestStruct>(input).expect_err("deserialization should fail");
+
+        //* Then
+        assert!(result.to_string().contains("invalid type"));
+        assert!(result.to_string().contains("expected string or map"));
+    }
+
+    #[test]
+    fn deserialize_from_yaml_mapping_with_empty_path() {
+        //* Given
+        let input = indoc::indoc! {r#"
+            use:
+              path: ""
+        "#};
+
+        //* When
+        let result =
+            serde_yaml::from_str::<TestStruct>(input).expect_err("deserialization should fail");
+
+        //* Then
+        assert!(result.to_string().contains("invalid path"));
+        assert!(result.to_string().contains("empty path"));
+    }
+
+    #[test]
+    fn deserialize_from_invalid_target_name() {
+        //* Given
+        let input = r#"use: path/to/package#invalid/target"#;
+
+        //* When
+        let result =
+            serde_yaml::from_str::<TestStruct>(input).expect_err("deserialization should fail");
+
+        //* Then
+        assert!(result.to_string().contains("invalid package target"));
+        assert!(result.to_string().contains("invalid/target"));
+    }
+
+    #[test]
+    fn serialize_to_yaml_mapping() {
+        //* Given
+        let test_struct = TestStruct {
+            package_use: Some(
+                "path/to/package#target"
+                    .parse::<PackageUse>()
+                    .expect("failed to parse package use"),
+            ),
+        };
+
+        let expected = indoc::indoc! {r#"
+            use:
+              path: path/to/package
+              target: target
+        "#};
+
+        //* When
+        let result = serde_yaml::to_string(&test_struct).expect("serialization failed");
+
+        //* Then
+        assert_eq!(result, expected);
+    }
+}

--- a/seahaven-file/src/model/parts/path.rs
+++ b/seahaven-file/src/model/parts/path.rs
@@ -1,0 +1,260 @@
+use std::path::{Path as StdPath, PathBuf};
+
+use serde::ser::Error as _;
+
+/// A relative file path.
+///
+/// This [`Path`] type represents a relative path with strict validation rules:
+/// - Paths must be non-empty
+/// - Paths must be relative to the current working directory
+/// - Paths cannot contain path traversal components (e.g., `..` or `//`)
+/// - Paths may only start with `.` if it represents the current directory
+///
+/// The [`Path`] type implements serialization and deserialization,
+/// ensuring that paths remain valid when loaded from configuration files.
+///
+/// # Safety
+///
+/// The [`Path`] type enforces strict validation to prevent path traversal attacks and
+/// ensure that all paths are relative to the current working directory.
+#[derive(Clone, PartialEq, Eq)]
+pub struct Path(Box<StdPath>);
+
+impl Path {
+    /// Create a new [`Path`] from a string.
+    #[cfg(test)]
+    fn new_unchecked(path: impl Into<String>) -> Self {
+        Self(std::path::PathBuf::from(path.into()).into_boxed_path())
+    }
+
+    /// Consume the [`Path`] and return the inner boxed path.
+    pub fn into_inner(self) -> Box<StdPath> {
+        self.0
+    }
+
+    /// Returns an object that implements [`Display`] for safely printing paths that
+    /// may contain non-Unicode data. This may perform lossy conversion, depending on the platform.
+    ///
+    /// If you would like an implementation which escapes the path please use [`Debug`] instead.
+    ///
+    /// [`Display`]: std::fmt::Display
+    /// [`Debug`]: std::fmt::Debug
+    pub fn display(&self) -> impl std::fmt::Display {
+        self.0.display()
+    }
+}
+
+impl AsRef<StdPath> for Path {
+    fn as_ref(&self) -> &StdPath {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for Path {
+    type Target = StdPath;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for Path {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::str::FromStr for Path {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Path MUST NOT be empty
+        if s.is_empty() {
+            return Err(Error {
+                reason: "empty path".to_string(),
+                path: s.to_string(),
+            });
+        }
+
+        let path = PathBuf::from(s).into_boxed_path();
+
+        // It MUST be a relative path, i.e. it MUST NOT contain any path traversal components,
+        // It MUST NOT contain any path traversal components, only an starting `.` is allowed.
+        let mut components = path.components().peekable();
+        if matches!(components.peek(), Some(std::path::Component::CurDir)) {
+            components.next();
+        }
+
+        // Check if the path has any prefix and/or is absolute
+        if components.clone().any(|c: std::path::Component| {
+            matches!(
+                c,
+                std::path::Component::Prefix(_) | std::path::Component::RootDir
+            )
+        }) {
+            return Err(Error {
+                reason: "cannot contain prefix or absolute path".to_string(),
+                path: s.to_string(),
+            });
+        }
+
+        // Check if the path contains any path traversal components
+        if components
+            .clone()
+            .any(|c: std::path::Component| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(Error {
+                reason: "cannot contain path traversal components".to_string(),
+                path: s.to_string(),
+            });
+        }
+
+        Ok(Path(path))
+    }
+}
+
+/// An error that occurs when a path is invalid.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("invalid path '{path}': {reason}")]
+pub struct Error {
+    pub reason: String,
+    pub path: String,
+}
+
+impl<'de> serde::de::Deserialize<'de> for Path {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: &str = serde::Deserialize::deserialize(deserializer)?;
+        s.parse::<Path>().map_err(serde::de::Error::custom)
+    }
+}
+
+impl serde::ser::Serialize for Path {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let path_str = self
+            .0
+            .to_str()
+            .ok_or(S::Error::custom("path must be valid UTF-8"))?;
+        serializer.serialize_str(path_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Path;
+
+    #[test]
+    fn valid_relative_path() {
+        //* Given
+        let path_str = "config/app.yaml";
+
+        //* When
+        let path = path_str.parse::<Path>().expect("path should be valid");
+
+        //* Then
+        assert_eq!(path.to_string_lossy(), path_str);
+    }
+
+    #[test]
+    fn empty_path_error() {
+        //* Given
+        let path_str = "";
+
+        //* When
+        let err = path_str
+            .parse::<Path>()
+            .expect_err("path should be invalid");
+
+        //* Then
+        assert_eq!(err.reason, "empty path");
+        assert_eq!(err.path, path_str);
+    }
+
+    #[test]
+    #[cfg(target_family = "unix")]
+    fn absolute_path_error() {
+        //* Given
+        let path_str = "/etc/config.yaml";
+
+        //* When
+        let err = path_str
+            .parse::<Path>()
+            .expect_err("path should be invalid");
+
+        //* Then
+        assert_eq!(err.reason, "cannot contain prefix or absolute path");
+        assert_eq!(err.path, path_str);
+    }
+
+    #[test]
+    fn path_traversal_error() {
+        //* Given
+        let path_str = "../config.yaml";
+
+        //* When
+        let err = path_str
+            .parse::<Path>()
+            .expect_err("path should be invalid");
+
+        //* Then
+        assert_eq!(err.reason, "cannot contain path traversal components");
+        assert_eq!(err.path, path_str);
+    }
+
+    #[test]
+    fn current_dir_allowed() {
+        //* Given
+        let path_str = "./config.yaml";
+
+        //* When
+        let path = path_str.parse::<Path>().expect("path should be valid");
+
+        //* Then
+        assert_eq!(path.to_string_lossy(), path_str);
+    }
+
+    #[test]
+    #[cfg(target_family = "windows")]
+    fn windows_absolute_path_error() {
+        //* Given
+        let path_str = "C:\\config.yaml";
+
+        //* When
+        let err = path_str
+            .parse::<Path>()
+            .expect_err("path should be invalid");
+
+        //* Then
+        assert_eq!(err.reason, "cannot contain prefix or absolute path");
+        assert_eq!(err.path, path_str);
+    }
+
+    #[test]
+    fn serialize_path() {
+        //* Given
+        let path = Path::new_unchecked("config/app.yaml");
+
+        //* When
+        let serialized = serde_yaml::to_string(&path).expect("path should be serializable");
+
+        //* Then
+        assert_eq!(serialized.trim(), "config/app.yaml");
+    }
+
+    #[test]
+    fn deserialize_path() {
+        //* Given
+        let path_str = "config/app.yaml";
+
+        //* When
+        let path = serde_yaml::from_str::<Path>(path_str).expect("path should be deserializable");
+
+        //* Then
+        assert_eq!(path.to_string_lossy(), path_str);
+    }
+}

--- a/seahaven-file/src/model/parts/services.rs
+++ b/seahaven-file/src/model/parts/services.rs
@@ -1,16 +1,30 @@
 use indexmap::IndexMap as Map;
 
+use super::{common::FromStructOrString, package_use::PackageUse};
+
 /// Represents a service in the setup file
+#[serde_with::serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct Service {
+    /// A package `use` binding
+    #[serde(rename = "use", default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<FromStructOrString>")]
+    pub package_use: Option<PackageUse>,
+
     /// The rest of the service content
     #[serde(flatten)]
     pub _rest: Map<String, serde_yaml::Value>,
 }
 
 /// Represents a init-container service in the setup file
+#[serde_with::serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct InitContainer {
+    /// A package `use` binding
+    #[serde(rename = "use", default, skip_serializing_if = "Option::is_none")]
+    #[serde_as(as = "Option<FromStructOrString>")]
+    pub package_use: Option<PackageUse>,
+
     /// The rest of the init-container content
     #[serde(flatten)]
     pub _rest: Map<String, serde_yaml::Value>,


### PR DESCRIPTION
- Added a new `Path` struct to enforce strict validation rules for relative file paths, preventing path traversal attacks.
- Introduced a `PackageUse` struct to represent package use entries, allowing for optional target specification.
- Implemented a `FromStructOrString` helper for deserializing package use from various formats.
- Updated existing `Service` and `InitContainer` structs to include package use bindings.

This update significantly enhances the robustness and safety of the Seahaven file model.