### PR TITLE
feat(seahaven-cli): add `truman restart` command

### DIFF
--- a/seahaven-cli/src/bin/truman/cmd.rs
+++ b/seahaven-cli/src/bin/truman/cmd.rs
@@ -7,6 +7,7 @@ mod init;
 mod logs;
 mod ps;
 mod pull;
+mod restart;
 mod root;
 mod run;
 mod start;

--- a/seahaven-cli/src/bin/truman/cmd/restart.rs
+++ b/seahaven-cli/src/bin/truman/cmd/restart.rs
@@ -1,0 +1,108 @@
+use std::path::PathBuf;
+
+use seahaven_cli::result::{Error, Result};
+use seahaven_docker::cmd::{DockerCmd, IntoCommand};
+
+use super::common::{env_file_arg, file_arg, project_directory_arg};
+use crate::{
+    deps::resolve_docker_executable,
+    files::{
+        env::load_and_merge_envs,
+        into_compose_file, resolve_setup_file_and_project_dir_paths,
+        setup_yaml::load_setup_file,
+        tempdir::{self, HasComposeFilePath as _, HasEnvFilePath as _},
+    },
+};
+
+/// The `restart` command name
+pub const CMD: &str = "restart";
+
+/// Create the `restart` command
+pub fn cmd() -> clap::Command {
+    clap::command!(CMD)
+        .about("Restart service containers using docker compose")
+        .args([file_arg(), env_file_arg(), project_directory_arg()])
+        .args([
+            clap::arg!(-t --timeout <SECONDS> "Specify a shutdown timeout in seconds")
+                .value_parser(clap::value_parser!(u32)),
+            clap::arg!(--"dry-run" "Execute command in dry run mode")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!(--"no-deps" "Don't restart dependent services")
+                .action(clap::ArgAction::SetTrue),
+            clap::arg!([SERVICE] ... "The services to restart").action(clap::ArgAction::Append),
+        ])
+}
+
+/// The `restart` command implementation
+pub async fn run(matches: &clap::ArgMatches) -> Result<()> {
+    // Check for requirements
+    let docker_exe = resolve_docker_executable()
+        .map_err(|err| anyhow::anyhow!("Failed to resolve docker executable: {}", err))?;
+
+    tracing::debug!("docker executable: {}", docker_exe);
+
+    let docker_version = seahaven_docker::version::fetch(&docker_exe)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to determine docker version: {err}"))?;
+
+    tracing::debug!("docker version: {:?}", docker_version);
+
+    if docker_version.plugin_compose.is_none() {
+        return Err(anyhow::anyhow!(
+            "Failed to determine the docker compose plugin version. Is the docker compose plugin installed?"
+        )
+        .into());
+    }
+
+    let (setup_file, project_directory) = resolve_setup_file_and_project_dir_paths(
+        matches
+            .get_one::<PathBuf>("file")
+            .expect("Failed to get setup file"),
+        matches.get_one::<PathBuf>("project-directory"),
+    )?;
+
+    let (front_matter_env, content) = load_setup_file(&setup_file, &project_directory)
+        .map_err(|err| anyhow::anyhow!("Failed to parse setup file: {err}"))?;
+
+    let env = load_and_merge_envs(
+        matches.get_many::<PathBuf>("env-file"),
+        &project_directory,
+        front_matter_env,
+    )?;
+
+    let compose = into_compose_file(content);
+
+    let temp = tempdir::new().create_dir()?.write_all(&env, &compose)?;
+
+    let mut command = DockerCmd::with_executable(docker_exe)
+        .compose()
+        .with_file(temp.compose_file_path())
+        .with_env_file(temp.env_file_path())
+        .with_project_directory(project_directory)
+        .with_plain_progress()
+        .restart()
+        .with_timeout(matches.get_one::<u32>("timeout").copied())
+        .with_no_deps(matches.get_flag("no-deps"))
+        .with_services(matches.get_many::<String>("SERVICE").unwrap_or_default())
+        .with_dry_run(matches.get_flag("dry-run"))
+        .into_command();
+
+    tracing::debug!("Running command: {:?}", command.as_std());
+
+    let mut child = command
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|err| anyhow::anyhow!("Failed to spawn docker compose restart command: {err}"))?;
+
+    let status = child.wait().await.map_err(|err| {
+        anyhow::anyhow!("Failed to wait for docker compose restart command: {err}")
+    })?;
+    if !status.success() {
+        return Err(
+            Error::new(anyhow::anyhow!("Docker compose restart command failed"))
+                .with_code(status.code().unwrap_or(1)),
+        );
+    }
+
+    Ok(())
+}

