### PR TITLE
feat(seahaven-docker): add `restart`, `start`, and `stop` command wrappers

### DIFF
--- a/seahaven-docker/src/cmd.rs
+++ b/seahaven-docker/src/cmd.rs
@@ -95,6 +95,9 @@ mod tests {
     mod it_compose_logs;
     mod it_compose_ps;
     mod it_compose_pull;
+    mod it_compose_restart;
+    mod it_compose_start;
+    mod it_compose_stop;
     mod it_compose_up;
     mod it_root;
     mod it_system;

--- a/seahaven-docker/src/cmd/compose.rs
+++ b/seahaven-docker/src/cmd/compose.rs
@@ -8,11 +8,15 @@ pub mod down;
 pub mod logs;
 pub mod ps;
 pub mod pull;
+pub mod restart;
+pub mod start;
+pub mod stop;
 pub mod up;
 
 use self::{
     build::DockerComposeBuildCmd, down::DockerComposeDownCmd, logs::DockerComposeLogsCmd,
-    ps::DockerComposePsCmd, pull::DockerComposePullCmd, up::DockerComposeUpCmd,
+    ps::DockerComposePsCmd, pull::DockerComposePullCmd, restart::DockerComposeRestartCmd,
+    start::DockerComposeStartCmd, stop::DockerComposeStopCmd, up::DockerComposeUpCmd,
 };
 use super::common::{IntoCmdOptValue, IntoCommand};
 
@@ -70,6 +74,30 @@ where
     /// for more information.
     pub fn build(self) -> DockerComposeBuildCmd {
         DockerComposeBuildCmd::new(self)
+    }
+
+    /// Start the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`docker compose start`](https://docs.docker.com/compose/reference/start/)
+    /// for more information.
+    pub fn start(self) -> DockerComposeStartCmd {
+        DockerComposeStartCmd::new(self)
+    }
+
+    /// Stop the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`docker compose stop`](https://docs.docker.com/compose/reference/stop/)
+    /// for more information.
+    pub fn stop(self) -> DockerComposeStopCmd {
+        DockerComposeStopCmd::new(self)
+    }
+
+    /// Restart the services defined in the `docker-compose.yml` file.
+    ///
+    /// See [`docker compose restart`](https://docs.docker.com/compose/reference/restart/)
+    /// for more information.
+    pub fn restart(self) -> DockerComposeRestartCmd {
+        DockerComposeRestartCmd::new(self)
     }
 
     /// Start the services defined in the `docker-compose.yml` file.

--- a/seahaven-docker/src/cmd/compose/restart.rs
+++ b/seahaven-docker/src/cmd/compose/restart.rs
@@ -1,0 +1,291 @@
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
+
+pub struct DockerComposeRestartCmd<
+    DR = DryRunNotSet,
+    ND = NoDepsNotSet,
+    TO = TimeoutNotSet,
+    S = ServicesNotSet,
+> {
+    cmd: tokio::process::Command,
+    dry_run_opt: DR,
+    no_deps_opt: ND,
+    timeout_opt: TO,
+    services_opt: S,
+}
+
+impl DockerComposeRestartCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> DockerComposeRestartCmd {
+        DockerComposeRestartCmd {
+            cmd: cmd.into_command(),
+            dry_run_opt: DryRunNotSet,
+            no_deps_opt: NoDepsNotSet,
+            timeout_opt: TimeoutNotSet,
+            services_opt: ServicesNotSet,
+        }
+    }
+}
+
+impl<DR, ND, TO, S> IntoCommand for DockerComposeRestartCmd<DR, ND, TO, S>
+where
+    DR: DryRunOpt,
+    ND: NoDepsOpt,
+    TO: TimeoutOpt,
+    S: ServicesOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `restart` subcommand
+        cmd.arg("restart");
+
+        // --dry-run
+        if self.dry_run_opt.into_flag_value() {
+            cmd.arg("--dry-run");
+        }
+
+        // --no-deps
+        if self.no_deps_opt.into_flag_value() {
+            cmd.arg("--no-deps");
+        }
+
+        // --timeout
+        if let Some(timeout) = self.timeout_opt.into_value() {
+            cmd.arg("--timeout").arg(timeout.to_string());
+        }
+
+        // [SERVICES...]
+        if let Some(services) = self.services_opt.into_value() {
+            cmd.args(services);
+        }
+
+        cmd
+    }
+}
+
+impl<ND, TO, S> DockerComposeRestartCmd<DryRunNotSet, ND, TO, S>
+where
+    ND: NoDepsOpt,
+    TO: TimeoutOpt,
+    S: ServicesOpt,
+{
+    /// Run the command in dry run mode with the `--dry-run` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/restart/)
+    /// for more information.
+    pub fn with_dry_run(self, dry_run: bool) -> DockerComposeRestartCmd<DryRunSet, ND, TO, S> {
+        DockerComposeRestartCmd {
+            cmd: self.cmd,
+            dry_run_opt: DryRunSet(dry_run),
+            no_deps_opt: self.no_deps_opt,
+            timeout_opt: self.timeout_opt,
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<DR, TO, S> DockerComposeRestartCmd<DR, NoDepsNotSet, TO, S>
+where
+    DR: DryRunOpt,
+    TO: TimeoutOpt,
+    S: ServicesOpt,
+{
+    /// Don't restart dependent services with the `--no-deps` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/restart/)
+    /// for more information.
+    pub fn with_no_deps(self, no_deps: bool) -> DockerComposeRestartCmd<DR, NoDepsSet, TO, S> {
+        DockerComposeRestartCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            no_deps_opt: NoDepsSet(no_deps),
+            timeout_opt: self.timeout_opt,
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<DR, ND, S> DockerComposeRestartCmd<DR, ND, TimeoutNotSet, S>
+where
+    DR: DryRunOpt,
+    ND: NoDepsOpt,
+    S: ServicesOpt,
+{
+    /// Specify a shutdown timeout in seconds with the `--timeout` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/restart/)
+    /// for more information.
+    pub fn with_timeout(self, timeout: u32) -> DockerComposeRestartCmd<DR, ND, TimeoutSet, S> {
+        DockerComposeRestartCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            no_deps_opt: self.no_deps_opt,
+            timeout_opt: TimeoutSet(timeout),
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<DR, ND, TO> DockerComposeRestartCmd<DR, ND, TO, ServicesNotSet>
+where
+    DR: DryRunOpt,
+    ND: NoDepsOpt,
+    TO: TimeoutOpt,
+{
+    /// Specify one or more services to restart.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/restart/)
+    /// for more information.
+    pub fn with_services<I, T>(
+        self,
+        services: I,
+    ) -> DockerComposeRestartCmd<DR, ND, TO, ServicesSet>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let services = services
+            .into_iter()
+            .filter_map(|s| {
+                // Filter out empty service names
+                let service = s.as_ref();
+                if service.is_empty() {
+                    None
+                } else {
+                    Some(service.to_string())
+                }
+            })
+            .collect();
+
+        DockerComposeRestartCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            no_deps_opt: self.no_deps_opt,
+            timeout_opt: self.timeout_opt,
+            services_opt: ServicesSet(services),
+        }
+    }
+
+    /// Specify a single service to restart.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/restart/)
+    /// for more information.
+    pub fn with_service<T>(self, service: T) -> DockerComposeRestartCmd<DR, ND, TO, ServicesSet>
+    where
+        T: AsRef<str>,
+    {
+        self.with_services([service])
+    }
+}
+
+/// A trait that represents the dry run option for the `docker compose restart` command.
+#[allow(private_bounds)]
+pub trait DryRunOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct DryRunNotSet;
+
+impl DryRunOpt for DryRunNotSet {}
+impl _priv::Sealed for DryRunNotSet {}
+
+impl IntoCmdOptValue<bool> for DryRunNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct DryRunSet(bool);
+
+impl DryRunOpt for DryRunSet {}
+impl _priv::Sealed for DryRunSet {}
+
+impl IntoCmdOptValue<bool> for DryRunSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the no deps option for the `docker compose restart` command.
+#[allow(private_bounds)]
+pub trait NoDepsOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct NoDepsNotSet;
+
+impl NoDepsOpt for NoDepsNotSet {}
+impl _priv::Sealed for NoDepsNotSet {}
+
+impl IntoCmdOptValue<bool> for NoDepsNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct NoDepsSet(bool);
+
+impl NoDepsOpt for NoDepsSet {}
+impl _priv::Sealed for NoDepsSet {}
+
+impl IntoCmdOptValue<bool> for NoDepsSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the timeout option for the `docker compose restart` command.
+#[allow(private_bounds)]
+pub trait TimeoutOpt: IntoCmdOptValue<u32> + _priv::Sealed {}
+
+pub struct TimeoutNotSet;
+
+impl TimeoutOpt for TimeoutNotSet {}
+impl _priv::Sealed for TimeoutNotSet {}
+
+impl IntoCmdOptValue<u32> for TimeoutNotSet {
+    fn into_value(self) -> Option<u32> {
+        None
+    }
+}
+
+pub struct TimeoutSet(u32);
+
+impl TimeoutOpt for TimeoutSet {}
+impl _priv::Sealed for TimeoutSet {}
+
+impl IntoCmdOptValue<u32> for TimeoutSet {
+    fn into_value(self) -> Option<u32> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents whether services have been specified for the `docker compose restart` command.
+#[allow(private_bounds)]
+pub trait ServicesOpt: IntoCmdOptValue<Box<[String]>> + _priv::Sealed {}
+
+pub struct ServicesNotSet;
+
+impl ServicesOpt for ServicesNotSet {}
+impl _priv::Sealed for ServicesNotSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesNotSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        None
+    }
+}
+
+pub struct ServicesSet(Box<[String]>);
+
+impl ServicesOpt for ServicesSet {}
+impl _priv::Sealed for ServicesSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/compose/start.rs
+++ b/seahaven-docker/src/cmd/compose/start.rs
@@ -1,0 +1,165 @@
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
+
+pub struct DockerComposeStartCmd<DR = DryRunNotSet, S = ServicesNotSet> {
+    cmd: tokio::process::Command,
+    dry_run_opt: DR,
+    services_opt: S,
+}
+
+impl DockerComposeStartCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> DockerComposeStartCmd {
+        DockerComposeStartCmd {
+            cmd: cmd.into_command(),
+            dry_run_opt: DryRunNotSet,
+            services_opt: ServicesNotSet,
+        }
+    }
+}
+
+impl<DR, S> IntoCommand for DockerComposeStartCmd<DR, S>
+where
+    DR: DryRunOpt,
+    S: ServicesOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `start` subcommand
+        cmd.arg("start");
+
+        // --dry-run
+        if self.dry_run_opt.into_flag_value() {
+            cmd.arg("--dry-run");
+        }
+
+        // [SERVICES...]
+        if let Some(services) = self.services_opt.into_value() {
+            cmd.args(services);
+        }
+
+        cmd
+    }
+}
+
+impl<S> DockerComposeStartCmd<DryRunNotSet, S>
+where
+    S: ServicesOpt,
+{
+    /// Run the command in dry run mode with the `--dry-run` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/start/)
+    /// for more information.
+    pub fn with_dry_run(self, dry_run: bool) -> DockerComposeStartCmd<DryRunSet, S> {
+        DockerComposeStartCmd {
+            cmd: self.cmd,
+            dry_run_opt: DryRunSet(dry_run),
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<DR> DockerComposeStartCmd<DR, ServicesNotSet>
+where
+    DR: DryRunOpt,
+{
+    /// Specify one or more services to start.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/start/)
+    /// for more information.
+    pub fn with_services<I, T>(self, services: I) -> DockerComposeStartCmd<DR, ServicesSet>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let services = services
+            .into_iter()
+            .filter_map(|s| {
+                // Filter out empty service names
+                let service = s.as_ref();
+                if service.is_empty() {
+                    None
+                } else {
+                    Some(service.to_string())
+                }
+            })
+            .collect();
+
+        DockerComposeStartCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            services_opt: ServicesSet(services),
+        }
+    }
+
+    /// Specify a single service to include.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/start/)
+    /// for more information.
+    pub fn with_service<T>(self, service: T) -> DockerComposeStartCmd<DR, ServicesSet>
+    where
+        T: AsRef<str>,
+    {
+        self.with_services([service])
+    }
+}
+
+/// A trait that represents the dry run option for the `docker compose start` command.
+#[allow(private_bounds)]
+pub trait DryRunOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct DryRunNotSet;
+
+impl DryRunOpt for DryRunNotSet {}
+impl _priv::Sealed for DryRunNotSet {}
+
+impl IntoCmdOptValue<bool> for DryRunNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct DryRunSet(bool);
+
+impl DryRunOpt for DryRunSet {}
+impl _priv::Sealed for DryRunSet {}
+
+impl IntoCmdOptValue<bool> for DryRunSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents whether services have been specified for the `docker compose start` command.
+#[allow(private_bounds)]
+pub trait ServicesOpt: IntoCmdOptValue<Box<[String]>> + _priv::Sealed {}
+
+pub struct ServicesNotSet;
+
+impl ServicesOpt for ServicesNotSet {}
+impl _priv::Sealed for ServicesNotSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesNotSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        None
+    }
+}
+
+pub struct ServicesSet(Box<[String]>);
+
+impl ServicesOpt for ServicesSet {}
+impl _priv::Sealed for ServicesSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/compose/stop.rs
+++ b/seahaven-docker/src/cmd/compose/stop.rs
@@ -1,0 +1,222 @@
+use crate::cmd::common::{IntoCmdFlagValue, IntoCmdOptValue, IntoCommand};
+
+pub struct DockerComposeStopCmd<DR = DryRunNotSet, TO = TimeoutNotSet, S = ServicesNotSet> {
+    cmd: tokio::process::Command,
+    dry_run_opt: DR,
+    timeout_opt: TO,
+    services_opt: S,
+}
+
+impl DockerComposeStopCmd {
+    pub(crate) fn new(cmd: impl IntoCommand) -> DockerComposeStopCmd {
+        DockerComposeStopCmd {
+            cmd: cmd.into_command(),
+            dry_run_opt: DryRunNotSet,
+            timeout_opt: TimeoutNotSet,
+            services_opt: ServicesNotSet,
+        }
+    }
+}
+
+impl<DR, TO, S> IntoCommand for DockerComposeStopCmd<DR, TO, S>
+where
+    DR: DryRunOpt,
+    TO: TimeoutOpt,
+    S: ServicesOpt,
+{
+    fn into_command(self) -> tokio::process::Command {
+        let mut cmd = self.cmd;
+
+        // Add the `stop` subcommand
+        cmd.arg("stop");
+
+        // --dry-run
+        if self.dry_run_opt.into_flag_value() {
+            cmd.arg("--dry-run");
+        }
+
+        // --timeout
+        if let Some(timeout) = self.timeout_opt.into_value() {
+            cmd.arg("--timeout").arg(timeout.to_string());
+        }
+
+        // [SERVICES...]
+        if let Some(services) = self.services_opt.into_value() {
+            cmd.args(services);
+        }
+
+        cmd
+    }
+}
+
+impl<TO, S> DockerComposeStopCmd<DryRunNotSet, TO, S>
+where
+    TO: TimeoutOpt,
+    S: ServicesOpt,
+{
+    /// Run the command in dry run mode with the `--dry-run` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/stop/)
+    /// for more information.
+    pub fn with_dry_run(self, dry_run: bool) -> DockerComposeStopCmd<DryRunSet, TO, S> {
+        DockerComposeStopCmd {
+            cmd: self.cmd,
+            dry_run_opt: DryRunSet(dry_run),
+            timeout_opt: self.timeout_opt,
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<DR, S> DockerComposeStopCmd<DR, TimeoutNotSet, S>
+where
+    DR: DryRunOpt,
+    S: ServicesOpt,
+{
+    /// Specify a shutdown timeout in seconds with the `--timeout` flag.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/stop/)
+    /// for more information.
+    pub fn with_timeout(self, timeout: u32) -> DockerComposeStopCmd<DR, TimeoutSet, S> {
+        DockerComposeStopCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            timeout_opt: TimeoutSet(timeout),
+            services_opt: self.services_opt,
+        }
+    }
+}
+
+impl<DR, TO> DockerComposeStopCmd<DR, TO, ServicesNotSet>
+where
+    DR: DryRunOpt,
+    TO: TimeoutOpt,
+{
+    /// Specify one or more services to stop.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/stop/)
+    /// for more information.
+    pub fn with_services<I, T>(self, services: I) -> DockerComposeStopCmd<DR, TO, ServicesSet>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let services = services
+            .into_iter()
+            .filter_map(|s| {
+                // Filter out empty service names
+                let service = s.as_ref();
+                if service.is_empty() {
+                    None
+                } else {
+                    Some(service.to_string())
+                }
+            })
+            .collect();
+
+        DockerComposeStopCmd {
+            cmd: self.cmd,
+            dry_run_opt: self.dry_run_opt,
+            timeout_opt: self.timeout_opt,
+            services_opt: ServicesSet(services),
+        }
+    }
+
+    /// Specify a single service to stop.
+    ///
+    /// If the service name is empty, it will be ignored.
+    ///
+    /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/stop/)
+    /// for more information.
+    pub fn with_service<T>(self, service: T) -> DockerComposeStopCmd<DR, TO, ServicesSet>
+    where
+        T: AsRef<str>,
+    {
+        self.with_services([service])
+    }
+}
+
+/// A trait that represents the dry run option for the `docker compose stop` command.
+#[allow(private_bounds)]
+pub trait DryRunOpt: IntoCmdOptValue<bool> + _priv::Sealed {}
+
+pub struct DryRunNotSet;
+
+impl DryRunOpt for DryRunNotSet {}
+impl _priv::Sealed for DryRunNotSet {}
+
+impl IntoCmdOptValue<bool> for DryRunNotSet {
+    fn into_value(self) -> Option<bool> {
+        None
+    }
+}
+
+pub struct DryRunSet(bool);
+
+impl DryRunOpt for DryRunSet {}
+impl _priv::Sealed for DryRunSet {}
+
+impl IntoCmdOptValue<bool> for DryRunSet {
+    fn into_value(self) -> Option<bool> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents the timeout option for the `docker compose stop` command.
+#[allow(private_bounds)]
+pub trait TimeoutOpt: IntoCmdOptValue<u32> + _priv::Sealed {}
+
+pub struct TimeoutNotSet;
+
+impl TimeoutOpt for TimeoutNotSet {}
+impl _priv::Sealed for TimeoutNotSet {}
+
+impl IntoCmdOptValue<u32> for TimeoutNotSet {
+    fn into_value(self) -> Option<u32> {
+        None
+    }
+}
+
+pub struct TimeoutSet(u32);
+
+impl TimeoutOpt for TimeoutSet {}
+impl _priv::Sealed for TimeoutSet {}
+
+impl IntoCmdOptValue<u32> for TimeoutSet {
+    fn into_value(self) -> Option<u32> {
+        Some(self.0)
+    }
+}
+
+/// A trait that represents whether services have been specified for the `docker compose stop` command.
+#[allow(private_bounds)]
+pub trait ServicesOpt: IntoCmdOptValue<Box<[String]>> + _priv::Sealed {}
+
+pub struct ServicesNotSet;
+
+impl ServicesOpt for ServicesNotSet {}
+impl _priv::Sealed for ServicesNotSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesNotSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        None
+    }
+}
+
+pub struct ServicesSet(Box<[String]>);
+
+impl ServicesOpt for ServicesSet {}
+impl _priv::Sealed for ServicesSet {}
+
+impl IntoCmdOptValue<Box<[String]>> for ServicesSet {
+    fn into_value(self) -> Option<Box<[String]>> {
+        Some(self.0)
+    }
+}
+
+#[allow(dead_code)]
+mod _priv {
+    pub trait Sealed {}
+}

