### PR TITLE
chore: group build-info crates in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -76,6 +76,17 @@
         'async-graphql-{/,}**',
       ],
     },
+    {
+      groupName: 'build-info crates',
+      groupSlug: 'build-info',
+      matchManagers: [
+        'cargo',
+      ],
+      matchPackageNames: [
+        'build-info',
+        'build-info-{/,}**',
+      ],
+    },
   ],
   ignoreDeps: [
     // Ignore serde_yaml because it is marked as deprecated. No new releases will be made


### PR DESCRIPTION
Group build-info and build-info-* crates together since they come from the same monorepo and should be updated together.