### PR TITLE
refactor(seahaven-cli): streamline environment variable loading and enhance modularity

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/build.rs
+++ b/seahaven-cli/src/bin/truman/cmd/build.rs
@@ -6,7 +6,7 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{into_compose_file, load_env_files, load_setup_file},
+    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
 };
 
 /// The `build` command name
@@ -79,22 +79,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/down.rs
+++ b/seahaven-cli/src/bin/truman/cmd/down.rs
@@ -6,7 +6,7 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{into_compose_file, load_env_files, load_setup_file},
+    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
 };
 
 /// The `down` command name
@@ -68,22 +68,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
 
-use crate::files::{load_env_files, load_setup_file_env};
+use crate::files::env::{load_and_merge_envs, load_setup_file_env};
 
 /// The `dump-config env-file` command name
 pub const CMD: &str = "env-file";
@@ -16,6 +16,13 @@ pub fn cmd() -> clap::Command {
 ///
 /// This function prints the .env file contents to the console.
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Get the project directory from the command line
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Get the setup file path from the command line (required)
     let setup_file_path = matches
         .get_one::<PathBuf>("file")
@@ -55,19 +62,11 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let front_matter_env = load_setup_file_env(setup_file_path)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // If no environment is present, print a warning and return
     let env = match env {

--- a/seahaven-cli/src/bin/truman/cmd/eject.rs
+++ b/seahaven-cli/src/bin/truman/cmd/eject.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use seahaven_cli::result::Result;
 
 use super::common::{env_file_arg, file_arg, project_directory_arg};
-use crate::files::{into_compose_file, load_env_files, load_setup_file};
+use crate::files::{env::load_and_merge_envs, into_compose_file, load_setup_file};
 
 /// The `eject` command name
 pub const CMD: &str = "eject";
@@ -68,22 +68,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file_path, &output_dir)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose_file = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Serialize the compose file to a string
     let compose_content = seahaven_compose_file::ser::to_string(&compose_file)

--- a/seahaven-cli/src/bin/truman/cmd/logs.rs
+++ b/seahaven-cli/src/bin/truman/cmd/logs.rs
@@ -6,7 +6,7 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{into_compose_file, load_env_files, load_setup_file},
+    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
 };
 
 /// The `logs` command name
@@ -68,22 +68,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/ps.rs
+++ b/seahaven-cli/src/bin/truman/cmd/ps.rs
@@ -6,7 +6,7 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{into_compose_file, load_env_files, load_setup_file},
+    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
 };
 
 /// The `ps` command name
@@ -66,22 +66,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/pull.rs
+++ b/seahaven-cli/src/bin/truman/cmd/pull.rs
@@ -6,7 +6,7 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{into_compose_file, load_env_files, load_setup_file},
+    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
 };
 
 /// The `pull` command name
@@ -65,22 +65,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -3,10 +3,10 @@ use std::{fs::File, path::PathBuf};
 use seahaven_cli::result::{Error, Result};
 use seahaven_just::cmd::{IntoCommand, JustCmd};
 
-use super::common::{env_file_arg, file_arg};
+use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_just_executable,
-    files::{load_env_files, load_setup_file_env},
+    files::env::{load_and_merge_envs, load_setup_file_env},
 };
 
 /// The `run` command name
