### PR TITLE
feat(seahaven-package): enhance manifest loading with improved error handling and directory support

### DIFF
--- a/seahaven-package/src/loader.rs
+++ b/seahaven-package/src/loader.rs
@@ -140,7 +140,30 @@ impl ManifestFileLoader {
 
 impl ManifestLoader for ManifestFileLoader {
     fn load_manifest(&self, path: &Path) -> Result<Manifest, Error> {
-        let manifest_path = self.root.join(path);
+        let full_path = self.root.join(path);
+
+        // Check if the path exists
+        if !full_path.exists() {
+            return Err(Error::FileOpen {
+                path: full_path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "Path does not exist"),
+            });
+        }
+
+        // Determine the actual file path to read
+        let manifest_path = if full_path.is_dir() {
+            full_path.join("package.toml")
+        } else {
+            full_path
+        };
+
+        // Check if the file exists
+        if !manifest_path.exists() {
+            return Err(Error::FileOpen {
+                path: manifest_path.clone(),
+                source: std::io::Error::new(std::io::ErrorKind::NotFound, "File does not exist"),
+            });
+        }
 
         let mut file = File::open(&manifest_path)
             .map(BufReader::new)
@@ -149,7 +172,7 @@ impl ManifestLoader for ManifestFileLoader {
                 source: err,
             })?;
 
-        let mut manifest_content = String::with_capacity(1024);
+        let mut manifest_content = String::with_capacity(2048);
         file.read_to_string(&mut manifest_content)
             .map_err(|err| Error::FileRead {
                 path: manifest_path.clone(),

--- a/seahaven-package/src/tests/common.rs
+++ b/seahaven-package/src/tests/common.rs
@@ -1,4 +1,4 @@
 //! Common utilities for tests
 
 /// The path to the fixtures directory
-pub const FIXTURES_DIR_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/tests/fixtures/");
+pub const TESTS_DIR_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/src/tests/");

--- a/seahaven-package/src/tests/fixtures/contracts/package.toml
+++ b/seahaven-package/src/tests/fixtures/contracts/package.toml
@@ -1,0 +1,1 @@
+../../../../testdata/data/kitchen_sink.toml

--- a/seahaven-package/src/tests/fixtures/invalid_package.toml
+++ b/seahaven-package/src/tests/fixtures/invalid_package.toml
@@ -1,0 +1,1 @@
+../../../testdata/data/no_targets.toml

--- a/seahaven-package/src/tests/fixtures/kitchen_sink.toml
+++ b/seahaven-package/src/tests/fixtures/kitchen_sink.toml
@@ -1,1 +1,0 @@
-../../../testdata/data/kitchen_sink.toml

--- a/seahaven-package/src/tests/it_loader.rs
+++ b/seahaven-package/src/tests/it_loader.rs
@@ -1,49 +1,114 @@
 use std::path::PathBuf;
 
-use super::common::FIXTURES_DIR_PATH;
-use crate::loader::{FileLoader, Loader};
+use super::common::TESTS_DIR_PATH;
+use crate::loader::{Error, FileLoader, Loader};
 
 #[test]
-fn load_package_from_file() {
+fn load_manifest_from_explicit_toml_file() {
     //* Given
-    let root_path = PathBuf::from(FIXTURES_DIR_PATH);
-    let fixture_path = PathBuf::from("kitchen_sink.toml");
+    let root_path = PathBuf::from(TESTS_DIR_PATH).join("fixtures");
+    let path = PathBuf::from("contracts/package.toml");
 
     let loader = FileLoader::new(root_path);
 
     //* When
-    let manifest = loader.load(&fixture_path).expect("Failed to load manifest");
+    let manifest = loader.load(&path).expect("Failed to load manifest");
 
     //* Then
     assert_eq!(manifest.package.name, "kitchen-sink");
 }
 
 #[test]
-fn load_package_from_non_existent_file() {
+fn load_manifest_from_directory_defaults_to_package_toml() {
     //* Given
-    let root_path = PathBuf::from(FIXTURES_DIR_PATH);
-    let fixture_path = PathBuf::from("non_existent.toml");
+    let root_path = PathBuf::from(TESTS_DIR_PATH).join("fixtures");
+    let package_path = PathBuf::from("contracts/");
 
     let loader = FileLoader::new(root_path);
 
     //* When
-    let result = loader.load(&fixture_path);
+    let manifest = loader.load(&package_path).expect("Failed to load manifest");
 
     //* Then
-    assert!(result.is_err(), "Should return an error");
+    assert_eq!(manifest.package.name, "kitchen-sink");
 }
 
 #[test]
-fn load_package_from_wrong_root_path() {
+fn load_manifest_fails_when_file_not_found() {
     //* Given
-    let root_path = PathBuf::from("/a/non/existent/path/");
-    let fixture_path = PathBuf::from("kitchen_sink.toml");
+    let root_path = PathBuf::from(TESTS_DIR_PATH).join("fixtures");
+    let package_path = PathBuf::from("non_existent.toml");
 
     let loader = FileLoader::new(root_path);
 
     //* When
-    let result = loader.load(&fixture_path);
+    let result = loader.load(&package_path);
 
     //* Then
-    assert!(result.is_err(), "Should return an error");
+    let err = result.expect_err("Should return an error when file does not exist");
+    assert!(matches!(err, Error::FileOpen { .. }));
+}
+
+#[test]
+fn load_manifest_fails_when_dir_path_does_not_exist() {
+    //* Given
+    let root_path = PathBuf::from(TESTS_DIR_PATH).join("fixtures");
+    let package_path = PathBuf::from("non_existent_directory/");
+
+    let loader = FileLoader::new(root_path);
+
+    //* When
+    let result = loader.load(&package_path);
+
+    //* Then
+    let err = result.expect_err("Should return an error when path does not exist");
+    assert!(matches!(err, Error::FileOpen { .. }));
+}
+
+#[test]
+fn load_manifest_fails_when_directory_has_no_package_toml() {
+    //* Given
+    let root_path = PathBuf::from(TESTS_DIR_PATH);
+    let package_path = PathBuf::from("fixtures");
+
+    let loader = FileLoader::new(root_path);
+
+    //* When
+    let result = loader.load(&package_path);
+
+    //* Then
+    let err = result.expect_err("Should return an error when package.toml is missing");
+    assert!(matches!(err, Error::FileOpen { .. }));
+}
+
+#[test]
+fn load_manifest_fails_when_root_path_invalid() {
+    //* Given
+    let root_path = PathBuf::from("/non/existent/path/");
+    let package_path = PathBuf::from("kitchen_sink.toml");
+
+    let loader = FileLoader::new(root_path);
+
+    //* When
+    let result = loader.load(&package_path);
+
+    //* Then
+    let err = result.expect_err("Should return an error when file path is invalid");
+    assert!(matches!(err, Error::FileOpen { .. }));
+}
+
+#[test]
+fn load_manifest_fails_when_file_is_not_a_valid_manifest() {
+    //* Given
+    let root_path = PathBuf::from(TESTS_DIR_PATH).join("fixtures");
+    let package_path = PathBuf::from("invalid_package.toml");
+
+    let loader = FileLoader::new(root_path);
+
+    //* When
+    let result = loader.load(&package_path);
+
+    //* Then
+    let err = result.expect_err("Should return an error when file is not a valid manifest");
+    assert!(matches!(err, Error::ManifestParse { .. }));
 }


### PR DESCRIPTION
- Updated the `load_manifest` function to check for the existence of the specified path and handle cases where the path is a directory, defaulting to `package.toml`.
- Added error handling for scenarios where the manifest file or directory does not exist, providing clearer feedback on loading failures.
- Refactored test cases to reflect changes in the loading logic and added new tests for error scenarios, ensuring robust validation of the manifest loading process.

This update improves the reliability and user experience of manifest loading in the Seahaven package.