### PR TITLE
 feat(seahaven-cli): enhance setup file loading and YAML merging capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ dependencies = [
  "seahaven-compose-file",
  "seahaven-docker",
  "seahaven-just",
+ "seahaven-package",
  "seahaven-setup-file",
  "serde",
  "serde-envfile",

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -21,6 +21,7 @@ indoc = "2.0.6"
 seahaven-compose-file = { version = "0.1.0", path = "../seahaven-compose-file", features = ["serde"] }
 seahaven-docker = { version = "0.1.0", path = "../seahaven-docker" }
 seahaven-just = { version = "0.1.0", path = "../seahaven-just" }
+seahaven-package = { version = "0.1.0", path = "../seahaven-package" }
 seahaven-setup-file = { version = "0.1.0", path = "../seahaven-setup-file" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "7d02f71" }

--- a/seahaven-cli/src/bin/truman/cmd/build.rs
+++ b/seahaven-cli/src/bin/truman/cmd/build.rs
@@ -61,6 +61,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -69,7 +76,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, content) = load_setup_file(setup_file)
+    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
@@ -130,12 +137,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
                 acc
             },
         );
-
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
 
     // Create and run the docker command
     let mut command = DockerCmd::with_executable(docker_exe)

--- a/seahaven-cli/src/bin/truman/cmd/down.rs
+++ b/seahaven-cli/src/bin/truman/cmd/down.rs
@@ -50,6 +50,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -58,7 +65,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, content) = load_setup_file(setup_file)
+    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
@@ -107,12 +114,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         seahaven_compose_file::ser::to_writer(content_file, &compose)
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
-
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()

--- a/seahaven-cli/src/bin/truman/cmd/dump_config.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config.rs
@@ -1,6 +1,6 @@
 use seahaven_cli::result::Result;
 
-use super::common::{env_file_arg, file_arg};
+use super::common::{env_file_arg, file_arg, project_directory_arg};
 
 mod compose_file;
 mod env_file;
@@ -45,7 +45,7 @@ pub fn cmd() -> clap::Command {
               docker compose --file <(truman dump-config compose-file) --env-file <(truman dump-config env-file) --project-directory=$PWD up
         "#})
         .subcommands([env_file::cmd(), compose_file::cmd()])
-        .args([file_arg().global(true), env_file_arg().global(true)])
+        .args([file_arg().global(true), env_file_arg().global(true), project_directory_arg().global(true)])
         .arg_required_else_help(true)
         .subcommand_required(true)
         .infer_long_args(true)

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/compose_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/compose_file.rs
@@ -51,8 +51,15 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file and environment files
-    let (_front_matter_env, content) = load_setup_file(setup_file_path)
+    let (_front_matter_env, content) = load_setup_file(setup_file_path, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     // Transform the content into a compose file

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
 
-use crate::files::{load_env_files, load_setup_file};
+use crate::files::{load_env_files, load_setup_file_env};
 
 /// The `dump-config env-file` command name
 pub const CMD: &str = "env-file";
@@ -52,7 +52,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     // Load the setup file and environment files
-    let (front_matter_env, _content) = load_setup_file(setup_file_path)
+    let front_matter_env = load_setup_file_env(setup_file_path)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;

--- a/seahaven-cli/src/bin/truman/cmd/eject.rs
+++ b/seahaven-cli/src/bin/truman/cmd/eject.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
 
-use super::common::{env_file_arg, file_arg};
+use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::files::{into_compose_file, load_env_files, load_setup_file};
 
 /// The `eject` command name
@@ -12,7 +12,7 @@ pub const CMD: &str = "eject";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("Eject the setup.yaml file to get the docker-compose.yaml and .env files")
-        .args([file_arg(), env_file_arg()])
+        .args([file_arg(), env_file_arg(), project_directory_arg()])
         .args([clap::arg!(-o --"output-dir" <DIR> "The output directory")
             .default_value(".")
             .value_parser(clap::value_parser!(PathBuf))])
@@ -41,6 +41,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Ok(());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Get the setup file path from the command line (required)
     let setup_file_path = matches
         .get_one::<PathBuf>("file")
@@ -58,7 +65,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     // Load the setup file and environment files
-    let (front_matter_env, content) = load_setup_file(setup_file_path)
+    let (front_matter_env, content) = load_setup_file(setup_file_path, &output_dir)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;

--- a/seahaven-cli/src/bin/truman/cmd/logs.rs
+++ b/seahaven-cli/src/bin/truman/cmd/logs.rs
@@ -50,6 +50,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -58,7 +65,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, content) = load_setup_file(setup_file)
+    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
@@ -107,12 +114,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         seahaven_compose_file::ser::to_writer(content_file, &compose)
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
-
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()

--- a/seahaven-cli/src/bin/truman/cmd/ps.rs
+++ b/seahaven-cli/src/bin/truman/cmd/ps.rs
@@ -48,6 +48,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -56,7 +63,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, content) = load_setup_file(setup_file)
+    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
@@ -105,12 +112,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         seahaven_compose_file::ser::to_writer(content_file, &compose)
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
-
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()

