### PR TITLE
refactor(seahaven-cli): update commands to utilize `files::tempdir` module

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd/build.rs
+++ b/seahaven-cli/src/bin/truman/cmd/build.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -7,8 +7,10 @@ use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
     files::{
-        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
         setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
     },
 };
 
@@ -81,38 +83,9 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         front_matter_env,
     )?;
 
-    // Transform the content into a compose file
     let compose = into_compose_file(content);
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-    let content_file_path = temp_dir_path.join("docker-compose.yaml");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        let content_file = File::create(&content_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-
-        tracing::debug!(
-            "Writing docker-compose.yaml file: {}",
-            content_file_path.display()
-        );
-        seahaven_compose_file::ser::to_writer(content_file, &compose)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
 
     // Process and sanitize the build args
     let build_args = matches
@@ -129,8 +102,8 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Create and run the docker command
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
-        .with_file(content_file_path)
-        .with_env_file(env_file_path)
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
         .with_project_directory(project_directory)
         .with_plain_progress()
         .build()

--- a/seahaven-cli/src/bin/truman/cmd/down.rs
+++ b/seahaven-cli/src/bin/truman/cmd/down.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -7,8 +7,10 @@ use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
     files::{
-        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
         setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
     },
 };
 
@@ -70,43 +72,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         front_matter_env,
     )?;
 
-    // Transform the content into a compose file
     let compose = into_compose_file(content);
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-    let content_file_path = temp_dir_path.join("docker-compose.yaml");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        let content_file = File::create(&content_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-
-        tracing::debug!(
-            "Writing docker-compose.yaml file: {}",
-            content_file_path.display()
-        );
-        seahaven_compose_file::ser::to_writer(content_file, &compose)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
-        .with_file(content_file_path)
-        .with_env_file(env_file_path)
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
         .with_project_directory(project_directory)
         .with_plain_progress()
         .down()

--- a/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
+++ b/seahaven-cli/src/bin/truman/cmd/dump_config/env_file.rs
@@ -37,13 +37,12 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     )?;
 
     // If no environment is present, print a warning and return
-    let env = match env {
-        Some(env) => env,
-        None => {
-            eprintln!("\x1b[33m\x1b[1mWarning\x1b[0m: No env found in the setup file");
-            return Ok(());
-        }
-    };
+    if env.is_empty() {
+        eprintln!(
+            "\x1b[33m\x1b[1mWarning\x1b[0m: No .env files, nor env variables found in the setup file"
+        );
+        return Ok(());
+    }
 
     // Serialize the environment variables to a string
     let env_content = serde_envfile::to_string(&env)

--- a/seahaven-cli/src/bin/truman/cmd/eject.rs
+++ b/seahaven-cli/src/bin/truman/cmd/eject.rs
@@ -87,7 +87,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     );
 
     // If environment section is present, write the .env file
-    if let Some(env) = env {
+    if !env.is_empty() {
         // Serialize the environment variables to a string
         let env_content = serde_envfile::to_string(&env)
             .map_err(|err| anyhow::anyhow!("Failed to serialize environment variables: {}", err))?;
@@ -98,7 +98,9 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
             .map_err(|err| anyhow::anyhow!("Failed to write .env file: {}", err))?;
         println!("Created .env file at {}", output_env_file_path.display());
     } else {
-        println!("No environment variables found in the setup file, skipping .env file creation");
+        println!(
+            "No .env file, nor environment variables found in the setup file, skipping .env file creation"
+        );
     }
 
     println!("Setup ejected successfully!");

--- a/seahaven-cli/src/bin/truman/cmd/logs.rs
+++ b/seahaven-cli/src/bin/truman/cmd/logs.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -7,8 +7,10 @@ use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
     files::{
-        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
         setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
     },
 };
 
@@ -73,40 +75,12 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Transform the content into a compose file
     let compose = into_compose_file(content);
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-    let content_file_path = temp_dir_path.join("docker-compose.yaml");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        let content_file = File::create(&content_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-
-        tracing::debug!(
-            "Writing docker-compose.yaml file: {}",
-            content_file_path.display()
-        );
-        seahaven_compose_file::ser::to_writer(content_file, &compose)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
-        .with_file(content_file_path)
-        .with_env_file(env_file_path)
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
         .with_project_directory(project_directory)
         .with_plain_progress()
         .logs()

--- a/seahaven-cli/src/bin/truman/cmd/ps.rs
+++ b/seahaven-cli/src/bin/truman/cmd/ps.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -7,8 +7,10 @@ use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
     files::{
-        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
         setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
     },
 };
 
