### PR TITLE
feat(seahaven-cli): streamline setup file and projectdir path resolution

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/build.rs
+++ b/seahaven-cli/src/bin/truman/cmd/build.rs
@@ -6,7 +6,10 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
+    files::{
+        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+    },
 };
 
 /// The `build` command name
@@ -61,22 +64,15 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    // Resolve the setup file and project directory paths
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/down.rs
+++ b/seahaven-cli/src/bin/truman/cmd/down.rs
@@ -6,7 +6,10 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
+    files::{
+        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+    },
 };
 
 /// The `down` command name
@@ -50,22 +53,15 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    // Resolve the setup file and project directory paths
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/compose_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/compose_file.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
 
-use crate::files::{into_compose_file, load_setup_file};
+use crate::files::{
+    into_compose_file, resolve_setup_file_and_project_dir_paths, setup_yaml::load_setup_file,
+};
 
 /// The `dump-config compose-file` command name
 pub const CMD: &str = "compose-file";
@@ -16,50 +18,15 @@ pub fn cmd() -> clap::Command {
 ///
 /// This function prints the docker-compose.yaml file contents to the console.
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
-    // Get the setup file path from the command line (required)
-    let setup_file_path = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file path");
-
-    match setup_file_path.try_exists() {
-        Ok(false) => {
-            tracing::debug!(file=%setup_file_path.display(), "Setup file does not exist");
-            return Err(anyhow::anyhow!(
-                "Setup file '{}' does not exist",
-                setup_file_path.display()
-            )
-            .into());
-        }
-        Err(err) => {
-            tracing::debug!(file=%setup_file_path.display(), "Failed to check if setup file exists: {}", err);
-            return Err(anyhow::anyhow!(
-                "Invalid setup file '{}': {}",
-                setup_file_path.display(),
-                err
-            )
-            .into());
-        }
-        _ => (), // The file exists, and we can access it
-    }
-
-    // Check if the provided path is a regular file
-    if !setup_file_path.is_file() {
-        return Err(anyhow::anyhow!(
-            "Invalid setup file '{}': not a file",
-            setup_file_path.display()
-        )
-        .into());
-    }
-
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
     // Load the setup file and environment files
-    let (_front_matter_env, content) = load_setup_file(setup_file_path, &project_directory)
+    let (_front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     // Transform the content into a compose file

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
@@ -2,7 +2,10 @@ use std::path::PathBuf;
 
 use seahaven_cli::result::Result;
 
-use crate::files::env::{load_and_merge_envs, load_setup_file_env};
+use crate::files::{
+    env::{load_and_merge_envs, load_setup_file_env},
+    resolve_setup_file_and_project_dir_paths,
+};
 
 /// The `dump-config env-file` command name
 pub const CMD: &str = "env-file";
@@ -16,50 +19,15 @@ pub fn cmd() -> clap::Command {
 ///
 /// This function prints the .env file contents to the console.
 pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
-    // Get the project directory from the command line
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Get the setup file path from the command line (required)
-    let setup_file_path = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file path");
-
-    match setup_file_path.try_exists() {
-        Ok(false) => {
-            tracing::debug!(file=%setup_file_path.display(), "Setup file does not exist");
-            return Err(anyhow::anyhow!(
-                "Setup file '{}' does not exist",
-                setup_file_path.display()
-            )
-            .into());
-        }
-        Err(err) => {
-            tracing::debug!(file=%setup_file_path.display(), "Failed to check if setup file exists: {}", err);
-            return Err(anyhow::anyhow!(
-                "Invalid setup file '{}': {}",
-                setup_file_path.display(),
-                err
-            )
-            .into());
-        }
-        _ => (), // The file exists, and we can access it
-    }
-
-    // Check if the provided path is a regular file
-    if !setup_file_path.is_file() {
-        return Err(anyhow::anyhow!(
-            "Invalid setup file '{}': not a file",
-            setup_file_path.display()
-        )
-        .into());
-    }
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
     // Load the setup file and environment files
-    let front_matter_env = load_setup_file_env(setup_file_path)
+    let front_matter_env = load_setup_file_env(&setup_file)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/eject.rs
+++ b/seahaven-cli/src/bin/truman/cmd/eject.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use seahaven_cli::result::Result;
 
 use super::common::{env_file_arg, file_arg, project_directory_arg};
-use crate::files::{env::load_and_merge_envs, into_compose_file, load_setup_file};
+use crate::files::{
+    env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+    setup_yaml::load_setup_file,
+};
 
 /// The `eject` command name
 pub const CMD: &str = "eject";
@@ -41,20 +44,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         return Ok(());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
-
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Get the setup file path from the command line (required)
-    let setup_file_path = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file path");
-    if !setup_file_path.is_file() {
-        return Err(anyhow::anyhow!("Invalid setup file: {}", setup_file_path.display()).into());
-    }
+    // Resolve the setup file and project directory paths
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
     // Get the output directory from the command line (required)
     let output_dir = matches
@@ -65,7 +61,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     }
 
     // Load the setup file and environment files
-    let (front_matter_env, content) = load_setup_file(setup_file_path, &output_dir)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {}", err))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/logs.rs
+++ b/seahaven-cli/src/bin/truman/cmd/logs.rs
@@ -6,7 +6,10 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
+    files::{
+        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+    },
 };
 
 /// The `logs` command name
@@ -50,22 +53,15 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    // Resolve the setup file and project directory paths
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/ps.rs
+++ b/seahaven-cli/src/bin/truman/cmd/ps.rs
@@ -6,7 +6,10 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
+    files::{
+        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+    },
 };
 
 /// The `ps` command name