--- a/seahaven-cli/src/bin/truman/cmd/pull.rs
+++ b/seahaven-cli/src/bin/truman/cmd/pull.rs
@@ -47,6 +47,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -55,7 +62,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, content) = load_setup_file(setup_file)
+    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
@@ -104,12 +111,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         seahaven_compose_file::ser::to_writer(content_file, &compose)
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
-
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
 
     // Create and run the docker command
     let mut command = DockerCmd::with_executable(docker_exe)

--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -6,7 +6,7 @@ use seahaven_just::cmd::{IntoCommand, JustCmd};
 use super::common::{env_file_arg, file_arg};
 use crate::{
     deps::resolve_just_executable,
-    files::{load_env_files, load_setup_file},
+    files::{load_env_files, load_setup_file_env},
 };
 
 /// The `run` command name
@@ -57,7 +57,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, _content) = load_setup_file(setup_file)
+    let front_matter_env = load_setup_file_env(setup_file)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;

--- a/seahaven-cli/src/bin/truman/cmd/up.rs
+++ b/seahaven-cli/src/bin/truman/cmd/up.rs
@@ -51,6 +51,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -59,7 +66,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
     }
 
-    let (front_matter_env, content) = load_setup_file(setup_file)
+    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
@@ -108,12 +115,6 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         seahaven_compose_file::ser::to_writer(content_file, &compose)
             .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
     }
-
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()

--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -1,19 +1,29 @@
 //! # Seahaven file processing
 
-use std::{fs::File, io::BufReader, path::Path};
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+    sync::Arc,
+};
 
-use seahaven_cli::{result::Result, transcoding};
+use seahaven_cli::{result::Result, serde_yaml_ext::MappingMergeExt, transcoding};
 use seahaven_compose_file::ComposeFile;
-use seahaven_setup_file::{Content, Env};
+use seahaven_package::manifest::Manifest;
+use seahaven_setup_file::{
+    Content, Env,
+    model::{PackageUse, Path as PackageUsePath},
+};
 
 /// Loads a single file and returns its environment variables and content.
 ///
 /// Returns an error if the file cannot be opened or parsed.
