### PR TITLE
fix(ci): correct variable reference in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
     - id: prepare
       run: |
         # Sanitize the ref name
-        echo "::debug::github.ref_name=${{ github.ref_name }}"
-        echo "name=${${{ github.ref_name }}//\//-}" >> $GITHUB_OUTPUT
+        echo "::debug::GITHUB_REF_NAME=${GITHUB_REF_NAME}"
+        echo "name=${GITHUB_REF_NAME//\//-}" >> $GITHUB_OUTPUT
 
         # Set the Rust target
         echo "::debug::matrix.os: ${{ matrix.os }}"


### PR DESCRIPTION
- Updated the variable reference in the build workflow from `${${{ github.ref_name }}//\//-}` to `${GITHUB_REF_NAME//\//-}` for proper sanitization of the ref name.

This change ensures the correct output format for the GitHub Actions workflow, improving reliability in build processes.