### PR TITLE
feat(seahaven-cli): add `truman start` command

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd.rs
+++ b/seahaven-cli/src/bin/truman/cmd.rs
@@ -9,6 +9,7 @@ mod ps;
 mod pull;
 mod root;
 mod run;
+mod start;
 mod system;
 mod up;
 mod version;

--- a/seahaven-cli/src/bin/truman/cmd/root.rs
+++ b/seahaven-cli/src/bin/truman/cmd/root.rs
@@ -1,6 +1,8 @@
 use seahaven_cli::result::Result;
 
-use super::{build, down, dump_config, eject, init, logs, ps, pull, run, system, up, version};
+use super::{
+    build, down, dump_config, eject, init, logs, ps, pull, run, start, system, up, version,
+};
 
 /// The name of the CLI
 pub const CMD: &str = "truman";
@@ -23,6 +25,7 @@ pub async fn cmd_run() -> Result<()> {
             run::cmd(),
             logs::cmd(),
             ps::cmd(),
+            start::cmd(),
             eject::cmd(),
             dump_config::cmd(),
             system::cmd(),
@@ -43,6 +46,7 @@ pub async fn cmd_run() -> Result<()> {
         Some((ps::CMD, matches)) => ps::run(matches).await,
         Some((pull::CMD, matches)) => pull::run(matches).await,
         Some((run::CMD, matches)) => run::run(matches).await,
+        Some((start::CMD, matches)) => start::run(matches).await,
         Some((dump_config::CMD, matches)) => dump_config::run(matches).await,
         Some((system::CMD, matches)) => system::run(matches).await,
         Some((up::CMD, matches)) => up::run(matches).await,

--- a/seahaven-cli/src/bin/truman/cmd/start.rs
+++ b/seahaven-cli/src/bin/truman/cmd/start.rs
@@ -1,0 +1,102 @@
+use std::path::PathBuf;
+
+use seahaven_cli::result::{Error, Result};
+use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+
+use super::common::{env_file_arg, file_arg, project_directory_arg};
+use crate::{
+    deps::resolve_docker_executable,
+    files::{
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
+    },
+};
+
+/// The `start` command name
+pub const CMD: &str = "start";
+
+/// Create the `start` command
+pub fn cmd() -> clap::Command {
+    clap::command!(CMD)
+        .about("Start services using docker compose")
+        .args([file_arg(), env_file_arg(), project_directory_arg()])
+        .args([
+            clap::arg!(--"dry-run" "Execute command in dry run mode")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!([SERVICE] ... "The services to start").action(clap::ArgAction::Append),
+        ])
+}
+
+/// The `start` command implementation
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    let docker_exe = resolve_docker_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {}", err))?;
+
+    tracing::debug!("docker executable: {}", docker_exe);
+
+    let docker_version = seahaven_docker::version::fetch(&docker_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine docker version: {err}"))?;
+
+    tracing::debug!("docker version: {:?}", docker_version);
+
+    if docker_version.plugin_compose.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the docker compose plugin version. Is the docker compose plugin installed?"
+        )
+        .into());
+    }
+
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
+
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
+
+    let compose = into_compose_file(content);
+
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
+
+    let mut command = DockerCmd::with_executable(docker_exe)
+        .compose()
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
+        .with_plain_progress()
+        .start()
+        .with_services(matches.get_many::<String>("SERVICE").unwrap_or_default())
+        .with_dry_run(matches.get_flag("dry-run"))
+        .into_command();
+
+    tracing::debug!("Running command: {:?}", command.as_std());
+
+    let mut child = command
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("Failed to spawn docker compose start command: {err}"))?;
+
+    let status = child
+        .wait()
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to wait for docker compose start command: {err}"))?;
+    if !status.success() {
+        return Err(
+            Error::new(anyhow::anyhow!("Docker compose start command failed"))
+                .with_code(status.code().unwrap_or(1)),
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
- Introduced a new `start` command in the `truman` CLI, enhancing the command set for managing services.
- Updated the command registration and execution logic to include the new `start` command, ensuring it integrates seamlessly with existing functionality.

This update improves the Seahaven CLI's capabilities for service management.