@@ -16,7 +16,7 @@ pub const CMD: &str = "run";
 pub fn cmd() -> clap::Command {
     clap::command!(CMD)
         .about("run the development environment images using docker compose")
-        .args([file_arg(), env_file_arg()])
+        .args([file_arg(), env_file_arg(), project_directory_arg()])
         .args([
             clap::arg!(--"dry-run" "Execute command in dry run mode")
                 .action(clap::ArgAction::SetTrue),
@@ -49,6 +49,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
 
     tracing::debug!("just version: {}", just_version);
 
+    // Resolve the project directory
+    let project_directory = matches
+        .get_one::<PathBuf>("project-directory")
+        .expect("Failed to get project directory");
+
+    tracing::debug!("Project directory: {}", project_directory.display());
+
     // Load the setup file
     let setup_file = matches
         .get_one::<PathBuf>("file")
@@ -60,19 +67,11 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let front_matter_env = load_setup_file_env(setup_file)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()
@@ -101,6 +100,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     } else {
         JustCmd::with_executable(just_exe)
             .with_justfile::<&PathBuf>(matches.get_one::<PathBuf>("justfile"))
+            .with_working_directory(project_directory)
             .with_env_file(env_file_path)
             .with_dry_run(matches.get_flag("dry-run"))
             .with_args(matches.get_many::<String>("ARGUMENTS").unwrap_or_default())

--- a/seahaven-cli/src/bin/truman/cmd/up.rs
+++ b/seahaven-cli/src/bin/truman/cmd/up.rs
@@ -6,7 +6,7 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{into_compose_file, load_env_files, load_setup_file},
+    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
 };
 
 /// The `up` command name
@@ -69,22 +69,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
-    let files_env = load_env_files(matches.get_many::<PathBuf>("env-file").unwrap_or_default())?;
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
 
     // Transform the content into a compose file
     let compose = into_compose_file(content);
-
-    // Merge the env files and front matter env
-    let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
-            let mut env = files_env;
-            env.extend(front_matter_env);
-            Some(env)
-        }
-        (None, None) => None,
-    };
 
     // Create a tempfile for the env and the content
     let temp_dir = tempfile::Builder::new()

--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -16,6 +16,8 @@ use seahaven_setup_file::{
     model::{PackageUse, Path as PackageUsePath},
 };
 
+pub mod env;
+
 /// Loads a single file and returns its environment variables and content.
 ///
 /// Returns an error if the file cannot be opened or parsed.
@@ -181,77 +183,6 @@ pub fn load_setup_file(
     }
 
     Ok((env, content))
-}
-
-/// Loads the environment variables from a setup file.
-///
-/// Returns an error if the file cannot be opened or parsed.
-pub fn load_setup_file_env(path: &impl AsRef<Path>) -> Result<Option<Env>> {
-    let file = File::open(path).map(BufReader::new).map_err(|err| {
-        anyhow::anyhow!(
-            "Failed to open setup file '{}': {}",
-            path.as_ref().display(),
-            err
-        )
-    })?;
-
-    let env = seahaven_setup_file::env_from_reader(file).map_err(|err| {
-        anyhow::anyhow!(
-            "Failed to parse setup file '{}': {}",
-            path.as_ref().display(),
-            err
-        )
-    })?;
-
-    Ok(env)
-}
-
-/// Loads all variables found in the files into the environment,
-/// overriding any existing environment variables of the same name.
-///
-/// If a variable is specified multiple times in different files,
-/// then the last occurrence is applied.
-///
-/// Files are loaded in order, with later values overriding earlier ones.
-/// If a file is invalid or unreadable, an error is returned.
-pub fn load_env_files<P>(files: impl IntoIterator<Item = P>) -> Result<Option<Env>>
-where
-    P: AsRef<Path>,
-{
-    let mut env = Env::new();
-
-    // Load all files into the environment
-    for path in files {
-        let reader = File::open(&path).map(BufReader::new).map_err(|err| {
-            anyhow::anyhow!(
-                "Failed to open env file '{}': {}",
-                path.as_ref().display(),
-                err,
-            )
-        })?;
-
-        for pair in dotenvy::Iter::new(reader) {
-            match pair {
-                Ok((key, value)) => {
-                    env.insert(key, value);
-                }
-                Err(err) => {
-                    return Err(anyhow::anyhow!(
-                        "Failed to parse env file '{}': {}",
-                        path.as_ref().display(),
-                        err
-                    )
-                    .into());
-                }
-            }
-        }
-    }
-
-    if env.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(env))
 }
 
 /// Convert a [`Content`] into a [`ComposeFile`].