-pub fn load_setup_file<P>(path: P) -> Result<(Option<Env>, Content)>
-where
-    P: AsRef<Path>,
-{
-    let file = File::open(&path).map(BufReader::new).map_err(|err| {
+pub fn load_setup_file(
+    path: &impl AsRef<Path>,
+    workdir: &impl AsRef<Path>,
+) -> Result<(Option<Env>, Content)> {
+    let file = File::open(path).map(BufReader::new).map_err(|err| {
         anyhow::anyhow!(
             "Failed to open setup file '{}': {}",
             path.as_ref().display(),
@@ -21,7 +31,7 @@ where
         )
     })?;
 
-    let res = seahaven_setup_file::from_reader(file)
+    let (env, mut content) = seahaven_setup_file::from_reader(file)
         .map_err(|err| {
             anyhow::anyhow!(
                 "Failed to parse setup file '{}': {}",
@@ -31,7 +41,169 @@ where
         })?
         .unpack();
 
-    Ok(res)
+    let mut manifests_cache = HashMap::new();
+
+    // Merge the services' configuration into the service defaults
+    for (_, service) in content.services.iter_mut() {
+        // Get the package use
+        let package_use = match service.package_use.as_ref() {
+            Some(package_use) => package_use,
+            None => continue,
+        };
+
+        let manifest =
+            load_package_manifest_with_cache(package_use, workdir, &mut manifests_cache)?;
+
+        // Check the package use target:
+        // - The target must be specified in the manifest (as a service)
+        // - If the target is not specified, it means the target is the service. If the service
+        //   is not found in the manifest, an error is returned.
+        let manifest_target = match &package_use.target {
+            Some(target) => {
+                if let Some(service) = manifest
+                    .service
+                    .as_ref()
+                    .filter(|service| service.name == target)
+                {
+                    service
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Service target '{}' not found in manifest file '{}'",
+                        target,
+                        package_use.path.display()
+                    )
+                    .into());
+                }
+            }
+            None => {
+                if let Some(service) = &manifest.service {
+                    service
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Service target not specified in manifest file '{}'",
+                        package_use.path.display()
+                    )
+                    .into());
+                }
+            }
+        };
+
+        let mut service_config = {
+            let mut mapping = serde_yaml::Mapping::new();
+            for (key, value) in manifest_target.defaults.iter() {
+                match transcode_package_target_defaults(value.clone()) {
+                    Ok(transcoded) => {
+                        mapping.insert(serde_yaml::Value::String(key.to_owned()), transcoded);
+                    }
+                    Err(err) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to transcode package target defaults: {}",
+                            err
+                        )
+                        .into());
+                    }
+                }
+            }
+
+            mapping
+        };
+
+        // Merge the service's configuration into the service defaults
+        service_config.merge(&service._rest);
+
+        // Update the service's configuration
+        service._rest = service_config;
+    }
+
+    // Merge the init containers' package default configuration into the init containers' configuration
+    if let Some(init) = content.init.as_mut() {
+        for (_, init) in init.iter_mut() {
+            // Get the package use
+            let package_use = match init.package_use.as_ref() {
+                Some(package_use) => package_use,
+                None => continue,
+            };
+
+            let manifest =
+                load_package_manifest_with_cache(package_use, workdir, &mut manifests_cache)?;
+
+            // Check the package use target:
+            // - The target must be specified in the manifest (init container)
+            // - If the target is not specified, an error is returned.
+            let manifest_target = match &package_use.target {
+                Some(target) => {
+                    if let Some(init) = manifest.init.iter().find(|init| init.name == target) {
+                        init
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "Init container target '{}' not found in manifest file '{}'",
+                            target,
+                            package_use.path.display()
+                        )
+                        .into());
+                    }
+                }
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "Init container target required for 'use' key '{}'",
+                        package_use.path.display()
+                    )
+                    .into());
+                }
+            };
+
+            let mut init_config = {
+                let mut mapping = serde_yaml::Mapping::new();
+                for (key, value) in manifest_target.defaults.iter() {
+                    match transcode_package_target_defaults(value.clone()) {
+                        Ok(transcoded) => {
+                            mapping.insert(serde_yaml::Value::String(key.to_owned()), transcoded);
+                        }
+                        Err(err) => {
+                            return Err(anyhow::anyhow!(
+                                "Failed to transcode package target defaults: {}",
+                                err
+                            )
+                            .into());
+                        }
+                    }
+                }
+
+                mapping
+            };
+
+            // Merge the init's configuration into the init defaults
+            init_config.merge(&init._rest);
+
+            // Update the init's configuration
+            init._rest = init_config;
+        }
+    }
+
+    Ok((env, content))
+}
+
+/// Loads the environment variables from a setup file.
+///
+/// Returns an error if the file cannot be opened or parsed.
+pub fn load_setup_file_env(path: &impl AsRef<Path>) -> Result<Option<Env>> {
+    let file = File::open(path).map(BufReader::new).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to open setup file '{}': {}",
+            path.as_ref().display(),
+            err
+        )
+    })?;
+
+    let env = seahaven_setup_file::env_from_reader(file).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to parse setup file '{}': {}",
+            path.as_ref().display(),
+            err
+        )
+    })?;
+
+    Ok(env)
 }
 
 /// Loads all variables found in the files into the environment,