@@ -68,43 +70,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         front_matter_env,
     )?;
 
-    // Transform the content into a compose file
     let compose = into_compose_file(content);
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-    let content_file_path = temp_dir_path.join("docker-compose.yaml");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        let content_file = File::create(&content_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-
-        tracing::debug!(
-            "Writing docker-compose.yaml file: {}",
-            content_file_path.display()
-        );
-        seahaven_compose_file::ser::to_writer(content_file, &compose)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
-        .with_file(content_file_path)
-        .with_env_file(env_file_path)
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
         .with_project_directory(project_directory)
         .with_plain_progress()
         .ps()

--- a/seahaven-cli/src/bin/truman/cmd/pull.rs
+++ b/seahaven-cli/src/bin/truman/cmd/pull.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -7,8 +7,10 @@ use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
     files::{
-        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
         setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
     },
 };
 
@@ -69,41 +71,13 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
     // Transform the content into a compose file
     let compose = into_compose_file(content);
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-    let content_file_path = temp_dir_path.join("docker-compose.yaml");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        let content_file = File::create(&content_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-
-        tracing::debug!(
-            "Writing docker-compose.yaml file: {}",
-            content_file_path.display()
-        );
-        seahaven_compose_file::ser::to_writer(content_file, &compose)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
 
     // Create and run the docker command
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
-        .with_file(content_file_path)
-        .with_env_file(env_file_path)
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
         .with_project_directory(project_directory)
         .with_plain_progress()
         .pull()

--- a/seahaven-cli/src/bin/truman/cmd/run.rs
+++ b/seahaven-cli/src/bin/truman/cmd/run.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_just::cmd::{IntoCommand, JustCmd};
@@ -9,6 +9,7 @@ use crate::{
     files::{
         env::{load_and_merge_envs, load_setup_file_env},
         resolve_setup_file_and_project_dir_paths,
+        tempdir::{self, HasEnvFilePath as _},
     },
 };
 
@@ -68,24 +69,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         front_matter_env,
     )?;
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_env_file(&env)?;
 
     // Create and run the just command
     let mut command = if matches.get_flag("list") {
@@ -96,7 +80,7 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         JustCmd::with_executable(just_exe)
             .with_justfile::<&PathBuf>(matches.get_one::<PathBuf>("justfile"))
             .with_working_directory(project_directory)
-            .with_env_file(env_file_path)
+            .with_env_file(temp.env_file_path())
             .with_dry_run(matches.get_flag("dry-run"))
             .with_args(matches.get_many::<String>("ARGUMENTS").unwrap_or_default())
             .into_command()

--- a/seahaven-cli/src/bin/truman/cmd/up.rs
+++ b/seahaven-cli/src/bin/truman/cmd/up.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf};
+use std::path::PathBuf;
 
 use seahaven_cli::result::{Error, Result};
 use seahaven_docker::cmd::{DockerCmd, IntoCommand};
@@ -7,8 +7,10 @@ use super::common::{env_file_arg, file_arg, project_directory_arg};
 use crate::{
     deps::resolve_docker_executable,
     files::{
-        env::load_and_merge_envs, into_compose_file, resolve_setup_file_and_project_dir_paths,
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
         setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
     },
 };
 
@@ -70,43 +72,14 @@ pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
         front_matter_env,
     )?;
 
-    // Transform the content into a compose file
     let compose = into_compose_file(content);
 