--- a/seahaven-docker/src/cmd/tests/it_compose_restart.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_restart.rs
@@ -1,0 +1,169 @@
+use super::common::{fixture_exe, parse_fixture_exe_output};
+use crate::cmd::{DockerCmd, IntoCommand};
+
+#[tokio::test]
+async fn run_docker_compose_restart() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "restart"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_restart_with_services() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["service1", "service2"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart with services");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "restart", "service1", "service2"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_restart_with_single_service() {
+    //* Given
+    let exe = fixture_exe();
+
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart with a single service");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "restart", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_restart_with_dry_run() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .with_dry_run(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart with dry run");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "restart", "--dry-run"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_restart_with_no_deps() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .with_no_deps(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart with no deps");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "restart", "--no-deps"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_restart_with_timeout() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .with_timeout(30)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart with timeout");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "restart", "--timeout", "30"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_restart_with_all_options() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .restart()
+        .with_dry_run(true)
+        .with_no_deps(true)
+        .with_timeout(30)
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose restart with all options");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "restart",
+            "--dry-run",
+            "--no-deps",
+            "--timeout",
+            "30",
+            "api-service",
+            "web-service"
+        ]
+    );
+}

--- a/seahaven-docker/src/cmd/tests/it_compose_start.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_start.rs
@@ -1,0 +1,122 @@
+use super::common::{fixture_exe, parse_fixture_exe_output};
+use crate::cmd::{DockerCmd, IntoCommand};
+
+#[tokio::test]
+async fn run_docker_compose_start() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .start()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose start");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "start"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_start_with_services() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["service1", "service2"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .start()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose start with services");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "start", "service1", "service2"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_start_with_single_service() {
+    //* Given
+    let exe = fixture_exe();
+
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .start()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose start with a single service");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "start", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_start_with_dry_run() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .start()
+        .with_dry_run(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose start with dry run");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "start", "--dry-run"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_start_with_dry_run_and_services() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .start()
+        .with_dry_run(true)
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose start with dry run and services");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "start",
+            "--dry-run",
+            "api-service",
+            "web-service"
+        ]
+    );
+}

