### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1671,7 +1671,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "seahaven-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "build-info",
@@ -1699,7 +1699,7 @@ dependencies = [
 
 [[package]]
 name = "seahaven-compose-file"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "diffy",
  "reqwest",
@@ -1711,7 +1711,7 @@ dependencies = [
 
 [[package]]
 name = "seahaven-docker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "indoc",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "seahaven-just"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "semver",
  "test-with",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "seahaven-package"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "indoc",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "seahaven-setup-file"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "indexmap 2.9.0",

--- a/seahaven-cli/Cargo.toml
+++ b/seahaven-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seahaven-cli"
 description = "Seahaven CLI"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
@@ -18,11 +18,11 @@ build-info = "0.0.40"
 clap = { version = "4.5", features = ["cargo", "derive"] }
 dotenvy = "0.15.7"
 indoc = "2.0.6"
-seahaven-compose-file = { version = "0.1.0", path = "../seahaven-compose-file", features = ["serde"] }
-seahaven-docker = { version = "0.1.0", path = "../seahaven-docker" }
-seahaven-just = { version = "0.1.0", path = "../seahaven-just" }
-seahaven-package = { version = "0.1.0", path = "../seahaven-package" }
-seahaven-setup-file = { version = "0.1.0", path = "../seahaven-setup-file" }
+seahaven-compose-file = { version = "0.2.0", path = "../seahaven-compose-file", features = ["serde"] }
+seahaven-docker = { version = "0.2.0", path = "../seahaven-docker" }
+seahaven-just = { version = "0.2.0", path = "../seahaven-just" }
+seahaven-package = { version = "0.2.0", path = "../seahaven-package" }
+seahaven-setup-file = { version = "0.2.0", path = "../seahaven-setup-file" }
 serde = { version = "1.0.197", features = ["derive"] }
 serde-envfile = { version = "0.2.0", features = ["preserve_order"], git = "https://github.com/LNSD/serde-envfile.git", rev = "7d02f71" }
 serde_json = { version = "1.0.140", features = ["preserve_order"] }

--- a/seahaven-compose-file/Cargo.toml
+++ b/seahaven-compose-file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "seahaven-compose-file"
-version = "0.1.0"
+version = "0.2.0"
 description = "A library for working with Compose files"
 authors.workspace = true
 license.workspace = true

--- a/seahaven-docker/Cargo.toml
+++ b/seahaven-docker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seahaven-docker"
 description = "A Rust wrapper for Docker operations"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/seahaven-just/Cargo.toml
+++ b/seahaven-just/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seahaven-just"
 description = "A Rust wrapper for the just command runner"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/seahaven-package/Cargo.toml
+++ b/seahaven-package/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seahaven-package"
 description = "The Seahaven package manifest"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/seahaven-setup-file/Cargo.toml
+++ b/seahaven-setup-file/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "seahaven-setup-file"
 description = "Seahaven setup description file"
-version = "0.1.0"
+version = "0.2.0"
 authors.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
- Bumped version numbers for all Seahaven-related packages in the Cargo.toml files and Cargo.lock to 0.2.0.
- Ensured consistency in versioning across the seahaven-cli, seahaven-compose-file, seahaven-docker, seahaven-just, seahaven-package, and seahaven-setup-file modules.

This update prepares the project for the next release cycle.