--- a/seahaven-cli/src/bin/truman/files/env.rs
+++ b/seahaven-cli/src/bin/truman/files/env.rs
@@ -1,0 +1,124 @@
+use std::{fs::File, io::BufReader, path::Path};
+
+use seahaven_cli::result::Result;
+use seahaven_setup_file::Env;
+
+/// Loads the environment variables from a setup file.
+///
+/// Returns an error if the file cannot be opened or parsed.
+pub fn load_setup_file_env(path: &impl AsRef<Path>) -> Result<Option<Env>> {
+    let file = File::open(path).map(BufReader::new).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to open setup file '{}': {}",
+            path.as_ref().display(),
+            err
+        )
+    })?;
+
+    let env = seahaven_setup_file::env_from_reader(file).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to parse setup file '{}': {}",
+            path.as_ref().display(),
+            err
+        )
+    })?;
+
+    Ok(env)
+}
+
+/// Loads environment variables from files, with fallback to project directory's `.env` file.
+///
+/// If no environment files are provided, it will look for a `.env` file in the project directory.
+/// If found, it will be used. If not found, an empty environment will be returned.
+///
+/// The environment variables from the files are merged with the front matter environment.
+pub fn load_and_merge_envs(
+    file_paths: Option<impl IntoIterator<Item = impl AsRef<Path>>>,
+    project_directory: &impl AsRef<Path>,
+    front_matter_env: Option<Env>,
+) -> Result<Option<Env>> {
+    let paths = file_paths
+        .map(|paths| {
+            paths
+                .into_iter()
+                .map(|p| p.as_ref().to_path_buf())
+                .collect()
+        })
+        .unwrap_or_else(|| {
+            let env_file_path = project_directory.as_ref().join(".env");
+            if env_file_path.exists() {
+                tracing::debug!(
+                    "Found .env file in project directory: {}",
+                    env_file_path.display()
+                );
+                vec![env_file_path]
+            } else {
+                tracing::debug!("No .env file found in project directory, skipping");
+                vec![]
+            }
+        });
+
+    let files_env = load_files(paths)?;
+
+    // Merge the files env with the front matter env
+    let env = match (files_env, front_matter_env) {
+        (Some(files_env), None) => Some(files_env),
+        (None, Some(front_matter_env)) => Some(front_matter_env),
+        (Some(files_env), Some(front_matter_env)) => {
+            let mut env = files_env;
+            env.extend(front_matter_env);
+            Some(env)
+        }
+        (None, None) => None,
+    };
+
+    Ok(env)
+}
+
+/// Loads all variables found in the files into the environment,
+/// overriding any existing environment variables of the same name.
+///
+/// If a variable is specified multiple times in different files,
+/// then the last occurrence is applied.
+///
+/// Files are loaded in order, with later values overriding earlier ones.
+/// If a file is invalid or unreadable, an error is returned.
+fn load_files<P>(files: impl IntoIterator<Item = P>) -> Result<Option<Env>>
+where
+    P: AsRef<Path>,
+{
+    let mut env = Env::new();
+
+    // Load all files into the environment
+    for path in files {
+        let reader = File::open(&path).map(BufReader::new).map_err(|err| {
+            anyhow::anyhow!(
+                "Failed to open env file '{}': {}",
+                path.as_ref().display(),
+                err,
+            )
+        })?;
+
+        for pair in dotenvy::Iter::new(reader) {
+            match pair {
+                Ok((key, value)) => {
+                    env.insert(key, value);
+                }
+                Err(err) => {
+                    return Err(anyhow::anyhow!(
+                        "Failed to parse env file '{}': {}",
+                        path.as_ref().display(),
+                        err
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+
+    if env.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(env))
+}


### PR DESCRIPTION
- Introduced a new `env` module to encapsulate environment variable loading logic.
- Replaced direct calls to `load_env_files` with `resolve_env` across multiple command implementations, improving code organization and maintainability.
- Removed redundant merging logic for environment variables, simplifying the overall structure.

This update enhances the modularity of the Seahaven CLI and improves the clarity of environment variable handling.