--- a/seahaven-docker/src/cmd/tests/it_compose_stop.rs
+++ b/seahaven-docker/src/cmd/tests/it_compose_stop.rs
@@ -1,0 +1,146 @@
+use super::common::{fixture_exe, parse_fixture_exe_output};
+use crate::cmd::{DockerCmd, IntoCommand};
+
+#[tokio::test]
+async fn run_docker_compose_stop() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .stop()
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose stop");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "stop"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_stop_with_services() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["service1", "service2"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .stop()
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose stop with services");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "stop", "service1", "service2"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_stop_with_single_service() {
+    //* Given
+    let exe = fixture_exe();
+
+    let service = "api-service";
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .stop()
+        .with_service(service)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose stop with a single service");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "stop", "api-service"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_stop_with_dry_run() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .stop()
+        .with_dry_run(true)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose stop with dry run");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "stop", "--dry-run"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_stop_with_timeout() {
+    //* Given
+    let exe = fixture_exe();
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .stop()
+        .with_timeout(30)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose stop with timeout");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(args, ["compose", "stop", "--timeout", "30"]);
+}
+
+#[tokio::test]
+async fn run_docker_compose_stop_with_all_options() {
+    //* Given
+    let exe = fixture_exe();
+
+    let services = ["api-service", "web-service"];
+
+    let mut cmd = DockerCmd::with_executable(exe)
+        .compose()
+        .stop()
+        .with_dry_run(true)
+        .with_timeout(30)
+        .with_services(services)
+        .into_command();
+
+    //* When
+    let res = cmd.kill_on_drop(true).output().await;
+
+    //* Then
+    let output = res.expect("Failed to run docker compose stop with all options");
+    let args = parse_fixture_exe_output(&output);
+
+    assert_eq!(
+        args,
+        [
+            "compose",
+            "stop",
+            "--dry-run",
+            "--timeout",
+            "30",
+            "api-service",
+            "web-service"
+        ]
+    );
+}


### PR DESCRIPTION
- Introduced new commands for `restart`, `start`, and `stop` in the `compose` module, enhancing the Seahaven CLI's functionality for managing Docker services.
- Implemented command structures and options, including support for dry run, service specification, and timeout settings.
- Added comprehensive tests for each new command to ensure correct behavior and integration.

This update significantly improves the user experience by providing essential service management capabilities within the Seahaven CLI.