-    // Create a tempfile for the env and the content
-    let temp_dir = tempfile::Builder::new()
-        .prefix("seahaven-")
-        .tempdir()
-        .map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
-    let temp_dir_path = temp_dir.path();
-    tracing::debug!("Compose temporary directory: {}", temp_dir_path.display());
-
-    let env_file_path = temp_dir_path.join(".env");
-    let content_file_path = temp_dir_path.join("docker-compose.yaml");
-
-    {
-        let env_file = File::create(&env_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
-
-        let content_file = File::create(&content_file_path)
-            .map_err(|err| anyhow::anyhow!("Failed to create docker-compose.yaml file: {err}"))?;
-
-        tracing::debug!("Writing .env file: {}", env_file_path.display());
-        serde_envfile::to_writer(env_file, &env)
-            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
-
-        tracing::debug!(
-            "Writing docker-compose.yaml file: {}",
-            content_file_path.display()
-        );
-        seahaven_compose_file::ser::to_writer(content_file, &compose)
-            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
-    }
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
 
     let mut command = DockerCmd::with_executable(docker_exe)
         .compose()
-        .with_file(content_file_path)
-        .with_env_file(env_file_path)
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
         .with_project_directory(project_directory)
         .with_plain_progress()
         .up()

--- a/seahaven-cli/src/bin/truman/files.rs
+++ b/seahaven-cli/src/bin/truman/files.rs
@@ -8,6 +8,7 @@ use seahaven_setup_file::Content;
 
 pub mod env;
 pub mod setup_yaml;
+pub mod tempdir;
 
 /// Resolves the setup file and project directory paths.
 ///
@@ -102,4 +103,9 @@ pub fn into_compose_file(file: Content) -> ComposeFile {
             .and_then(|secrets| secrets.as_mapping())
             .cloned(),
     }
+}
+
+#[cfg(test)]
+mod tests {
+    mod it_tempdir;
 }