@@ -132,11 +304,58 @@ pub fn into_compose_file(file: Content) -> ComposeFile {
     }
 }
 
+/// Loads a package manifest file from the given path relative to the provided base path.
+///
+/// The base path should be the working directory path.
+///
+/// If the manifest is already loaded, it is returned from the cache.
+fn load_package_manifest_with_cache(
+    package_use: &PackageUse,
+    workdir: &impl AsRef<Path>,
+    cache: &mut HashMap<PackageUsePath, Arc<Manifest>>,
+) -> Result<Arc<Manifest>> {
+    if let Some(manifest) = cache.get(&package_use.path) {
+        return Ok(manifest.clone());
+    }
+
+    let manifest = load_manifest_file(&package_use.path, workdir).map(Arc::new)?;
+
+    cache.insert(package_use.path.clone(), manifest.clone());
+
+    Ok(manifest)
+}
+
+/// Loads a package manifest file from the given path relative to the provided base path.
+///
+/// The base path should be the working directory path.
+fn load_manifest_file(path: &impl AsRef<Path>, working_dir: &impl AsRef<Path>) -> Result<Manifest> {
+    let path = working_dir.as_ref().join(path.as_ref());
+
+    let mut file = File::open(&path).map(BufReader::new).map_err(|err| {
+        anyhow::anyhow!("Failed to open manifest file '{}': {}", path.display(), err)
+    })?;
+
+    let mut manifest = String::with_capacity(1024);
+    file.read_to_string(&mut manifest).map_err(|err| {
+        anyhow::anyhow!("Failed to read manifest file '{}': {}", path.display(), err)
+    })?;
+
+    let manifest = seahaven_package::manifest::from_str(&manifest).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to parse manifest file '{}': {}",
+            path.display(),
+            err
+        )
+    })?;
+
+    Ok(manifest)
+}
+
 /// This function converts the `[service.defaults]` or `[[init.defaults]]` table into
 /// a setup-file's `service` or `init` fields.
 ///
 /// Transcodes a [`toml::Value`] to a [`serde_yaml::Value`].
