### PR TITLE
feat(seahaven-cli): implement YAML value merging and transcoding functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2079,9 +2080,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2096,6 +2097,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -29,8 +29,12 @@ serde_yaml = "0.9.34"
 tempfile = "3.19.1"
 thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "macros"] }
+toml = { version = "0.8.22", features = ["preserve_order"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 [build-dependencies]
 build-info-build = "0.0.40"
+
+[dev-dependencies]
+toml = "0.8.22"

--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -2,7 +2,7 @@
 
 use std::{fs::File, io::BufReader, path::Path};
 
-use seahaven_cli::result::Result;
+use seahaven_cli::{result::Result, transcoding};
 use seahaven_compose_file::ComposeFile;
 use seahaven_setup_file::{Content, Env};
 
@@ -142,4 +142,14 @@ pub fn into_compose_file(file: Content) -> ComposeFile {
             .and_then(|secrets| secrets.as_mapping())
             .cloned(),
     }
+}
+
+/// This function converts the `[service.defaults]` or `[[init.defaults]]` table into
+/// a setup-file's `service` or `init` fields.
+///
+/// Transcodes a [`toml::Value`] to a [`serde_yaml::Value`].
+pub fn transcode_package_target_defaults(
+    value: toml::Value,
+) -> Result<serde_yaml::Value, serde_yaml::Error> {
+    transcoding::transcode(value, serde_yaml::value::Serializer)
 }

--- a/seahaven-cli/src/lib.rs
+++ b/seahaven-cli/src/lib.rs
@@ -1,3 +1,8 @@
 //! # Seahaven CLI
 
+#[macro_use]
+extern crate serde;
+
 pub mod result;
+pub mod serde_yaml_ext;
+pub mod transcoding;

--- a/seahaven-cli/src/serde_yaml_ext.rs
+++ b/seahaven-cli/src/serde_yaml_ext.rs
@@ -1,0 +1,207 @@
+//! Extension of the `serde_yaml` crate providing YAML value merging functionality.
+
+/// Trait extending [`Value`] with merging capabilities.
+///
+/// Merging follows these rules:
+/// - Mappings: Recursively merge matching keys, insert new keys.
+/// - Sequences: Append source to target.
+/// - Scalars: Overwrite target with source.
+///
+/// [`Value`]: serde_yaml::Value
+pub trait ValueMergeExt: _priv::Sealed {
+    /// Merges the current value with another [`Value`].
+    ///
+    /// The current value is modified in-place according to the merging rules.
+    ///
+    /// [`Value`]: serde_yaml::Value
+    fn merge(&mut self, other: &serde_yaml::Value);
+
+    /// Merges the current value into the target [`Value`].
+    ///
+    /// The target [`Value`] is modified in-place according to the merging rules.
+    ///
+    /// [`Value`]: serde_yaml::Value
+    fn merge_into(&self, target: &mut serde_yaml::Value);
+}
+
+impl ValueMergeExt for serde_yaml::Value {
+    fn merge(&mut self, other: &serde_yaml::Value) {
+        match (self, other) {
+            // If the source and the target are both mappings, merge the source into the target.
+            (serde_yaml::Value::Mapping(dst_map), serde_yaml::Value::Mapping(src_map)) => {
+                for (key, src_val) in src_map {
+                    // If the key is present in both, recursively merge the values;
+                    // otherwise, insert the source key into the target.
+                    match dst_map.get_mut(key) {
+                        Some(dst_val) => dst_val.merge(src_val),
+                        None => {
+                            dst_map.insert(key.clone(), src_val.clone());
+                        }
+                    };
+                }
+            }
+
+            // If the source and the target are both sequences, extend the target with the source.
+            (serde_yaml::Value::Sequence(dst_seq), serde_yaml::Value::Sequence(src_seq)) => {
+                dst_seq.extend_from_slice(src_seq);
+            }
+
+            // Otherwise overwrite the target value with the source value.
+            (dst, src) => *dst = src.clone(),
+        }
+    }
+
+    fn merge_into(&self, target: &mut serde_yaml::Value) {
+        target.merge(self);
+    }
+}
+
+impl _priv::Sealed for serde_yaml::Value {}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_yaml::Value;
+
+    use super::ValueMergeExt as _;
+
+    #[test]
+    fn merge_mappings_recursively() {
+        //* Given
+        let mut target: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            a: 1
+            b: 2
+            nested:
+                x: 10
+                y: 20
+        "#})
+        .expect("Failed to parse target YAML");
+
+        let source: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            b: 3
+            c: 4
+            nested:
+                y: 30
+                z: 40
+        "#})
+        .expect("Failed to parse source YAML");
+
+        //* When
+        target.merge(&source);
+
+        //* Then
+        let expected: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            a: 1
+            b: 3
+            c: 4
+            nested:
+                x: 10
+                y: 30
+                z: 40
+        "#})
+        .expect("Failed to parse expected YAML");
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn append_sequences_on_merge() {
+        //* Given
+        let mut target: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            - 1
+            - 2
+            - 3
+        "#})
+        .expect("Failed to parse target YAML");
+
+        let source: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            - 4
+            - 5
+        "#})
+        .expect("Failed to parse source YAML");
+
+        //* When
+        target.merge(&source);
+
+        //* Then
+        let expected: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            - 1
+            - 2
+            - 3
+            - 4
+            - 5
+        "#})
+        .expect("Failed to parse expected YAML");
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn overwrite_scalars_on_merge() {
+        //* Given
+        let mut target = Value::String(String::from("old"));
+        let source = Value::String(String::from("new"));
+
+        // When
+        target.merge(&source);
+
+        // Then
+        assert_eq!(target.as_str(), Some("new"));
+    }
+
+    #[test]
+    fn replace_on_different_types() {
+        //* Given
+        let mut target: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            a: 1
+            b: 2
+        "#})
+        .expect("Failed to parse target YAML");
+
+        let source: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            - 1
+            - 2
+            - 3
+        "#})
+        .expect("Failed to parse source YAML");
+
+        //* When
+        target.merge(&source);
+
+        //* Then
+        assert_eq!(target, source);
+    }
+
+    #[test]
+    fn merge_into() {
+        // Given
+        let source: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            a: 1
+            b: 2
+        "#})
+        .expect("Failed to parse source YAML");
+
+        let mut target: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            b: 3
+            c: 4
+        "#})
+        .expect("Failed to parse target YAML");
+
+        // When
+        source.merge_into(&mut target);
+
+        // Then
+        let expected: Value = serde_yaml::from_str(indoc::indoc! {r#"
+            a: 1
+            b: 2
+            c: 4
+        "#})
+        .expect("Failed to parse expected YAML");
+
+        assert_eq!(target, expected);
+    }
+}

--- a/seahaven-cli/src/transcoding.rs
+++ b/seahaven-cli/src/transcoding.rs
@@ -1,0 +1,30 @@
+//! Transcode from one [Serde](https://serde.rs/) format to another.
+//!
+//! This module provides functionality to "transcode" from an arbitrary Serde
+//! `Deserializer` to an arbitrary Serde `Serializer` without needing to
+//! collect the entire input into an intermediate form in memory. For example,
+//! you could translate a stream of JSON data into a stream of CBOR data, or
+//! translate JSON into its pretty-printed form.
+
+// Code borrowed with modifications from: https://github.com/sfackler/serde-transcode/blob/7c8dae5816dae317b0132ee02a35bb5d59b163a7/src/lib.rs
+// The original project (sfackler/serde-transcode) is licensed under either of the MIT license or the Apache License 2.0.
+
+mod transcoder;
+
+use serde::ser::Serialize as _;
+pub use transcoder::Transcoder;
+
+/// Transcodes from a Serde [`Deserializer`] to a Serde [`Serializer`].
+///
+/// [`Serializer`]: serde::ser::Serializer
+/// [`Deserializer`]: serde::de::Deserializer
+pub fn transcode<'de, D, S>(d: D, s: S) -> Result<S::Ok, S::Error>
+where
+    D: serde::de::Deserializer<'de>,
+    S: serde::ser::Serializer,
+{
+    Transcoder::new(d).serialize(s)
+}
+
+#[cfg(test)]
+mod tests;

--- a/seahaven-cli/src/transcoding/tests.rs
+++ b/seahaven-cli/src/transcoding/tests.rs
@@ -1,0 +1,870 @@
+// Code borrowed with modifications from: https://github.com/sfackler/serde-transcode/blob/7c8dae5816dae317b0132ee02a35bb5d59b163a7/src/test.rs
+// The original project (sfackler/serde-transcode) is licensed under either of the MIT license or the Apache License 2.0.
+
+use std::collections::HashMap;
+
+use crate::transcoding::transcode;
+
+#[test]
+fn boolean_true() {
+    //* Given
+    let input = true;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: bool =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn boolean_false() {
+    //* Given
+    let input = false;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: bool =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i8_min() {
+    //* Given
+    let input = i8::MIN;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i8 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i8_zero() {
+    //* Given
+    let input = 0i8;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i8 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i8_max() {
+    //* Given
+    let input = i8::MAX;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i8 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i16_min() {
+    //* Given
+    let input = i16::MIN;
+
+    // Type 'i16' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i16 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i16_zero() {
+    //* Given
+    let input = 0i16;
+
+    // Type 'i16' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i16 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i16_max() {
+    //* Given
+    let input = i16::MAX;
+
+    // Type 'i16' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i16 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i32_min() {
+    //* Given
+    let input = i32::MIN;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i32_zero() {
+    //* Given
+    let input = 0i32;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i32_max() {
+    //* Given
+    let input = i32::MAX;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i64_min() {
+    //* Given
+    let input = i64::MIN;
+
+    // Type 'i64' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i64_zero() {
+    //* Given
+    let input = 0i64;
+
+    // Type 'i64' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn i64_max() {
+    //* Given
+    let input = i64::MAX;
+
+    // Type 'i64' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: i64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn isize_min() {
+    //* Given
+    let input = isize::MIN;
+
+    // Type 'isize' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: isize =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn isize_zero() {
+    //* Given
+    let input = 0isize;
+
+    // Type 'isize' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: isize =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn isize_max() {
+    //* Given
+    let input = isize::MAX;
+
+    // Type 'isize' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: isize =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u8_zero() {
+    //* Given
+    let input = 0u8;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u8 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u8_max() {
+    //* Given
+    let input = u8::MAX;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u8 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u16_zero() {
+    //* Given
+    let input = 0u16;
+
+    // Type 'u16' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u16 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u16_max() {
+    //* Given
+    let input = u16::MAX;
+
+    // Type 'u16' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u16 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u32_zero() {
+    //* Given
+    let input = 0u32;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u32_max() {
+    //* Given
+    let input = u32::MAX;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u64_zero() {
+    //* Given
+    let input = 0u64;
+
+    // Type 'u64' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn u64_large() {
+    //* Given
+    let input = u32::MAX as u64 + 1;
+
+    // Type 'u64' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: u64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn usize_zero() {
+    //* Given
+    let input = 0usize;
+
+    // Type 'usize' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: usize =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn usize_large() {
+    //* Given
+    let input = u32::MAX as usize + 1;
+
+    // Type 'usize' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: usize =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+serde_if_integer128! {
+    #[test]
+    fn i128_min() {
+        //* Given
+        let input = i64::MIN as i128;
+
+        // Type 'i128' is not supported by `toml::Value`
+        let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+        //* When
+        let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+            .expect("Failed to serialize input to YAML value");
+
+        //* Then
+        let output: i128 = serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn i128_zero() {
+        //* Given
+        let input = 0i128;
+
+        // Type 'i128' is not supported by `toml::Value`
+        let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+        //* When
+        let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+            .expect("Failed to serialize input to YAML value");
+
+        //* Then
+        let output: i128 = serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn i128_large() {
+        //* Given
+        let input = i64::MAX as i128 + 1;
+
+        // Type 'i128' is not supported by `toml::Value`
+        let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+        //* When
+        let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+            .expect("Failed to serialize input to YAML value");
+
+        //* Then
+        let output: i128 = serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn u128_zero() {
+        //* Given
+        let input = 0u128;
+
+        // Type 'u128' is not supported by `toml::Value`
+        let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+        //* When
+        let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+            .expect("Failed to serialize input to YAML value");
+
+        //* Then
+        let output: u128 = serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn u128_large() {
+        //* Given
+        let input = u32::MAX as u128 + 1;
+
+        // Type 'u128' is not supported by `toml::Value`
+        let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+        //* When
+        let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+            .expect("Failed to serialize input to YAML value");
+
+        //* Then
+        let output: u128 = serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+        assert_eq!(input, output);
+    }
+}
+
+#[test]
+fn f32_positive() {
+    //* Given
+    let input = 1.3f32;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: f32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn f32_negative() {
+    //* Given
+    let input = -1e10f32;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: f32 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn f64_positive() {
+    //* Given
+    let input = 1.3f64;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: f64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn f64_negative() {
+    //* Given
+    let input = -1e10f64;
+
+    let input_value = toml::Value::from(input);
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: f64 =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn char_letter() {
+    //* Given
+    let input = 'a';
+
+    // Type 'char' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: char =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn char_null() {
+    //* Given
+    let input = '\0';
+
+    // Type 'char' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: char =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn string_nonempty() {
+    //* Given
+    let input = String::from("hello world");
+
+    let input_value = toml::Value::from(input.clone());
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: String =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn string_empty() {
+    //* Given
+    let input = String::from("");
+
+    let input_value = toml::Value::from(input.clone());
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: String =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn unit_type() {
+    //* Given
+    let input = ();
+
+    // Type '()' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let _output: () =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    // `assert_eq!` of unit values will always succeed
+}
+
+#[test]
+fn option_none() {
+    //* Given
+    let input: Option<i32> = None;
+
+    // Type 'Option' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: Option<i32> =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn option_some_int() {
+    //* Given
+    let input = Some(0i32);
+
+    // Type 'Option' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: Option<i32> =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn option_some_string() {
+    //* Given
+    let input = Some(String::from("hi"));
+
+    // Type 'Option' is not supported by `toml::Value`
+    let input_value = serde_yaml::to_value(&input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: Option<String> =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn sequence_numbers() {
+    //* Given
+    let input = vec![0, 1, 2, 3];
+
+    let input_value = toml::Value::from(input.clone());
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: Vec<i32> =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn map_string_vec() {
+    //* Given
+    let input = HashMap::from_iter([
+        ("hello".to_string(), vec![1, 2]),
+        ("goodbye".to_string(), vec![]),
+    ]);
+
+    let input_value = toml::Value::from(input.clone());
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: HashMap<String, Vec<i32>> =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}
+
+#[test]
+fn newtype_struct() {
+    //* Given
+    #[derive(PartialEq, Debug)]
+    struct Foo(i32);
+
+    impl serde::ser::Serialize for Foo {
+        fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::ser::Serializer,
+        {
+            s.serialize_newtype_struct("Foo", &self.0)
+        }
+    }
+
+    impl<'de> serde::de::Deserialize<'de> for Foo {
+        fn deserialize<D>(d: D) -> Result<Foo, D::Error>
+        where
+            D: serde::de::Deserializer<'de>,
+        {
+            struct V;
+
+            impl<'de> serde::de::Visitor<'de> for V {
+                type Value = Foo;
+
+                fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+                    write!(fmt, "a Foo struct")
+                }
+
+                fn visit_newtype_struct<D>(self, d: D) -> Result<Foo, D::Error>
+                where
+                    D: serde::de::Deserializer<'de>,
+                {
+                    Ok(Foo(serde::de::Deserialize::deserialize(d)?))
+                }
+            }
+
+            d.deserialize_newtype_struct("Foo", V)
+        }
+    }
+
+    let input = Foo(100);
+
+    // Serialize the input to `serde_yaml::Value`
+    let input_value = serde_yaml::to_value(&input).expect("Failed to serialize input to YAML");
+
+    //* When
+    let transcoded_value = transcode(input_value, serde_yaml::value::Serializer)
+        .expect("Failed to serialize input to YAML value");
+
+    //* Then
+    let output: Foo =
+        serde_yaml::from_value(transcoded_value).expect("Failed to deserialize to input type");
+    assert_eq!(input, output);
+}

--- a/seahaven-cli/src/transcoding/transcoder.rs
+++ b/seahaven-cli/src/transcoding/transcoder.rs
@@ -1,0 +1,300 @@
+use std::cell::Cell;
+
+use serde::ser::{SerializeMap as _, SerializeSeq as _};
+
+/// A Serde transcoder.
+///
+/// In most cases, the `transcode` function should be used instead of this
+/// type.
+///
+/// # Note
+///
+/// Unlike traditional serializable types, `Transcoder`'s `Serialize`
+/// implementation is *not* idempotent, as it advances the state of its
+/// internal `Deserializer`. It should only ever be serialized once.
+pub struct Transcoder<D>(Cell<Option<D>>);
+
+impl<'de, D> Transcoder<D>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    /// Constructs a new `Transcoder`.
+    pub fn new(d: D) -> Transcoder<D> {
+        Transcoder(Cell::new(Some(d)))
+    }
+}
+
+impl<'de, D> serde::ser::Serialize for Transcoder<D>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        self.0
+            .take()
+            .expect("Transcoder may only be serialized once")
+            .deserialize_any(Visitor(s))
+            .map_err(d2s)
+    }
+}
+
+struct Visitor<S>(S);
+
+impl<'de, S> serde::de::Visitor<'de> for Visitor<S>
+where
+    S: serde::ser::Serializer,
+{
+    type Value = S::Ok;
+
+    fn expecting(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(fmt, "any value")
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_bool(v).map_err(s2d)
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_i8(v).map_err(s2d)
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_i16(v).map_err(s2d)
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_i32(v).map_err(s2d)
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_i64(v).map_err(s2d)
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_u8(v).map_err(s2d)
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_u16(v).map_err(s2d)
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_u32(v).map_err(s2d)
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_u64(v).map_err(s2d)
+    }
+
+    serde_if_integer128! {
+        fn visit_i128<E>(self, v: i128) -> Result<S::Ok, E>
+            where E: serde::de::Error
+        {
+            self.0.serialize_i128(v).map_err(s2d)
+        }
+
+        fn visit_u128<E>(self, v: u128) -> Result<S::Ok, E>
+            where E: serde::de::Error
+        {
+            self.0.serialize_u128(v).map_err(s2d)
+        }
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_f32(v).map_err(s2d)
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_f64(v).map_err(s2d)
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_char(v).map_err(s2d)
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_str(v).map_err(s2d)
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_str(&v).map_err(s2d)
+    }
+
+    fn visit_unit<E>(self) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_unit().map_err(s2d)
+    }
+
+    fn visit_none<E>(self) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_none().map_err(s2d)
+    }
+
+    fn visit_some<D>(self, d: D) -> Result<S::Ok, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        self.0.serialize_some(&Transcoder::new(d)).map_err(s2d)
+    }
+
+    fn visit_newtype_struct<D>(self, d: D) -> Result<S::Ok, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        self.0
+            .serialize_newtype_struct("<unknown>", &Transcoder::new(d))
+            .map_err(s2d)
+    }
+
+    fn visit_seq<V>(self, mut v: V) -> Result<S::Ok, V::Error>
+    where
+        V: serde::de::SeqAccess<'de>,
+    {
+        let mut s = self.0.serialize_seq(v.size_hint()).map_err(s2d)?;
+        while let Some(()) = v.next_element_seed(SeqSeed(&mut s))? {}
+        s.end().map_err(s2d)
+    }
+
+    fn visit_map<V>(self, mut v: V) -> Result<S::Ok, V::Error>
+    where
+        V: serde::de::MapAccess<'de>,
+    {
+        let mut s = self.0.serialize_map(v.size_hint()).map_err(s2d)?;
+        while let Some(()) = v.next_key_seed(KeySeed(&mut s))? {
+            v.next_value_seed(ValueSeed(&mut s))?;
+        }
+        s.end().map_err(s2d)
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_bytes(v).map_err(s2d)
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<S::Ok, E>
+    where
+        E: serde::de::Error,
+    {
+        self.0.serialize_bytes(&v).map_err(s2d)
+    }
+}
+
+struct SeqSeed<'a, S: 'a>(&'a mut S);
+
+impl<'de, S> serde::de::DeserializeSeed<'de> for SeqSeed<'_, S>
+where
+    S: serde::ser::SerializeSeq,
+{
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        self.0
+            .serialize_element(&Transcoder::new(deserializer))
+            .map_err(s2d)
+    }
+}
+
+struct KeySeed<'a, S: 'a>(&'a mut S);
+
+impl<'de, S> serde::de::DeserializeSeed<'de> for KeySeed<'_, S>
+where
+    S: serde::ser::SerializeMap,
+{
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        self.0
+            .serialize_key(&Transcoder::new(deserializer))
+            .map_err(s2d)
+    }
+}
+
+struct ValueSeed<'a, S: 'a>(&'a mut S);
+
+impl<'de, S> serde::de::DeserializeSeed<'de> for ValueSeed<'_, S>
+where
+    S: serde::ser::SerializeMap,
+{
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<(), D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        self.0
+            .serialize_value(&Transcoder::new(deserializer))
+            .map_err(s2d)
+    }
+}
+
+fn d2s<D, S>(d: D) -> S
+where
+    D: serde::de::Error,
+    S: serde::ser::Error,
+{
+    S::custom(d.to_string())
+}
+
+fn s2d<S, D>(s: S) -> D
+where
+    S: serde::ser::Error,
+    D: serde::de::Error,
+{
+    D::custom(s.to_string())
+}


### PR DESCRIPTION
- Added a new `serde_yaml_ext` module with a `ValueMergeExt` trait to facilitate merging of YAML values, supporting mappings, sequences, and scalars.
- Introduced a `transcoding` module to enable conversion between different Serde formats without intermediate storage, enhancing flexibility in data handling.
- Updated the `Cargo.toml` to include the `toml` crate as a development dependency and adjusted existing dependencies for compatibility.
- Refactored the `into_compose_file` function to utilize the new transcoding capabilities, improving the conversion process for setup files.

This update significantly enhances the Seahaven CLI's ability to effectively manage and manipulate YAML data.