@@ -48,22 +51,15 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    // Resolve the setup file and project directory paths
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/pull.rs
+++ b/seahaven-cli/src/bin/truman/cmd/pull.rs
@@ -6,7 +6,10 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
+    files::{
+        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+    },
 };
 
 /// The `pull` command name
@@ -47,22 +50,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -6,7 +6,10 @@ use seahaven_just::cmd::{IntoCommand, JustCmd};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_just_executable,
-    files::env::{load_and_merge_envs, load_setup_file_env},
+    files::{
+        env::{load_and_merge_envs, load_setup_file_env},
+        resolve_setup_file_and_project_dir_paths,
+    },
 };
 
 /// The `run` command name
@@ -49,22 +52,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
 
     tracing::debug!("just version: {}", just_version);
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let front_matter_env = load_setup_file_env(setup_file)
+    let front_matter_env = load_setup_file_env(&setup_file)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/cmd/up.rs
+++ b/seahaven-cli/src/bin/truman/cmd/up.rs
@@ -6,7 +6,10 @@ use seahaven_docker::cmd::{DockerCmd, IntoCommand};
 use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
-    files::{env::load_and_merge_envs, into_compose_file, load_setup_file},
+    files::{
+        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+    },
 };
 
 /// The `up` command name
@@ -51,22 +54,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         .into());
     }
 
-    // Resolve the project directory
-    let project_directory = matches
-        .get_one::<PathBuf>("project-directory")
-        .expect("Failed to get project directory");
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
 