--- a/seahaven-cli/src/bin/truman/files/env.rs
+++ b/seahaven-cli/src/bin/truman/files/env.rs
@@ -36,7 +36,7 @@ pub fn load_and_merge_envs(
     file_paths: Option<impl IntoIterator<Item = impl AsRef<Path>>>,
     project_directory: &impl AsRef<Path>,
     front_matter_env: Option<Env>,
-) -> Result<Option<Env>> {
+) -> Result<Env> {
     let paths = file_paths
         .map(|paths| {
             paths
@@ -62,14 +62,12 @@ pub fn load_and_merge_envs(
 
     // Merge the files env with the front matter env
     let env = match (files_env, front_matter_env) {
-        (Some(files_env), None) => Some(files_env),
-        (None, Some(front_matter_env)) => Some(front_matter_env),
-        (Some(files_env), Some(front_matter_env)) => {
+        (files_env, None) => files_env,
+        (files_env, Some(front_matter_env)) => {
             let mut env = files_env;
             env.extend(front_matter_env);
-            Some(env)
+            env
         }
-        (None, None) => None,
     };
 
     Ok(env)
@@ -83,7 +81,7 @@ pub fn load_and_merge_envs(
 ///
 /// Files are loaded in order, with later values overriding earlier ones.
 /// If a file is invalid or unreadable, an error is returned.
-fn load_files<P>(files: impl IntoIterator<Item = P>) -> Result<Option<Env>>
+fn load_files<P>(files: impl IntoIterator<Item = P>) -> Result<Env>
 where
     P: AsRef<Path>,
 {
@@ -116,9 +114,5 @@ where
         }
     }
 
-    if env.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(env))
+    Ok(env)
 }

--- a/seahaven-cli/src/bin/truman/files/tempdir.rs
+++ b/seahaven-cli/src/bin/truman/files/tempdir.rs
@@ -1,0 +1,163 @@
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use seahaven_cli::result::Result;
+use seahaven_compose_file::ComposeFile;
+use seahaven_setup_file::Env;
+
+/// Creates a new temporary directory where the `.env` and `docker-compose.yaml`
+/// files will be written
+pub fn new() -> Uninitialized {
+    Uninitialized { _priv: () }
+}
+
+/// Represents the initial state before any directory is created
+pub struct Uninitialized {
+    /// Private field to prevent instantiation
+    _priv: (),
+}
+
+impl Uninitialized {
+    /// Creates a new temporary directory
+    pub fn create_dir(self) -> Result<DirCreated> {
+        let dir =
+            create_temp_dir().map_err(|err| anyhow::anyhow!("Failed to create tempdir: {err}"))?;
+        tracing::debug!("Created temporary directory: {}", dir.path().display());
+
+        Ok(DirCreated { dir })
+    }
+}
+
+/// Represents a state where only the directory has been created
+pub struct DirCreated {
+    dir: tempfile::TempDir,
+}
+
+impl DirCreated {
+    /// Writes the environment variables to the .env file
+    pub fn write_env_file(self, env: &Env) -> Result<EnvFileOnly> {
+        let env_file_path = self.dir.path().join(".env");
+        tracing::debug!("Writing .env file: {}", env_file_path.display());
+        write_env_file(&env_file_path, env)
+            .map_err(|err| anyhow::anyhow!("Failed to create .env file: {err}"))?;
+        tracing::debug!("Wrote .env file: {}", env_file_path.display());
+        Ok(EnvFileOnly {
+            dir: self.dir,
+            env_file_path,
+        })
+    }
+
+    /// Writes both the environment variables and Docker Compose configuration
+    pub fn write_all(self, env: &Env, compose: &ComposeFile) -> Result<Complete> {
+        let compose_file_path = self.dir.path().join("docker-compose.yaml");
+        tracing::debug!(
+            "Writing docker-compose.yaml file: {}",
+            compose_file_path.display()
+        );
+        write_compose_file(&compose_file_path, compose)
+            .map_err(|err| anyhow::anyhow!("Failed to write docker-compose.yaml file: {err}"))?;
+        tracing::debug!(
+            "Wrote docker-compose.yaml file: {}",
+            compose_file_path.display()
+        );
+
+        let env_file_path = self.dir.path().join(".env");
+        tracing::debug!("Writing .env file: {}", env_file_path.display());
+        write_env_file(&env_file_path, env)
+            .map_err(|err| anyhow::anyhow!("Failed to write .env file: {err}"))?;
+        tracing::debug!("Wrote .env file: {}", env_file_path.display());
+
+        Ok(Complete {
+            dir: self.dir,
+            env_file_path,
+            compose_file_path,
+        })
+    }
+}
+
+impl HasTempDirPath for DirCreated {
+    fn temp_dir_path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+/// Represents a state where directory and `.env` file have been created.
+///
+/// This is a terminal state.
+pub struct EnvFileOnly {
+    dir: tempfile::TempDir,
+    env_file_path: PathBuf,
+}
+
+impl HasTempDirPath for EnvFileOnly {
+    fn temp_dir_path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+impl HasEnvFilePath for EnvFileOnly {
+    fn env_file_path(&self) -> &Path {
+        self.env_file_path.as_path()
+    }
+}
+
+/// Represents a state where directory, `.env` file, and `docker-compose.yaml` file have been created
+///
+/// This is a terminal state.
+pub struct Complete {
+    dir: tempfile::TempDir,
+    env_file_path: PathBuf,
+    compose_file_path: PathBuf,
+}
+
+impl HasTempDirPath for Complete {
+    fn temp_dir_path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+impl HasEnvFilePath for Complete {
+    fn env_file_path(&self) -> &Path {
+        self.env_file_path.as_path()
+    }
+}
+
+impl HasComposeFilePath for Complete {
+    fn compose_file_path(&self) -> &Path {
+        self.compose_file_path.as_path()
+    }
+}
+
+/// Helper trait to get the temporary directory path
+pub trait HasTempDirPath {
+    fn temp_dir_path(&self) -> &Path;
+}
+
+/// Helper trait to get the `.env` file path
+pub trait HasEnvFilePath {
+    fn env_file_path(&self) -> &Path;
+}
+
+/// Helper trait to get the `docker-compose.yaml` file path
+pub trait HasComposeFilePath {
+    fn compose_file_path(&self) -> &Path;
+}
+
+fn create_temp_dir() -> anyhow::Result<tempfile::TempDir> {
+    let dir = tempfile::Builder::new().prefix("seahaven-").tempdir()?;
+    Ok(dir)
+}
+
+fn write_env_file(path: &Path, env: &Env) -> anyhow::Result<()> {
+    let env_file = File::create(path)?;
+    serde_envfile::to_writer(env_file, env)?;
+    Ok(())
+}
+
+fn write_compose_file(path: &Path, compose: &ComposeFile) -> anyhow::Result<()> {
+    let compose_file = File::create(path)?;
+    seahaven_compose_file::ser::to_writer(compose_file, compose)?;
+    Ok(())
+}

--- a/seahaven-cli/src/bin/truman/files/tests/it_tempdir.rs
+++ b/seahaven-cli/src/bin/truman/files/tests/it_tempdir.rs
@@ -1,0 +1,148 @@
+use std::fs;
+
+use seahaven_compose_file::ComposeFile;
+use seahaven_setup_file::Env;
+
+use crate::files::tempdir::{self, HasComposeFilePath, HasEnvFilePath, HasTempDirPath};
+
+/// Creates a test environment file
+fn test_env_file() -> Env {
+    let mut env = Env::new();
+    env.insert("TEST_KEY".to_string(), "test_value".to_string());
+    env.insert("ANOTHER_KEY".to_string(), "another_value".to_string());
+    env
+}
+
+/// Creates a test compose file
+fn test_compose_file() -> ComposeFile {
+    let services = serde_yaml::Mapping::from_iter([(
+        serde_yaml::Value::String("test-service".to_string()),
+        serde_yaml::Value::Mapping(serde_yaml::Mapping::from_iter([(
+            serde_yaml::Value::String("image".to_string()),
+            serde_yaml::Value::String("test-image:latest".to_string()),
+        )])),
+    )]);
+
+    ComposeFile {
+        name: Some("test-project".to_string()),
+        services,
+        networks: None,
+        volumes: None,
+        configs: None,
+        secrets: None,
+    }
+}
+
+#[test]
+fn creates_temp_dir() {
+    //* Given
+    let uninit = tempdir::new();
+
+    //* When
+    let dir_created = uninit.create_dir().expect("Failed to create temp dir");
+
+    //* Then
+    assert!(
+        dir_created.temp_dir_path().is_dir(),
+        "Temp dir should exist"
+    );
+}
+
+#[test]
+fn writes_env_file_with_contents() {
+    //* Given
+    let env_file = test_env_file();
+
+    let created_dir = tempdir::new()
+        .create_dir()
+        .expect("Failed to create temp dir");
+
+    //* When
+    let env_file_only = created_dir
+        .write_env_file(&env_file)
+        .expect("Failed to write env file");
+
+    //* Then
+    assert!(
+        env_file_only.temp_dir_path().is_dir(),
+        "Temp dir should exist"
+    );
+
+    // Assert env file was correctly written
+    assert!(
+        env_file_only.env_file_path().is_file(),
+        "Env file should exist"
+    );
+    let contents =
+        fs::read_to_string(env_file_only.env_file_path()).expect("Failed to read env file");
+    assert!(!contents.is_empty(), "Env file should not be empty");
+}
+
+#[test]
+fn writes_all_files_successfully() {
+    //* Given
+    let env_file = test_env_file();
+    let compose_file = test_compose_file();
+
+    let created_dir = tempdir::new()
+        .create_dir()
+        .expect("Failed to create temp dir");
+
+    //* When
+    let complete = created_dir
+        .write_all(&env_file, &compose_file)
+        .expect("Failed to write all files");
+
+    //* Then
+    assert!(complete.temp_dir_path().is_dir(), "Temp dir should exist");
+
+    // Assert env file was correctly written
+    assert!(complete.env_file_path().is_file(), "Env file should exist");
+    let env_contents =
+        fs::read_to_string(complete.env_file_path()).expect("Failed to read env file");
+    assert!(!env_contents.is_empty(), "Env file should not be empty");
+
+    // Assert compose file was correctly written
+    assert!(
+        complete.compose_file_path().is_file(),
+        "Compose file should exist"
+    );
+    let compose_file_contents =
+        fs::read_to_string(complete.compose_file_path()).expect("Failed to read compose file");
+    assert!(
+        !compose_file_contents.is_empty(),
+        "Compose file should not be empty"
+    );
+}
+
+#[test]
+fn cleans_up_temp_dir_on_drop() {
+    //* Given
+    let test_env_file = test_env_file();
+    let test_compose_file = test_compose_file();
+
+    let created_dir = tempdir::new()
+        .create_dir()
+        .expect("Failed to create temp dir");
+
+    let complete = created_dir
+        .write_all(&test_env_file, &test_compose_file)
+        .expect("Failed to write all files");
+
+    //* When
+    // Track the paths to check if they exist after the complete struct is dropped
+    let temp_dir_path = complete.temp_dir_path().to_path_buf();
+    let env_file_path = complete.env_file_path().to_path_buf();
+    let compose_file_path = complete.compose_file_path().to_path_buf();
+
+    // Drop the complete struct
+    drop(complete);
+
+    //* Then
+    assert!(!temp_dir_path.is_dir(), "Temp dir should not exist");
+    assert!(!env_file_path.is_file(), "Env file should not exist");
+    assert!(
+        !compose_file_path.is_file(),
+        "Compose file should not exist"
+    );
+}


### PR DESCRIPTION
- Introduced a new `tempdir` module to streamline the creation and management of temporary directories for environment and compose files.
- Updated multiple command implementations (`build`, `down`, `logs`, `ps`, `pull`, `run`, `up`) to replace manual tempfile handling with the new `tempdir` functionality, enhancing code clarity and reducing redundancy.
- Improved error handling and logging during temporary file operations.

This update enhances the Seahaven CLI's efficiency in managing temporary files and improves overall code organization.