--- a/seahaven-cli/src/bin/truman/cmd/root.rs
+++ b/seahaven-cli/src/bin/truman/cmd/root.rs
@@ -1,7 +1,8 @@
 use seahaven_cli::result::Result;
 
 use super::{
-    build, down, dump_config, eject, init, logs, ps, pull, run, start, stop, system, up, version,
+    build, down, dump_config, eject, init, logs, ps, pull, restart, run, start, stop, system, up,
+    version,
 };
 
 /// The name of the CLI
@@ -27,6 +28,7 @@ pub async fn cmd_run() -> Result<()> {
             ps::cmd(),
             start::cmd(),
             stop::cmd(),
+            restart::cmd(),
             eject::cmd(),
             dump_config::cmd(),
             system::cmd(),
@@ -49,6 +51,7 @@ pub async fn cmd_run() -> Result<()> {
         Some((run::CMD, matches)) => run::run(matches).await,
         Some((start::CMD, matches)) => start::run(matches).await,
         Some((stop::CMD, matches)) => stop::run(matches).await,
+        Some((restart::CMD, matches)) => restart::run(matches).await,
         Some((dump_config::CMD, matches)) => dump_config::run(matches).await,
         Some((system::CMD, matches)) => system::run(matches).await,
         Some((up::CMD, matches)) => up::run(matches).await,

--- a/seahaven-docker/src/cmd/compose/restart.rs
+++ b/seahaven-docker/src/cmd/compose/restart.rs
@@ -114,12 +114,15 @@ where
     ///
     /// See the [Docker Compose documentation](https://docs.docker.com/compose/reference/restart/)
     /// for more information.
-    pub fn with_timeout(self, timeout: u32) -> DockerComposeRestartCmd<DR, ND, TimeoutSet, S> {
+    pub fn with_timeout(
+        self,
+        timeout: impl Into<Option<u32>>,
+    ) -> DockerComposeRestartCmd<DR, ND, TimeoutSet, S> {
         DockerComposeRestartCmd {
             cmd: self.cmd,
             dry_run_opt: self.dry_run_opt,
             no_deps_opt: self.no_deps_opt,
-            timeout_opt: TimeoutSet(timeout),
+            timeout_opt: TimeoutSet(timeout.into()),
             services_opt: self.services_opt,
         }
     }
@@ -248,14 +251,14 @@ impl IntoCmdOptValue<u32> for TimeoutNotSet {
     }
 }
 
-pub struct TimeoutSet(u32);
+pub struct TimeoutSet(Option<u32>);
 
 impl TimeoutOpt for TimeoutSet {}
 impl _priv::Sealed for TimeoutSet {}
 
 impl IntoCmdOptValue<u32> for TimeoutSet {
     fn into_value(self) -> Option<u32> {
-        Some(self.0)
+        self.0
     }
 }
 


### PR DESCRIPTION
- Introduced a new `restart` command in the `truman` CLI for restarting service containers using Docker Compose.
- Updated command registration and execution logic to include the `restart` command, ensuring it integrates with existing functionality.
- Implemented command options for timeout, dry run, and service specification, enhancing user control over the restart operation.

This update expands the Seahaven CLI's capabilities for managing Docker services effectively.