-    tracing::debug!("Project directory: {}", project_directory.display());
-
-    // Load the setup file
-    let setup_file = matches
-        .get_one::<PathBuf>("file")
-        .expect("Failed to get setup file");
-    if !setup_file.exists() {
-        return Err(anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into());
-    }
-
-    let (front_matter_env, content) = load_setup_file(setup_file, &project_directory)
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
         .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
 
     let env = load_and_merge_envs(

--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -1,189 +1,57 @@
 //! # Seahaven file processing
 
-use std::{fs::File, io::BufReader, path::Path};
+use std::path::{Path, PathBuf};
 
-use seahaven_cli::{result::Result, serde_yaml_ext::MappingMergeExt, transcoding};
+use seahaven_cli::result::Result;
 use seahaven_compose_file::ComposeFile;
-use seahaven_package::loader::{FileLoader, Loader};
-use seahaven_setup_file::{Content, Env};
+use seahaven_setup_file::Content;
 
 pub mod env;
+pub mod setup_yaml;
 
-/// Loads a single file and returns its environment variables and content.
+/// Resolves the setup file and project directory paths.
 ///
-/// Returns an error if the file cannot be opened or parsed.
-pub fn load_setup_file(
-    path: &impl AsRef<Path>,
-    workdir: &impl AsRef<Path>,
-) -> Result<(Option<Env>, Content)> {
-    let file = File::open(path).map(BufReader::new).map_err(|err| {
-        anyhow::anyhow!(
-            "Failed to open setup file '{}': {}",
-            path.as_ref().display(),
-            err
-        )
-    })?;
-
-    let (env, mut content) = seahaven_setup_file::from_reader(file)
-        .map_err(|err| {
-            anyhow::anyhow!(
-                "Failed to parse setup file '{}': {}",
-                path.as_ref().display(),
-                err
-            )
-        })?
-        .unpack();
-
-    let package_loader = FileLoader::new(workdir.as_ref().to_path_buf());
-
-    // Merge the services' configuration into the service defaults
-    for (_, service) in content.services.iter_mut() {
-        // Get the package use
-        let package_use = match service.package_use.as_ref() {
-            Some(package_use) => package_use,
-            None => continue,
-        };
-
-        let manifest = package_loader.load(&package_use.path).map_err(|err| {
-            anyhow::anyhow!(
-                "Failed to load manifest file '{}': {}",
-                package_use.path.display(),
-                err
-            )
-        })?;
-
-        // Check the package use target:
-        // - The target must be specified in the manifest (as a service)
-        // - If the target is not specified, it means the target is the service. If the service
-        //   is not found in the manifest, an error is returned.
-        let manifest_target = match &package_use.target {
-            Some(target) => {
-                if let Some(service) = manifest
-                    .service
-                    .as_ref()
-                    .filter(|service| service.name == target)
-                {
-                    service
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "Service target '{}' not found in manifest file '{}'",
-                        target,
-                        package_use.path.display()
-                    )
-                    .into());
-                }
+/// The setup file path is canonicalized and verified to exist. If the project directory
+/// is not provided, it defaults to the parent directory of the setup file, or the current
+/// directory if the setup file has no parent.
+///
+/// Returns a tuple containing the canonicalized setup file path and the resolved project
+/// directory path. Returns an error if the setup file does not exist or the absolute path
+/// cannot be resolved.
+pub fn resolve_setup_file_and_project_dir_paths(
+    setup_file: impl AsRef<Path>,
+    project_directory: Option<impl AsRef<Path>>,
+) -> Result<(PathBuf, PathBuf)> {
+    let setup_file = setup_file.as_ref();
+    let setup_file = match setup_file.canonicalize() {
+        Ok(path) => path,
+        Err(err) => match err.kind() {
+            std::io::ErrorKind::NotFound => {
+                return Err(
+                    anyhow::anyhow!("Setup file not found: {}", setup_file.display()).into(),
+                );
             }
-            None => {
-                if let Some(service) = &manifest.service {
-                    service
-                } else {
-                    return Err(anyhow::anyhow!(
-                        "Service target not specified in manifest file '{}'",
-                        package_use.path.display()
-                    )
-                    .into());
-                }
+            _ => {
+                return Err(anyhow::anyhow!("Failed to resolve setup file path: {err}").into());
             }
-        };
+        },
+    };
 
-        let mut service_config = {
-            let mut mapping = serde_yaml::Mapping::new();
-            for (key, value) in manifest_target.defaults.iter() {
-                match transcode_package_target_defaults(value.clone()) {
-                    Ok(transcoded) => {
-                        mapping.insert(serde_yaml::Value::String(key.to_owned()), transcoded);
-                    }
-                    Err(err) => {
-                        return Err(anyhow::anyhow!(
-                            "Failed to transcode package target defaults: {}",
-                            err
-                        )
-                        .into());
-                    }
-                }
-            }
+    tracing::debug!("Setup file: {}", setup_file.display());
 
-            mapping
-        };
+    // Get the project directory, if not provided, use the parent directory of the setup file,
+    // otherwise use the current directory
+    let project_directory = match project_directory {
+        Some(project_directory) => project_directory.as_ref().to_path_buf(),
+        None => setup_file
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| PathBuf::from(".")),
+    };
 
-        // Merge the service's configuration into the service defaults
-        service_config.merge(&service._rest);
+    tracing::debug!("Project directory: {}", project_directory.display());
 
-        // Update the service's configuration
-        service._rest = service_config;
-    }
-
-    // Merge the init containers' package default configuration into the init containers' configuration
-    if let Some(init) = content.init.as_mut() {
-        for (_, init) in init.iter_mut() {
-            // Get the package use
-            let package_use = match init.package_use.as_ref() {
-                Some(package_use) => package_use,
-                None => continue,
-            };
-
-            let manifest = package_loader.load(&package_use.path).map_err(|err| {
-                anyhow::anyhow!(
-                    "Failed to load manifest file '{}': {}",
-                    package_use.path.display(),
-                    err
-                )
-            })?;
-
-            // Check the package use target:
-            // - The target must be specified in the manifest (init container)
-            // - If the target is not specified, an error is returned.
-            let manifest_target = match &package_use.target {
-                Some(target) => {
-                    if let Some(init) = manifest.init.iter().find(|init| init.name == target) {
-                        init
-                    } else {
-                        return Err(anyhow::anyhow!(
-                            "Init container target '{}' not found in manifest file '{}'",
-                            target,
-                            package_use.path.display()
-                        )
-                        .into());
-                    }
-                }
-                None => {
-                    return Err(anyhow::anyhow!(
-                        "Init container target required for 'use' key '{}'",
-                        package_use.path.display()
-                    )
-                    .into());
-                }
-            };
-
-            let mut init_config = {
-                let mut mapping = serde_yaml::Mapping::new();
-                for (key, value) in manifest_target.defaults.iter() {
-                    match transcode_package_target_defaults(value.clone()) {
-                        Ok(transcoded) => {
-                            mapping.insert(serde_yaml::Value::String(key.to_owned()), transcoded);
-                        }
-                        Err(err) => {
-                            return Err(anyhow::anyhow!(
-                                "Failed to transcode package target defaults: {}",
-                                err
-                            )
-                            .into());
-                        }
-                    }
-                }
-
-                mapping
-            };
-
-            // Merge the init's configuration into the init defaults
-            init_config.merge(&init._rest);
-
-            // Update the init's configuration
-            init._rest = init_config;
-        }
-    }
-
-    Ok((env, content))
+    Ok((setup_file, project_directory))
 }
 
 /// Convert a [`Content`] into a [`ComposeFile`].
@@ -234,14 +102,4 @@ pub fn into_compose_file(file: Content) -> ComposeFile {
             .and_then(|secrets| secrets.as_mapping())
             .cloned(),
     }
-}
-
-/// This function converts the `[service.defaults]` or `[[init.defaults]]` table into
-/// a setup-file's `service` or `init` fields.
-///
-/// Transcodes a [`toml::Value`] to a [`serde_yaml::Value`].
-fn transcode_package_target_defaults(
-    value: toml::Value,
-) -> Result<serde_yaml::Value, serde_yaml::Error> {
-    transcoding::transcode(value, serde_yaml::value::Serializer)
 }