-pub fn transcode_package_target_defaults(
+fn transcode_package_target_defaults(
     value: toml::Value,
 ) -> Result<serde_yaml::Value, serde_yaml::Error> {
     transcoding::transcode(value, serde_yaml::value::Serializer)

--- a/seahaven-cli/src/serde_yaml_ext.rs
+++ b/seahaven-cli/src/serde_yaml_ext.rs
@@ -58,6 +58,85 @@ impl ValueMergeExt for serde_yaml::Value {
 
 impl _priv::Sealed for serde_yaml::Value {}
 
+/// Trait extending [`Mapping`] with merging capabilities.
+///
+/// Merging follows these rules:
+/// - For matching keys: Recursively merge the values if both are mappings, otherwise overwrite
+/// - For new keys: Insert the key-value pair from source
+///
+/// [`Mapping`]: serde_yaml::Mapping
+pub trait MappingMergeExt: _priv::Sealed {
+    /// Merges the current mapping with another [`Mapping`].
+    ///
+    /// The current mapping is modified in-place according to the merging rules.
+    ///
+    /// [`Mapping`]: serde_yaml::Mapping
+    fn merge(&mut self, other: &serde_yaml::Mapping);
+
+    /// Merges the current mapping into the target [`Mapping`].
+    ///
+    /// The target [`Mapping`] is modified in-place according to the merging rules.
+    ///
+    /// [`Mapping`]: serde_yaml::Mapping
+    fn merge_into(&self, target: &mut serde_yaml::Mapping);
+}
+
+impl MappingMergeExt for serde_yaml::Mapping {
+    fn merge(&mut self, other: &serde_yaml::Mapping) {
+        for (key, src_val) in other {
+            match self.get_mut(key) {
+                Some(dst_val) => {
+                    dst_val.merge(src_val);
+                }
+                None => {
+                    // Insert new key-value pair
+                    self.insert(key.clone(), src_val.clone());
+                }
+            }
+        }
+    }
+
+    fn merge_into(&self, target: &mut serde_yaml::Mapping) {
+        target.merge(self);
+    }
+}
+
+impl _priv::Sealed for serde_yaml::Mapping {}
+
+/// Trait extending [`Sequence`] with merging capabilities.
+///
+/// Merging follows these rules:
+/// - Append all elements from the source sequence to the target sequence
+///
+/// [`Sequence`]: serde_yaml::Sequence
+pub trait SequenceMergeExt: _priv::Sealed {
+    /// Merges the current sequence with another [`Sequence`].
+    ///
+    /// The current sequence is modified in-place by appending all elements from the source sequence.
+    ///
+    /// [`Sequence`]: serde_yaml::Sequence
+    fn merge(&mut self, other: &serde_yaml::Sequence);
+
+    /// Merges the current sequence into the target [`Sequence`].
+    ///
+    /// The target [`Sequence`] is modified in-place by appending all elements from the current sequence.
+    ///
+    /// [`Sequence`]: serde_yaml::Sequence
+    fn merge_into(&self, target: &mut serde_yaml::Sequence);
+}
+
+impl SequenceMergeExt for serde_yaml::Sequence {
+    fn merge(&mut self, other: &serde_yaml::Sequence) {
+        self.extend_from_slice(other);
+    }
+
+    fn merge_into(&self, target: &mut serde_yaml::Sequence) {
+        target.extend_from_slice(self);
+    }
+}
+
+impl _priv::Sealed for serde_yaml::Sequence {}
+
 #[allow(dead_code)]
 mod _priv {
     pub trait Sealed {}
@@ -67,7 +146,7 @@ mod _priv {
 mod tests {
     use serde_yaml::Value;
 
-    use super::ValueMergeExt as _;
+    use super::{MappingMergeExt as _, SequenceMergeExt as _, ValueMergeExt as _};
 
     #[test]
     fn merge_mappings_recursively() {
@@ -111,31 +190,17 @@ mod tests {
     #[test]
     fn append_sequences_on_merge() {
         //* Given
-        let mut target: Value = serde_yaml::from_str(indoc::indoc! {r#"
-            - 1
-            - 2
-            - 3
-        "#})
-        .expect("Failed to parse target YAML");
+        let mut target: Value =
+            serde_yaml::from_str("[1, 2, 3]").expect("Failed to parse target YAML");
 
-        let source: Value = serde_yaml::from_str(indoc::indoc! {r#"
-            - 4
-            - 5
-        "#})
-        .expect("Failed to parse source YAML");
+        let source: Value = serde_yaml::from_str("[4, 5]").expect("Failed to parse source YAML");
 
         //* When
         target.merge(&source);
 
         //* Then
-        let expected: Value = serde_yaml::from_str(indoc::indoc! {r#"
-            - 1
-            - 2
-            - 3
-            - 4
-            - 5
-        "#})
-        .expect("Failed to parse expected YAML");
+        let expected: Value =
+            serde_yaml::from_str("[1, 2, 3, 4, 5]").expect("Failed to parse expected YAML");
 
         assert_eq!(target, expected);
     }
@@ -201,6 +266,125 @@ mod tests {
             c: 4
         "#})
         .expect("Failed to parse expected YAML");
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn mapping_merge_recursively() {
+        //* Given
+        let target = serde_yaml::Mapping::from_iter([
+            (
+                Value::String("a".to_string()),
+                Value::Mapping(
+                    serde_yaml::from_str("{x: 1, y: 2}").expect("Failed to parse nested mapping"),
+                ),
+            ),
+            (Value::String("b".to_string()), Value::Number(1.into())),
+        ]);
+
+        let source = serde_yaml::Mapping::from_iter([
+            (
+                Value::String("a".to_string()),
+                Value::Mapping(
+                    serde_yaml::from_str("{y: 3, z: 4}").expect("Failed to parse nested mapping"),
+                ),
+            ),
+            (Value::String("c".to_string()), Value::Number(2.into())),
+        ]);
+
+        //* When
+        let mut target = target;
+        target.merge(&source);
+
+        //* Then
+        let expected = serde_yaml::Mapping::from_iter([
+            (
+                Value::String("a".to_string()),
+                Value::Mapping(
+                    serde_yaml::from_str("{x: 1, y: 3, z: 4}")
+                        .expect("Failed to parse expected mapping"),
+                ),
+            ),
+            (Value::String("b".to_string()), Value::Number(1.into())),
+            (Value::String("c".to_string()), Value::Number(2.into())),
+        ]);
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn mapping_merge_into() {
+        //* Given
+        let source = serde_yaml::Mapping::from_iter([
+            (Value::String("a".to_string()), Value::Number(1.into())),
+            (Value::String("b".to_string()), Value::Number(2.into())),
+        ]);
+
+        let mut target = serde_yaml::Mapping::from_iter([
+            (Value::String("b".to_string()), Value::Number(3.into())),
+            (Value::String("c".to_string()), Value::Number(4.into())),
+        ]);
+
+        //* When
+        source.merge_into(&mut target);
+
+        //* Then
+        let expected = serde_yaml::Mapping::from_iter([
+            (Value::String("a".to_string()), Value::Number(1.into())),
+            (Value::String("b".to_string()), Value::Number(2.into())),
+            (Value::String("c".to_string()), Value::Number(4.into())),
+        ]);
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn sequence_merge() {
+        //* Given
+        let mut target =
+            serde_yaml::Sequence::from_iter([Value::Number(1.into()), Value::Number(2.into())]);
+
+        let source =
+            serde_yaml::Sequence::from_iter([Value::Number(3.into()), Value::Number(4.into())]);
+
+        //* When
+        target.merge(&source);
+
+        //* Then
+        let expected = serde_yaml::Sequence::from_iter([
+            Value::Number(1.into()),
+            Value::Number(2.into()),
+            Value::Number(3.into()),
+            Value::Number(4.into()),
+        ]);
+
+        assert_eq!(target, expected);
+    }
+
+    #[test]
+    fn sequence_merge_into() {
+        //* Given
+        let source = serde_yaml::Sequence::from_iter([
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ]);
+
+        let mut target = serde_yaml::Sequence::from_iter([
+            Value::String("c".to_string()),
+            Value::String("d".to_string()),
+        ]);
+
+        //* When
+        source.merge_into(&mut target);
+
+        //* Then
+        let expected = serde_yaml::Sequence::from_iter([
+            Value::String("c".to_string()),
+            Value::String("d".to_string()),
+            Value::String("a".to_string()),
+            Value::String("b".to_string()),
+        ]);
 
         assert_eq!(target, expected);
     }


### PR DESCRIPTION
- Added `seahaven-package` as a dependency in `Cargo.toml` and `Cargo.lock`.
- Introduced `MappingMergeExt` and `SequenceMergeExt` traits to extend YAML mapping and sequence functionalities, allowing for recursive merging of configurations.
- Updated `load_setup_file` function to accept a working directory parameter, enabling better handling of package manifests and service configurations.
- Refactored various command implementations to utilize the new setup file loading logic, improving the overall structure and maintainability of the Seahaven CLI.

This update significantly enhances the Seahaven CLI's ability to manage and merge YAML configurations effectively.