--- a/seahaven-cli/src/bin/truman/files/setup_yaml.rs
+++ b/seahaven-cli/src/bin/truman/files/setup_yaml.rs
@@ -1,0 +1,192 @@
+use std::{fs::File, io::BufReader, path::Path};
+
+use seahaven_cli::{result::Result, serde_yaml_ext::MappingMergeExt, transcoding};
+use seahaven_package::loader::{FileLoader, Loader};
+use seahaven_setup_file::{Content, Env};
+
+/// Loads a single file and returns its environment variables and content.
+///
+/// Returns an error if the file cannot be opened or parsed.
+pub fn load_setup_file(
+    path: &impl AsRef<Path>,
+    workdir: &impl AsRef<Path>,
+) -> Result<(Option<Env>, Content)> {
+    let file = File::open(path).map(BufReader::new).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to open setup file '{}': {}",
+            path.as_ref().display(),
+            err
+        )
+    })?;
+
+    let (env, mut content) = seahaven_setup_file::from_reader(file)
+        .map_err(|err| {
+            anyhow::anyhow!(
+                "Failed to parse setup file '{}': {}",
+                path.as_ref().display(),
+                err
+            )
+        })?
+        .unpack();
+
+    let package_loader = FileLoader::new(workdir.as_ref().to_path_buf());
+
+    // Merge the services' configuration into the service defaults
+    for (_, service) in content.services.iter_mut() {
+        // Get the package use
+        let package_use = match service.package_use.as_ref() {
+            Some(package_use) => package_use,
+            None => continue,
+        };
+
+        let manifest = package_loader.load(&package_use.path).map_err(|err| {
+            anyhow::anyhow!(
+                "Failed to load manifest file '{}': {}",
+                package_use.path.display(),
+                err
+            )
+        })?;
+
+        // Check the package use target:
+        // - The target must be specified in the manifest (as a service)
+        // - If the target is not specified, it means the target is the service. If the service
+        //   is not found in the manifest, an error is returned.
+        let manifest_target = match &package_use.target {
+            Some(target) => {
+                if let Some(service) = manifest
+                    .service
+                    .as_ref()
+                    .filter(|service| service.name == target)
+                {
+                    service
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Service target '{}' not found in manifest file '{}'",
+                        target,
+                        package_use.path.display()
+                    )
+                    .into());
+                }
+            }
+            None => {
+                if let Some(service) = &manifest.service {
+                    service
+                } else {
+                    return Err(anyhow::anyhow!(
+                        "Service target not specified in manifest file '{}'",
+                        package_use.path.display()
+                    )
+                    .into());
+                }
+            }
+        };
+
+        let mut service_config = {
+            let mut mapping = serde_yaml::Mapping::new();
+            for (key, value) in manifest_target.defaults.iter() {
+                match transcode_package_target_defaults(value.clone()) {
+                    Ok(transcoded) => {
+                        mapping.insert(serde_yaml::Value::String(key.to_owned()), transcoded);
+                    }
+                    Err(err) => {
+                        return Err(anyhow::anyhow!(
+                            "Failed to transcode package target defaults: {}",
+                            err
+                        )
+                        .into());
+                    }
+                }
+            }
+
+            mapping
+        };
+
+        // Merge the service's configuration into the service defaults
+        service_config.merge(&service._rest);
+
+        // Update the service's configuration
+        service._rest = service_config;
+    }
+
+    // Merge the init containers' package default configuration into the init containers' configuration
+    if let Some(init) = content.init.as_mut() {
+        for (_, init) in init.iter_mut() {
+            // Get the package use
+            let package_use = match init.package_use.as_ref() {
+                Some(package_use) => package_use,
+                None => continue,
+            };
+
+            let manifest = package_loader.load(&package_use.path).map_err(|err| {
+                anyhow::anyhow!(
+                    "Failed to load manifest file '{}': {}",
+                    package_use.path.display(),
+                    err
+                )
+            })?;
+
+            // Check the package use target:
+            // - The target must be specified in the manifest (init container)
+            // - If the target is not specified, an error is returned.
+            let manifest_target = match &package_use.target {
+                Some(target) => {
+                    if let Some(init) = manifest.init.iter().find(|init| init.name == target) {
+                        init
+                    } else {
+                        return Err(anyhow::anyhow!(
+                            "Init container target '{}' not found in manifest file '{}'",
+                            target,
+                            package_use.path.display()
+                        )
+                        .into());
+                    }
+                }
+                None => {
+                    return Err(anyhow::anyhow!(
+                        "Init container target required for 'use' key '{}'",
+                        package_use.path.display()
+                    )
+                    .into());
+                }
+            };
+
+            let mut init_config = {
+                let mut mapping = serde_yaml::Mapping::new();
+                for (key, value) in manifest_target.defaults.iter() {
+                    match transcode_package_target_defaults(value.clone()) {
+                        Ok(transcoded) => {
+                            mapping.insert(serde_yaml::Value::String(key.to_owned()), transcoded);
+                        }
+                        Err(err) => {
+                            return Err(anyhow::anyhow!(
+                                "Failed to transcode package target defaults: {}",
+                                err
+                            )
+                            .into());
+                        }
+                    }
+                }
+
+                mapping
+            };
+
+            // Merge the init's configuration into the init defaults
+            init_config.merge(&init._rest);
+
+            // Update the init's configuration
+            init._rest = init_config;
+        }
+    }
+
+    Ok((env, content))
+}
+
+/// This function converts the `[service.defaults]` or `[[init.defaults]]` table into
+/// a setup-file's `service` or `init` fields.
+///
+/// Transcodes a [`toml::Value`] to a [`serde_yaml::Value`].
+fn transcode_package_target_defaults(
+    value: toml::Value,
+) -> Result<serde_yaml::Value, serde_yaml::Error> {
+    transcoding::transcode(value, serde_yaml::value::Serializer)
+}


### PR DESCRIPTION
- Introduced a new function `resolve_setup_file_and_project_dir_paths` to handle the resolution of setup file and project directory paths, improving error handling and defaulting behavior.
- Refactored existing command implementations to utilize the new resolution function, enhancing code clarity and maintainability.
- Moved the `load_setup_file` function to a new `setup_yaml` module, further organizing the file processing logic.

This update enhances the Seahaven CLI's setup file handling capabilities and improves overall code organization.